### PR TITLE
Update .prettierignore config to not verify builds

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build/
 coverage/
 node_modules/
+**/dist/


### PR DESCRIPTION
`dist` directories are not pushed to the repository. Nevertheless build fails because some of build fails are not prettified.