### PR TITLE
[DEV-4114] Chore - Preparation for colors consistency refactoring

### DIFF
--- a/packages/slate-editor/src/components/CloseButtonV2/CloseButtonV2.scss
+++ b/packages/slate-editor/src/components/CloseButtonV2/CloseButtonV2.scss
@@ -10,7 +10,7 @@
     height: $button-size;
     padding: 0;
     background: #ffffff !important;
-    border: 1px solid $color-grey-250 !important;
+    border: 1px solid $legacy-color-grey-250 !important;
     border-radius: $border-radius-base;
     box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.06);
 

--- a/packages/slate-editor/src/components/FloatingMenu/Dropdown.scss
+++ b/packages/slate-editor/src/components/FloatingMenu/Dropdown.scss
@@ -4,7 +4,7 @@
     display: inline-block;
     width: 180px;
     vertical-align: top;
-    border-right: 1px solid $color-grey-250;
+    border-right: 1px solid $legacy-color-grey-250;
 
     &:last-child {
         border-right: none;
@@ -47,7 +47,7 @@
         margin: -2px 0 0 -1px;
         padding: 0;
         border-top: 0;
-        border-color: $color-grey-250;
+        border-color: $legacy-color-grey-250;
         border-radius: 0 0 4px 4px;
         box-shadow: none;
         overflow: auto;
@@ -59,7 +59,7 @@
 
     &--rich-text-formatting-options {
         .floating-menu-dropdown__menu-item {
-            border-top: 1px solid $color-grey-250;
+            border-top: 1px solid $legacy-color-grey-250;
             margin-bottom: 0;
             min-height: 34px;
             // Workaround to center the text inside a fixed-height container.

--- a/packages/slate-editor/src/components/FloatingMenu/FloatingMenu.scss
+++ b/packages/slate-editor/src/components/FloatingMenu/FloatingMenu.scss
@@ -7,7 +7,7 @@
 
     display: flex;
     background-color: #ffffff;
-    border: 1px solid $color-grey-250;
+    border: 1px solid $legacy-color-grey-250;
     border-radius: $border-radius-base;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.11);
     font-size: 0;
@@ -25,7 +25,7 @@
         font-size: $font-size;
         color: #767676;
         cursor: pointer;
-        border-right: 1px solid $color-grey-250;
+        border-right: 1px solid $legacy-color-grey-250;
 
         &:hover {
             background-color: #f5f5f5;
@@ -38,13 +38,13 @@
         }
 
         &--disabled {
-            color: $color-grey-250;
+            color: $legacy-color-grey-250;
             pointer-events: none;
         }
     }
 
     &__button-group {
-        border-right: 1px solid $color-grey-250;
+        border-right: 1px solid $legacy-color-grey-250;
         // Use inline-flex to prevent the button-group from collapsing
         // when there is not enough horizontal space.
         display: inline-flex;
@@ -80,11 +80,11 @@
         overflow: hidden;
 
         &:hover {
-            color: $color-green-500;
+            color: $legacy-color-green-500;
         }
 
         &--active {
-            color: $color-green-500;
+            color: $legacy-color-green-500;
 
             &:before {
                 content: "";
@@ -95,14 +95,14 @@
                 width: $spacing-3;
                 height: $spacing-half;
                 border-radius: math.div($border-radius-base, 2);
-                background-color: $color-green-500;
+                background-color: $legacy-color-green-500;
             }
         }
 
         &--danger {
             &,
             &:hover {
-                color: $color-red-500;
+                color: $legacy-color-red-500;
             }
         }
 

--- a/packages/slate-editor/src/components/GalleryLayoutSettings/GalleryLayoutSettings.scss
+++ b/packages/slate-editor/src/components/GalleryLayoutSettings/GalleryLayoutSettings.scss
@@ -4,7 +4,7 @@
     position: relative;
     padding: $spacing-2 $spacing-3;
     background-color: white;
-    border: 1px solid $color-grey-250;
+    border: 1px solid $legacy-color-grey-250;
     border-radius: $border-radius-base;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.11);
     text-align: left;

--- a/packages/slate-editor/src/components/ImageSizeWarning/ImageSizeWarning.scss
+++ b/packages/slate-editor/src/components/ImageSizeWarning/ImageSizeWarning.scss
@@ -9,6 +9,6 @@
     width: $size;
     height: $size;
     background-color: rgba(black, 0.5);
-    color: $color-orange-400;
+    color: $legacy-color-orange-400;
     font-size: 20px;
 }

