### PR TITLE
[DEV-2184] [@prezly/slate-renderer] Prevent the same embed scripts being loaded multiple times

### DIFF
--- a/packages/slate-renderer/src/elements/Embed/lib/injectOembedMarkup.ts
+++ b/packages/slate-renderer/src/elements/Embed/lib/injectOembedMarkup.ts
@@ -13,12 +13,20 @@ const injectOembedMarkup = ({ oembed, onError, target }: Parameters): void => {
     container.innerHTML = oembed.html || '';
     const embedScripts = Array.from(container.getElementsByTagName('script'));
 
-    embedScripts.forEach((embedScript) => {
-        const script = document.createElement('script');
-        copyScriptAttributes(embedScript, script);
-        script.addEventListener('error', onError);
+    const currentScriptSources = Array.from(document.getElementsByTagName('script')).map((script) => (
+        script.getAttribute('src')
+    ));
 
-        document.body.appendChild(script);
+    embedScripts.forEach((embedScript) => {
+        // Prevent same scripts from loading multiple times
+        if (!currentScriptSources.includes(embedScript.getAttribute('src'))) {
+            const script = document.createElement('script');
+            copyScriptAttributes(embedScript, script);
+            script.addEventListener('error', onError);
+    
+            document.body.appendChild(script);
+        }
+
         // Remove the original script so it's not loaded twice.
         embedScript.remove();
     });

--- a/packages/slate-renderer/src/elements/Embed/lib/injectOembedMarkup.ts
+++ b/packages/slate-renderer/src/elements/Embed/lib/injectOembedMarkup.ts
@@ -13,9 +13,9 @@ const injectOembedMarkup = ({ oembed, onError, target }: Parameters): void => {
     container.innerHTML = oembed.html || '';
     const embedScripts = Array.from(container.getElementsByTagName('script'));
 
-    const currentScriptSources = Array.from(document.getElementsByTagName('script')).map((script) => (
-        script.getAttribute('src')
-    ));
+    const currentScriptSources = Array.from(document.getElementsByTagName('script')).map((script) =>
+        script.getAttribute('src'),
+    );
 
     embedScripts.forEach((embedScript) => {
         // Prevent same scripts from loading multiple times
@@ -23,7 +23,7 @@ const injectOembedMarkup = ({ oembed, onError, target }: Parameters): void => {
             const script = document.createElement('script');
             copyScriptAttributes(embedScript, script);
             script.addEventListener('error', onError);
-    
+
             document.body.appendChild(script);
         }
 


### PR DESCRIPTION
Attempted fix for this issue:
https://linear.app/prezly/issue/DEV-2184/errors-in-console-when-browsing-a-page-with-multiple-videos
