### PR TITLE
[MT-4316] Fix - Type-guards bug

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4/EditorV4.tsx
+++ b/packages/slate-editor/src/modules/editor-v4/EditorV4.tsx
@@ -1,6 +1,5 @@
 import Events from '@prezly/events';
 import { EditableWithExtensions, EditorCommands } from '@prezly/slate-commons';
-import { isBlockNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 import React, {
@@ -43,7 +42,7 @@ import {
     isEditorValueEquivalent,
     useCursorInView,
 } from './lib';
-import { EditorRef, EditorV4Props } from './types';
+import { EditorRef, EditorV4Props, isValue } from './types';
 import useCreateEditor from './useCreateEditor';
 import usePendingOperation from './usePendingOperation';
 import withAvailableWidth from './withAvailableWidth';
@@ -273,7 +272,7 @@ const EditorV4: FunctionComponent<EditorV4Props> = ({
             <Slate
                 editor={editor}
                 onChange={(newValue) => {
-                    if (!newValue.every(isBlockNode)) {
+                    if (!isValue(newValue)) {
                         throw new Error("New editor value doesn't match Prezly document format");
                     }
                     onChange(newValue);

--- a/packages/slate-editor/src/modules/editor-v4/lib/isEditorValueEquivalent.ts
+++ b/packages/slate-editor/src/modules/editor-v4/lib/isEditorValueEquivalent.ts
@@ -1,9 +1,9 @@
-import { BlockNode } from '@prezly/slate-types';
+import { Value } from '../types';
 
 import deserialize from './deserialize';
 import serialize from './serialize';
 
-const isEditorValueEquivalent = (a: string | BlockNode[], b: string | BlockNode[]): boolean => {
+const isEditorValueEquivalent = (a: string | Value, b: string | Value): boolean => {
     const aContent = typeof a === 'string' ? deserialize(a) : a;
     const bContent = typeof b === 'string' ? deserialize(b) : b;
     return serialize(aContent) === serialize(bContent);

--- a/packages/slate-editor/src/modules/editor-v4/lib/serialize/serialize.ts
+++ b/packages/slate-editor/src/modules/editor-v4/lib/serialize/serialize.ts
@@ -1,6 +1,7 @@
-import { BlockNode } from '@prezly/slate-types';
 import jsonStableStringify from 'json-stable-stringify';
 import { createEditor } from 'slate';
+
+import { Value } from '../../types';
 
 import { Transform } from './types';
 import withoutImageCandidates from './withoutImageCandidates';
@@ -13,7 +14,7 @@ const transforms: Transform[] = [
     withoutLoaderBlocks,
 ];
 
-const serialize = (value: BlockNode[]): string => {
+const serialize = (value: Value): string => {
     /**
      * Create an editor instance so we can use it with `Transforms` instead of having to
      * manually implement the traversal and unwrapping code.

--- a/packages/slate-editor/src/modules/editor-v4/types/index.ts
+++ b/packages/slate-editor/src/modules/editor-v4/types/index.ts
@@ -1,6 +1,6 @@
-import { Editor } from 'slate';
+import { Descendant, Editor } from 'slate';
 import Events from '@prezly/events';
-import { BlockNode } from '@prezly/slate-types';
+import { BlockNode, isBlockNode } from '@prezly/slate-types';
 import { CSSProperties, KeyboardEvent, ReactNode, RefObject } from 'react';
 
 import { CoverageExtensionParameters } from '../../../modules/editor-v4-coverage';
@@ -9,11 +9,20 @@ import { EditorEventMap } from '../../../modules/editor-v4-events';
 import { FileAttachmentExtensionParameters } from '../../../modules/editor-v4-file-attachment';
 import { FloatingAddMenuExtensionParameters } from '../../../modules/editor-v4-floating-add-menu';
 import { GalleriesExtensionParameters } from '../../../modules/editor-v4-galleries';
-import { ImageExtensionParameters } from '../../../modules/editor-v4-image';
+import {
+    ImageExtensionParameters,
+    isImageCandidateElement,
+} from '../../../modules/editor-v4-image';
 import { PlaceholderMentionsExtensionParameters } from '../../../modules/editor-v4-placeholder-mentions';
 import { PressContactsExtensionParameters } from '../../../modules/editor-v4-press-contacts';
-import { RichFormattingExtensionParameters } from '../../../modules/editor-v4-rich-formatting';
+import {
+    isLinkCandidateElement,
+    RichFormattingExtensionParameters,
+} from '../../../modules/editor-v4-rich-formatting';
 import { UserMentionsExtensionParameters } from '../../../modules/editor-v4-user-mentions';
+import { LinkCandidateElementType } from '../../editor-v4-rich-formatting/types';
+import { isLoaderElement, LoaderElementType } from '../../editor-v4-loader';
+import { ImageCandidateElementType } from '../../editor-v4-image/types';
 
 export interface EditorRef {
     events: Events<EditorEventMap>;
@@ -36,12 +45,29 @@ export interface EditorV4ExtensionsProps {
     withUserMentions?: UserMentionsExtensionParameters;
 }
 
+export type Value = (
+    | BlockNode
+    | LinkCandidateElementType
+    | ImageCandidateElementType
+    | LoaderElementType
+)[];
+
+export function isValue(value: Descendant[]): value is Value {
+    return value.every(
+        (node) =>
+            isBlockNode(node) ||
+            isLinkCandidateElement(node) ||
+            isImageCandidateElement(node) ||
+            isLoaderElement(node),
+    );
+}
+
 export interface EditorV4Props extends EditorV4ExtensionsProps {
     autoFocus?: boolean;
     className?: string;
     contentStyle?: CSSProperties;
     editorRef?: RefObject<EditorRef>;
-    onChange: (value: BlockNode[]) => void;
+    onChange: (value: Value) => void;
     onIsOperationPendingChange?: (isOperationPending: boolean) => void;
     onKeyDown?: (event: KeyboardEvent) => void;
     placeholder?: ReactNode;
@@ -52,7 +78,7 @@ export interface EditorV4Props extends EditorV4ExtensionsProps {
     plugins?: (<T extends Editor>(editor: T) => T)[];
     readOnly?: boolean;
     style?: CSSProperties;
-    value: BlockNode[];
+    value: Value;
     withCursorInView?: {
         minBottom: number;
         minTop: number;


### PR DESCRIPTION
- Fix bug on type-guards not allowing valid editor values

The `isBlockNode` type guard did not allow Loader & Link/Image candidates nodes.
The new `isValue` type guard does.