### PR TITLE
Refactor - Simplify `normalizeNestedElement()` normalizer interface

### DIFF
--- a/packages/slate-commons/src/commands/index.ts
+++ b/packages/slate-commons/src/commands/index.ts
@@ -24,7 +24,7 @@ export { default as isValidLocation } from './isValidLocation';
 export { default as makeDirty } from './makeDirty';
 export { default as moveCursorToEndOfDocument } from './moveCursorToEndOfDocument';
 export { default as moveCursorToNextBlock } from './moveCursorToNextBlock';
-export { default as normalizeNestedElement } from './normalizeNestedElement';
+export { normalizeNestedElement } from './normalizeNestedElement';
 export { default as normalizeRedundantAttributes } from './normalizeRedundantAttributes';
 export { default as removeChildren } from './removeChildren';
 export { default as removeNode } from './removeNode';

--- a/packages/slate-commons/src/commands/normalizeNestedElement.ts
+++ b/packages/slate-commons/src/commands/normalizeNestedElement.ts
@@ -1,29 +1,13 @@
 import { ElementNode, isElementNode } from '@prezly/slate-types';
-import { Editor, ElementEntry, Transforms } from 'slate';
+import { Editor, Element, ElementEntry, Transforms } from 'slate';
 
 import makeDirty from './makeDirty';
 
-type Options =
-    | {
-          allowedParentTypes: ElementNode['type'][];
-      }
-    | {
-          disallowedParentTypes: ElementNode['type'][];
-      };
-
-const isParentTypeAllowed = (options: Options, parentType: ElementNode['type']): boolean => {
-    if ('allowedParentTypes' in options) {
-        return options.allowedParentTypes.includes(parentType);
-    }
-
-    return !options.disallowedParentTypes.includes(parentType);
-};
-
-const normalizeNestedElement = (
+export function normalizeNestedElement(
     editor: Editor,
     [element, path]: ElementEntry,
-    options: Options,
-): boolean => {
+    isParentAllowed: (element: Element) => boolean,
+): boolean {
     const ancestor = Editor.above(editor, { at: path });
     if (!ancestor) {
         return false;
@@ -31,11 +15,11 @@ const normalizeNestedElement = (
 
     const [ancestorNode, ancestorPath] = ancestor;
 
-    if (!isElementNode(ancestorNode)) {
+    if (!Element.isElement(ancestorNode)) {
         return false;
     }
 
-    if (isParentTypeAllowed(options, ancestorNode.type)) {
+    if (isParentAllowed(ancestorNode)) {
         return false;
     }
 
@@ -56,6 +40,4 @@ const normalizeNestedElement = (
     }
 
     return true;
-};
-
-export default normalizeNestedElement;
+}

--- a/packages/slate-editor/src/modules/editor-v4-rich-formatting/lib/index.ts
+++ b/packages/slate-editor/src/modules/editor-v4-rich-formatting/lib/index.ts
@@ -11,7 +11,7 @@ export { default as isRichTextBlockElement } from './isRichTextBlockElement';
 export { default as isRichTextElement } from './isRichTextElement';
 export { default as isSelectionSupported } from './isSelectionSupported';
 export { default as normalizeEmptyLink } from './normalizeEmptyLink';
-export { default as normalizeNestedLink } from './normalizeNestedLink';
+export { normalizeNestedLink } from './normalizeNestedLink';
 export { default as normalizeRedundantRichTextAttributes } from './normalizeRedundantRichTextAttributes';
 export { default as parseSerializedElement } from './parseSerializedElement';
 export { default as parseSerializedLinkElement } from './parseSerializedLinkElement';

--- a/packages/slate-editor/src/modules/editor-v4-rich-formatting/lib/normalizeNestedLink.ts
+++ b/packages/slate-editor/src/modules/editor-v4-rich-formatting/lib/normalizeNestedLink.ts
@@ -1,18 +1,14 @@
 import { EditorCommands } from '@prezly/slate-commons';
 import { isLinkNode } from '@prezly/slate-types';
-import { Editor, Node, NodeEntry } from 'slate';
+import { Editor, Element, Node, NodeEntry } from 'slate';
 
-import { ElementType } from '../types';
+const disallowParentLink = (parent: Element) => !isLinkNode(parent);
 
-const normalizeNestedLink = (editor: Editor, [node, path]: NodeEntry<Node>): boolean => {
+export function normalizeNestedLink(editor: Editor, [node, path]: NodeEntry<Node>): boolean {
     if (!isLinkNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
 
-    return EditorCommands.normalizeNestedElement(editor, [node, path], {
-        disallowedParentTypes: [ElementType.LINK],
-    });
-};
-
-export default normalizeNestedLink;
+    return EditorCommands.normalizeNestedElement(editor, [node, path], disallowParentLink);
+}

--- a/packages/slate-editor/src/modules/editor-v4/plugins/index.ts
+++ b/packages/slate-editor/src/modules/editor-v4/plugins/index.ts
@@ -1,6 +1,6 @@
 export { default as withDeserializeHtml } from './withDeserializeHtml';
 export { default as withFilePasting } from './withFilePasting';
 export { default as withNonEmptyValue } from './withNonEmptyValue';
-export { default as withRootElements } from './withRootElements';
+export { withRootElements } from './withRootElements';
 export { default as withSlatePasting } from './withSlatePasting';
 export { default as withVoids } from './withVoids';

--- a/packages/slate-editor/src/modules/editor-v4/plugins/withRootElements.ts
+++ b/packages/slate-editor/src/modules/editor-v4/plugins/withRootElements.ts
@@ -3,32 +3,32 @@
 import { EditorCommands, Extension } from '@prezly/slate-commons';
 import { Editor, Element, Node, NodeEntry } from 'slate';
 
-const normalizeNestedRootElement = (
+const disallowAnyParent = () => false;
+
+function normalizeNestedRootElement(
     editor: Editor,
     rootTypes: Element['type'][],
     [node, path]: NodeEntry<Node>,
-): boolean => {
+): boolean {
     if (!Element.isElement(node) || !rootTypes.includes(node.type)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
 
-    return EditorCommands.normalizeNestedElement(editor, [node, path], {
-        allowedParentTypes: [],
-    });
-};
+    return EditorCommands.normalizeNestedElement(editor, [node, path], disallowAnyParent);
+}
 
-const getRootTypes = (getExtensions: () => Extension[]): string[] =>
-    getExtensions().reduce<string[]>((result, extension) => {
+function getRootTypes(getExtensions: () => Extension[]): string[] {
+    return getExtensions().reduce<string[]>((result, extension) => {
         if (Array.isArray(extension.rootTypes)) {
             return [...result, ...extension.rootTypes];
         }
         return result;
     }, []);
+}
 
-const withRootElements =
-    (getExtensions: () => Extension[]) =>
-    <T extends Editor>(editor: T): T => {
+export function withRootElements(getExtensions: () => Extension[]) {
+    return <T extends Editor>(editor: T): T => {
         const { normalizeNode } = editor;
 
         editor.normalizeNode = (entry) => {
@@ -47,5 +47,4 @@ const withRootElements =
 
         return editor;
     };
-
-export default withRootElements;
+}


### PR DESCRIPTION
- Simplify `normalizeNestedElement()` normalizer interface
  Also this change relaxing the expecrations on Element structure -- the check is delegated to the caller code, which is good.