--- a/packages/slate-editor/src/components/KeyboardKey/KeyboardKey.scss
+++ b/packages/slate-editor/src/components/KeyboardKey/KeyboardKey.scss
@@ -8,9 +8,9 @@
     height: $size;
     padding: $spacing-half;
     background-color: #f5f5f5;
-    border: $border-width solid $color-grey-500;
+    border: $border-width solid $legacy-color-grey-500;
     border-radius: 3px;
-    box-shadow: 0 1px 0 0 $color-grey-500;
+    box-shadow: 0 1px 0 0 $legacy-color-grey-500;
     line-height: $size - 2 * ($spacing-half + $border-width);
     text-align: center;
     white-space: nowrap;

--- a/packages/slate-editor/src/components/LoadingPlaceholderV2/LoadingPlaceholderV2.scss
+++ b/packages/slate-editor/src/components/LoadingPlaceholderV2/LoadingPlaceholderV2.scss
@@ -9,8 +9,8 @@
     justify-content: center;
     height: 240px;
     padding: 0 $horizontal-padding;
-    background: $color-grey-100;
-    border: 1px solid $color-grey-500;
+    background: $legacy-color-grey-100;
+    border: 1px solid $legacy-color-grey-500;
 
     &__icon {
         $size: 24px;
@@ -18,7 +18,7 @@
         width: $size;
         height: $size;
         margin: $spacing-2 0;
-        color: $color-grey-750;
+        color: $legacy-color-grey-750;
     }
 
     &__description {
@@ -31,7 +31,7 @@
 
     &__message {
         font-weight: 600;
-        color: $color-type-primary;
+        color: $legacy-color-type-primary;
     }
 
     &__progress {
@@ -39,7 +39,7 @@
         width: 34px; // constant width to avoid content jump when number of % digits change
         text-align: right;
         font-weight: 600;
-        color: $color-type-secondary;
+        color: $legacy-color-type-secondary;
     }
 
     &__progress-bar {

--- a/packages/slate-editor/src/components/TooltipV2/TooltipV2.scss
+++ b/packages/slate-editor/src/components/TooltipV2/TooltipV2.scss
@@ -1,7 +1,7 @@
 @import "styles/variables";
 
 .tooltip-v2 {
-    $background-color: $color-type-primary;
+    $background-color: $legacy-color-type-primary;
     $foreground-color: #ffffff;
     $arrow-padding: 2px;
     $arrow-size: 4px;

--- a/packages/slate-editor/src/modules/editor-v4-components/FloatingContainer/components/Button/Button.scss
+++ b/packages/slate-editor/src/modules/editor-v4-components/FloatingContainer/components/Button/Button.scss
@@ -2,7 +2,7 @@
 @import "styles/variables";
 
 .editor-v4-floating-container-button {
-    @include button-variant(#767676, $color-grey-250, transparent);
+    @include button-variant(#767676, $legacy-color-grey-250, transparent);
 
     width: $editor-v4-floating-button-size;
     height: $editor-v4-floating-button-size;
@@ -16,7 +16,7 @@
     padding: 0;
 
     &--variant-green {
-        @include button-variant(#ffffff, $color-green-500, transparent);
+        @include button-variant(#ffffff, $legacy-color-green-500, transparent);
     }
 
     &__icon {

--- a/packages/slate-editor/src/modules/editor-v4-components/LinkMenu/LinkMenu.scss
+++ b/packages/slate-editor/src/modules/editor-v4-components/LinkMenu/LinkMenu.scss
@@ -12,7 +12,7 @@
         display: flex;
         align-items: stretch;
         justify-content: stretch;
-        border-right: 1px solid $color-grey-250;
+        border-right: 1px solid $legacy-color-grey-250;
     }
 
     &__input {

--- a/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageBlock/CoverageBlock.scss
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageBlock/CoverageBlock.scss
@@ -36,17 +36,17 @@
         font-weight: bold;
         font-size: 16px;
         line-height: 22px;
-        color: $color-type-primary;
+        color: $legacy-color-type-primary;
     }
 
     &__description {
         margin-bottom: $spacing-1;
         font-size: 14px;
         line-height: 20px;
-        color: $color-type-primary;
+        color: $legacy-color-type-primary;
 
         &--secondary {
-            color: $color-type-secondary;
+            color: $legacy-color-type-secondary;
         }
     }
 
@@ -55,7 +55,7 @@
         align-items: center;
         font-size: 14px;
         line-height: 20px;
-        color: $color-type-secondary;
+        color: $legacy-color-type-secondary;
     }
 
     &__outlet {

--- a/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.scss
@@ -7,7 +7,7 @@
     @include editor-v4-block($void: false);
 
     max-height: $block-height;
-    border: 1px solid $color-grey-250;
+    border: 1px solid $legacy-color-grey-250;
     border-radius: $border-radius-base;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.04);
 
@@ -16,8 +16,8 @@
     }
 
     &--error {
-        background: $alert-danger-bg;
-        border-color: $alert-danger-border;
+        background: $legacy-alert-danger-bg;
+        border-color: $legacy-alert-danger-border;
     }
 
     &__loading-placeholder {

--- a/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.scss
@@ -16,7 +16,7 @@
     &__line {
         margin: 0;
         border: none;
-        border-top: 1px solid $color-grey-750;
+        border-top: 1px solid $legacy-color-grey-750;
     }
 
     &__hitbox {

--- a/packages/slate-editor/src/modules/editor-v4-embed/components/EmbedElement/EmbedElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-embed/components/EmbedElement/EmbedElement.scss
@@ -12,8 +12,8 @@
     }
 
     &--invalid {
-        color: $color-status-error;
-        border: 1px solid $color-status-error;
+        color: $legacy-color-status-error;
+        border: 1px solid $legacy-color-status-error;
         border-radius: $border-radius-base;
     }
 

--- a/packages/slate-editor/src/modules/editor-v4-file-attachment/components/FileAttachmentElement/FileAttachmentElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-file-attachment/components/FileAttachmentElement/FileAttachmentElement.scss
@@ -5,7 +5,7 @@
 .editor-v4-file-attachment-element {
     @include editor-v4-block($void: false);
 
-    border: 1px solid $color-grey-250;
+    border: 1px solid $legacy-color-grey-250;
     border-radius: 2px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.04);
 
@@ -30,7 +30,7 @@
         width: $size;
         height: $size;
         color: #000000;
-        border: 1px solid $color-grey-250;
+        border: 1px solid $legacy-color-grey-250;
         border-radius: 2.67px;
         margin-left: $spacing-3;
         display: flex;
@@ -51,7 +51,7 @@
     }
 
     &__title {
-        color: $color-type-primary;
+        color: $legacy-color-type-primary;
         font-size: 24px;
         line-height: 1;
         font-weight: bold;
@@ -59,7 +59,7 @@
     }
 
     &__subtitle {
-        color: $color-type-secondary;
+        color: $legacy-color-type-secondary;
         font-size: 15px;
         line-height: math.div(22, 15);
         cursor: default;

--- a/packages/slate-editor/src/modules/editor-v4-galleries/components/GalleryElement/GalleryTooltip/GalleryTooltip.scss
+++ b/packages/slate-editor/src/modules/editor-v4-galleries/components/GalleryElement/GalleryTooltip/GalleryTooltip.scss
@@ -5,11 +5,11 @@
     align-items: center;
     padding: $spacing-1 ($spacing-1 + $spacing-half);
     font-size: 14px;
-    color: $color-type-primary;
+    color: $legacy-color-type-primary;
 
     &__icon {
         font-size: 18px;
-        color: $color-purple-500;
+        color: $legacy-color-purple-500;
         margin-right: $spacing-1;
     }
 

--- a/packages/slate-editor/src/modules/editor-v4-image/components/ResizableContainer/ResizableContainer.scss
+++ b/packages/slate-editor/src/modules/editor-v4-image/components/ResizableContainer/ResizableContainer.scss
@@ -24,7 +24,7 @@
     &__button {
         $size: 24px;
 
-        @include button-variant(#767676, $color-grey-250, transparent);
+        @include button-variant(#767676, $legacy-color-grey-250, transparent);
 
         width: $size;
         height: $size;
@@ -38,7 +38,7 @@
         padding: 0;
 
         &:hover {
-            color: $color-green-500;
+            color: $legacy-color-green-500;
         }
 
         &:active {

--- a/packages/slate-editor/src/modules/editor-v4-mentions/components/MentionElement/MentionElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-mentions/components/MentionElement/MentionElement.scss
@@ -5,10 +5,10 @@
     @include editor-v4-void-element;
 
     padding: 0 2px;
-    background-color: $alert-info-bg;
-    border: 1px solid $alert-info-border;
+    background-color: $legacy-alert-info-bg;
+    border: 1px solid $legacy-alert-info-border;
     border-radius: 3px;
-    color: darken($alert-info-text, 5%);
+    color: darken($legacy-alert-info-text, 5%);
 
     &:hover {
         color: #004492;

--- a/packages/slate-editor/src/modules/editor-v4-press-contacts/components/JobDescription/JobDescription.scss
+++ b/packages/slate-editor/src/modules/editor-v4-press-contacts/components/JobDescription/JobDescription.scss
@@ -1,5 +1,5 @@
 @import "styles/variables";
 
 .editor-v4-press-contact-job-description {
-    color: $color-type-secondary;
+    color: $legacy-color-type-secondary;
 }

--- a/packages/slate-editor/src/modules/editor-v4-press-contacts/components/PressContactElement/PressContactElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-press-contacts/components/PressContactElement/PressContactElement.scss
@@ -6,10 +6,10 @@
 
     @include editor-v4-block($void: false);
 
-    border: 1px solid $color-grey-250;
+    border: 1px solid $legacy-color-grey-250;
     border-radius: $border-radius-base;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.11);
-    color: $color-type-primary;
+    color: $legacy-color-type-primary;
 
     &--active {
         @include editor-v4-block-active;
@@ -39,7 +39,7 @@
         align-items: center;
         height: $avatar-size;
         border-radius: $border-radius-base;
-        border: 1px solid $color-grey-250;
+        border: 1px solid $legacy-color-grey-250;
         grid-row: 1;
         grid-column: 1;
     }

--- a/packages/slate-editor/src/modules/editor-v4-rich-formatting/components/BlockQuoteElement/BlockQuoteElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-rich-formatting/components/BlockQuoteElement/BlockQuoteElement.scss
@@ -4,7 +4,7 @@
     margin: $spacing-3 0;
     padding: 20px;
     border-left: 4px solid #c4c4c4;
-    color: $color-type-secondary;
+    color: $legacy-color-type-secondary;
     font-size: $editor-v4-paragraph-font-size;
     line-height: $editor-v4-paragraph-line-height;
     font-style: italic;

--- a/packages/slate-editor/src/styles/colors.scss
+++ b/packages/slate-editor/src/styles/colors.scss
@@ -1,0 +1,106 @@
+/* Greys */
+$grey-900: #111827;
+$grey-800: #1f2937;
+$grey-700: #374151;
+$grey-600: #4b5563;
+$grey-500: #6b7280;
+$grey-400: #9ca3af;
+$grey-300: #d1d5db;
+$grey-200: #e5e7eb;
+$grey-100: #f3f4f6;
+$grey-50: #f9fafb;
+$white: #ffffff;
+
+/* Indigo */
+$indigo-50: #eef2ff;
+$indigo-100: #e0e7ff;
+$indigo-200: #c7d2fe;
+$indigo-300: #a5b4fc;
+$indigo-400: #818cf8;
+$indigo-500: #6366f1;
+$indigo-600: #4f46e5;
+$indigo-700: #4338ca;
+$indigo-800: #3730a3;
+$indigo-900: #312e81;
+
+/* Jean */
+$jean-50: #edf0f2;
+$jean-100: #dce2e4;
+$jean-200: #b9c5ca;
+$jean-300: #95a7af;
+$jean-400: #728a95;
+$jean-500: #4f6d7a;
+$jean-600: #405964;
+$jean-700: #29434e;
+$jean-800: #202c31;
+$jean-800: #101618;
+
+/* Greens */
+$green-50: #e8faf2;
+$green-100: #cceede;
+$green-200: #99dcbd;
+$green-300: #67cb9b;
+$green-400: #34b97a;
+$green-500: #01a859;
+$green-600: #018647;
+$green-700: #016535;
+$green-800: #004324;
+$green-900: #002212;
+
+/* Yellows */
+$yellow-50: #fff6e8;
+$yellow-100: #fdedd3;
+$yellow-200: #fbdba7;
+$yellow-300: #f9ca7b;
+$yellow-400: #f7b84f;
+$yellow-500: #f5a623;
+$yellow-600: #d88a09;
+$yellow-700: #936415;
+$yellow-800: #62420e;
+$yellow-900: #312107;
+
+/* Reds */
+$red-50: #fff1f2;
+$red-100: #ffe4e6;
+$red-200: #fecdd3;
+$red-300: #fda4af;
+$red-400: #fb7185;
+$red-500: #f43f5e;
+$red-600: #e11d48;
+$red-700: #9f1239;
+$red-800: #74102f;
+$red-900: #3a0818;
+
+/* Misc. */
+$misc-red: $red-500;
+$misc-orange: #f27615;
+$misc-yellow: $yellow-500;
+$misc-green: $green-500;
+$misc-blue: #2fa4f9;
+$misc-purple: $indigo-500;
+
+/* Focus */
+$focus-light: $indigo-200;
+$focus-dark: $yellow-200;
+
+/* Social */
+$dodger-blue: #1da1f2;
+$chambray: #3b5998;
+$deep-cerulean: #0077b5;
+
+// color aliases - use this variables in other places
+$color-brand-primary: $green-600;
+$color-brand-alternative: $jean-500;
+
+$color-status-error: $red-600;
+$color-status-error-lighter: $red-500;
+$color-status-error-darker: $red-700;
+
+$color-status-warning: $yellow-700;
+
+$color-status-warning-text: $yellow-700;
+$color-status-warning-bg: $yellow-500;
+
+$color-twitter: $dodger-blue;
+$color-facebook: $chambray;
+$color-linked-in: $deep-cerulean;

--- a/packages/slate-editor/src/styles/legacy-colors.scss
+++ b/packages/slate-editor/src/styles/legacy-colors.scss
@@ -1,34 +1,39 @@
+/**
+ * TODO: Replace all usages of these colors with updated values in colors.scss
+ * @see colors.scss
+ */
+
 /* Greens */
-$color-green-500: #02ab5c;
-$color-green-10: rgba(0, 174, 49, 0.06);
+$legacy-color-green-500: #02ab5c;
+$legacy-color-green-10: rgba(0, 174, 49, 0.06);
 
 /* Greys */
-$color-grey-100: #f4f4f4;
-$color-grey-250: #ececec;
-$color-grey-375: #dcdcdc;
-$color-grey-500: #cccccc;
-$color-grey-750: #afafaf;
-$color-grey-900: #757777;
+$legacy-color-grey-100: #f4f4f4;
+$legacy-color-grey-250: #ececec;
+$legacy-color-grey-375: #dcdcdc;
+$legacy-color-grey-500: #cccccc;
+$legacy-color-grey-750: #afafaf;
+$legacy-color-grey-900: #757777;
 
 /* Purples */
-$color-purple-10: rgba(67, 59, 161, 0.06);
-$color-purple-250: #1c165f;
-$color-purple-500: #2c248d;
-$color-purple-900: #433ba1;
+$legacy-color-purple-10: rgba(67, 59, 161, 0.06);
+$legacy-color-purple-250: #1c165f;
+$legacy-color-purple-500: #2c248d;
+$legacy-color-purple-900: #433ba1;
 
 /* Text Colors */
-$color-type-primary: #333333;
-$color-type-secondary: #757777;
+$legacy-color-type-primary: #333333;
+$legacy-color-type-secondary: #757777;
 
 /* Warnings and Errors */
-$color-orange-400: #ebce31;
-$color-orange-500: #f5c723;
-$color-red-500: #ce1d33;
-$color-red-10: #feeef0;
+$legacy-color-orange-400: #ebce31;
+$legacy-color-orange-500: #f5c723;
+$legacy-color-red-500: #ce1d33;
+$legacy-color-red-10: #feeef0;
 
-$alert-danger-bg: #f2dede;
-$alert-danger-border: darken(adjust-hue($alert-danger-bg, -10), 5%) !default;
-$alert-info-bg: #d9edf7;
-$alert-info-border: darken(adjust-hue($alert-info-bg, -10), 7%);
-$alert-info-text: #31708f;
-$color-status-error: #c43a3a;
+$legacy-alert-danger-bg: #f2dede;
+$legacy-alert-danger-border: darken(adjust-hue($legacy-alert-danger-bg, -10), 5%) !default;
+$legacy-alert-info-bg: #d9edf7;
+$legacy-alert-info-border: darken(adjust-hue($legacy-alert-info-bg, -10), 7%);
+$legacy-alert-info-text: #31708f;
+$legacy-color-status-error: #c43a3a;

--- a/packages/slate-editor/src/styles/legacy-colors.scss
+++ b/packages/slate-editor/src/styles/legacy-colors.scss
@@ -1,0 +1,34 @@
+/* Greens */
+$color-green-500: #02ab5c;
+$color-green-10: rgba(0, 174, 49, 0.06);
+
+/* Greys */
+$color-grey-100: #f4f4f4;
+$color-grey-250: #ececec;
+$color-grey-375: #dcdcdc;
+$color-grey-500: #cccccc;
+$color-grey-750: #afafaf;
+$color-grey-900: #757777;
+
+/* Purples */
+$color-purple-10: rgba(67, 59, 161, 0.06);
+$color-purple-250: #1c165f;
+$color-purple-500: #2c248d;
+$color-purple-900: #433ba1;
+
+/* Text Colors */
+$color-type-primary: #333333;
+$color-type-secondary: #757777;
+
+/* Warnings and Errors */
+$color-orange-400: #ebce31;
+$color-orange-500: #f5c723;
+$color-red-500: #ce1d33;
+$color-red-10: #feeef0;
+
+$alert-danger-bg: #f2dede;
+$alert-danger-border: darken(adjust-hue($alert-danger-bg, -10), 5%) !default;
+$alert-info-bg: #d9edf7;
+$alert-info-border: darken(adjust-hue($alert-info-bg, -10), 7%);
+$alert-info-text: #31708f;
+$color-status-error: #c43a3a;

--- a/packages/slate-editor/src/styles/variables.scss
+++ b/packages/slate-editor/src/styles/variables.scss
@@ -1,4 +1,5 @@
 @import "./shared";
+@import "./colors";
 @import "./legacy-colors";
 
 $spacing-base: 8px;

--- a/packages/slate-editor/src/styles/variables.scss
+++ b/packages/slate-editor/src/styles/variables.scss
@@ -1,4 +1,5 @@
 @import "./shared";
+@import "./legacy-colors";
 
 $spacing-base: 8px;
 $spacing-half: 0.5 * $spacing-base;
@@ -21,41 +22,6 @@ $font-size-medium: 16px;
 $font-size-large: 18px;
 
 $ease-in-out-sine: cubic-bezier(0.445, 0.05, 0.55, 0.95);
-
-/* Greens */
-$color-green-500: #02ab5c;
-$color-green-10: rgba(0, 174, 49, 0.06);
-
-/* Greys */
-$color-grey-100: #f4f4f4;
-$color-grey-250: #ececec;
-$color-grey-375: #dcdcdc;
-$color-grey-500: #cccccc;
-$color-grey-750: #afafaf;
-$color-grey-900: #757777;
-
-/* Purples */
-$color-purple-10: rgba(67, 59, 161, 0.06);
-$color-purple-250: #1c165f;
-$color-purple-500: #2c248d;
-$color-purple-900: #433ba1;
-
-/* Text Colors */
-$color-type-primary: #333333;
-$color-type-secondary: #757777;
-
-/* Warnings and Errors */
-$color-orange-400: #ebce31;
-$color-orange-500: #f5c723;
-$color-red-500: #ce1d33;
-$color-red-10: #feeef0;
-
-$alert-danger-bg: #f2dede;
-$alert-danger-border: darken(adjust-hue($alert-danger-bg, -10), 5%) !default;
-$alert-info-bg: #d9edf7;
-$alert-info-border: darken(adjust-hue($alert-info-bg, -10), 7%);
-$alert-info-text: #31708f;
-$color-status-error: #c43a3a;
 
 $slate-floating-button-size: 32px;
 $slate-floating-button-margin: $spacing-2;


### PR DESCRIPTION
Based on DEV-4114 

We need to make sure this repo is using color codes consistent with the main app. However, it doesn't make sense to work on it now, but better to postpone and address in scope of MT-4461.

- Add `legacy-` prefix to all existing color variables
- Introduce new color variables to be used instead 
- No changes to the stylesheets yet