### PR TITLE
Add Void extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .next/
 .idea/
+.history
 build/
 dist/
 coverage/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4680,8 +4680,9 @@
             "dev": true
         },
         "node_modules/@types/is-hotkey": {
-            "version": "0.1.5",
-            "integrity": "sha512-pZTb6AsG7I56FJgYA8Cbit3cB3NGVwyHgwyUCENjXewTQChOtQaxaV+u6BO4hqtS1o9KT1wML+NRkGhQZ6swtA=="
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.6.tgz",
+            "integrity": "sha512-kG4tCqu3S4rsgkvmFy75I3Dt99kP/ipZMYi73JpsPSa/IIlHYigxD0XdyM0yn8BpGcD1hvlnrYzoZgzm88peKw=="
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.3",
@@ -20608,7 +20609,7 @@
             },
             "devDependencies": {
                 "@types/classnames": "^2.2.11",
-                "@types/is-hotkey": "^0.1.5",
+                "@types/is-hotkey": "^0.1.6",
                 "@types/json-stable-stringify": "^1.0.32",
                 "@types/lodash": "^4.14.167",
                 "@types/react": "^16.14.2",
@@ -23874,7 +23875,7 @@
                 "@prezly/slate-types": "^0.9.1",
                 "@prezly/uploadcare": "^1.0.0",
                 "@types/classnames": "^2.2.11",
-                "@types/is-hotkey": "^0.1.5",
+                "@types/is-hotkey": "^0.1.6",
                 "@types/json-stable-stringify": "^1.0.32",
                 "@types/lodash": "^4.14.167",
                 "@types/react": "^16.14.2",
@@ -24307,8 +24308,9 @@
             "dev": true
         },
         "@types/is-hotkey": {
-            "version": "0.1.5",
-            "integrity": "sha512-pZTb6AsG7I56FJgYA8Cbit3cB3NGVwyHgwyUCENjXewTQChOtQaxaV+u6BO4hqtS1o9KT1wML+NRkGhQZ6swtA=="
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.6.tgz",
+            "integrity": "sha512-kG4tCqu3S4rsgkvmFy75I3Dt99kP/ipZMYi73JpsPSa/IIlHYigxD0XdyM0yn8BpGcD1hvlnrYzoZgzm88peKw=="
         },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
                 "react": "^16.9.0",
                 "react-bootstrap": "=0.32.4",
                 "react-dom": "^16.9.0",
-                "slate": "^0.70.0",
+                "slate": "^0.71.0",
                 "slate-history": "^0.66.0",
-                "slate-react": "^0.70.0"
+                "slate-react": "^0.71.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
@@ -18004,8 +18004,9 @@
             }
         },
         "node_modules/slate": {
-            "version": "0.70.0",
-            "integrity": "sha512-mLBr20GW8VX0vWZBXv/DGz6Mj2wMHvlFld6NK+9wfMqjO9L/E5TuY6ytC30GGQSAHJAoVVmYYSpqwkwjbexMRQ==",
+            "version": "0.71.0",
+            "resolved": "https://registry.npmjs.org/slate/-/slate-0.71.0.tgz",
+            "integrity": "sha512-DKK7Fk9UzCgN31X7safnJE0i9CbXv9pdnwTyt3NYak9xDFTltv27U+z9NCyi9M5ahqEK2fO5hjjDzPBuPOSRLQ==",
             "dependencies": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",
@@ -18030,8 +18031,9 @@
             }
         },
         "node_modules/slate-react": {
-            "version": "0.70.0",
-            "integrity": "sha512-7txteUdJZL46R7jaPzXiv9vN9/8ATPQtwf7irRb6/BclPwJ5kmg9Q35Rn2ETlWJCRX84eVtLTPX8u7p5kKwHkA==",
+            "version": "0.71.0",
+            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.71.0.tgz",
+            "integrity": "sha512-UgryclHduQyOUAtoCk/05/4z6CMSURV+WyTwNMJZB10QDVviI78LsLCWstSo0jDlewM8KAX150s3aC2EZwH70w==",
             "dependencies": {
                 "@types/is-hotkey": "^0.1.1",
                 "@types/lodash": "^4.14.149",
@@ -19515,7 +19517,8 @@
         },
         "node_modules/tslib": {
             "version": "1.14.1",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -20552,26 +20555,26 @@
         },
         "packages/slate-commons": {
             "name": "@prezly/slate-commons",
-            "version": "0.6.4",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-types": "^0.9.1",
                 "uuid": "^8.3.0"
             },
             "devDependencies": {
-                "@prezly/slate-hyperscript": "^0.6.4",
+                "@prezly/slate-hyperscript": "^0.9.1",
                 "@types/uuid": "^8.3.0"
             },
             "peerDependencies": {
                 "react": "^16.9.0",
-                "slate": "^0.70.0",
+                "slate": "^0.71.0",
                 "slate-history": "^0.66.0",
-                "slate-react": "^0.70.0"
+                "slate-react": "^0.71.0"
             }
         },
         "packages/slate-editor": {
             "name": "@prezly/slate-editor",
-            "version": "0.6.4",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
                 "@popperjs/core": "^2.6.0",
@@ -20580,10 +20583,10 @@
                 "@prezly/linear-partition": "^1.0.2",
                 "@prezly/progress-promise": "^1.0.1",
                 "@prezly/sdk": "^6.3.1",
-                "@prezly/slate-commons": "^0.6.4",
-                "@prezly/slate-hyperscript": "^0.6.4",
-                "@prezly/slate-lists": "^0.6.4",
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-commons": "^0.9.1",
+                "@prezly/slate-hyperscript": "^0.9.1",
+                "@prezly/slate-lists": "^0.9.1",
+                "@prezly/slate-types": "^0.9.1",
                 "@prezly/uploadcare": "^1.0.0",
                 "classnames": "^2.3.1",
                 "is-hotkey": "^0.2.0",
@@ -20605,6 +20608,7 @@
             },
             "devDependencies": {
                 "@types/classnames": "^2.2.11",
+                "@types/is-hotkey": "^0.1.5",
                 "@types/json-stable-stringify": "^1.0.32",
                 "@types/lodash": "^4.14.167",
                 "@types/react": "^16.14.2",
@@ -20617,9 +20621,9 @@
             },
             "peerDependencies": {
                 "react": "^16.9.0",
-                "slate": "^0.70.0",
+                "slate": "^0.71.0",
                 "slate-history": "^0.66.0",
-                "slate-react": "^0.70.0"
+                "slate-react": "^0.71.0"
             }
         },
         "packages/slate-editor/node_modules/is-hotkey": {
@@ -20629,14 +20633,14 @@
         },
         "packages/slate-hyperscript": {
             "name": "@prezly/slate-hyperscript",
-            "version": "0.6.4",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
                 "is-plain-object": "^5.0.0"
             },
             "peerDependencies": {
                 "react": "^16.9.0",
-                "slate": "^0.70.0"
+                "slate": "^0.71.0"
             }
         },
         "packages/slate-hyperscript/node_modules/is-plain-object": {
@@ -20649,26 +20653,26 @@
         },
         "packages/slate-lists": {
             "name": "@prezly/slate-lists",
-            "version": "0.6.4",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
-                "@prezly/slate-commons": "^0.6.4",
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-commons": "^0.9.1",
+                "@prezly/slate-types": "^0.9.1",
                 "uuid": "^8.3.0"
             },
             "devDependencies": {
-                "@prezly/slate-hyperscript": "^0.6.4",
+                "@prezly/slate-hyperscript": "^0.9.1",
                 "@types/uuid": "^8.3.0"
             },
             "peerDependencies": {
                 "react": "^16.9.0",
-                "slate": "^0.70.0",
-                "slate-react": "^0.70.0"
+                "slate": "^0.71.0",
+                "slate-react": "^0.71.0"
             }
         },
         "packages/slate-types": {
             "name": "@prezly/slate-types",
-            "version": "0.6.4",
+            "version": "0.9.1",
             "license": "MIT",
             "dependencies": {
                 "@prezly/sdk": "^6.3.1",
@@ -23694,8 +23698,7 @@
         "@octokit/plugin-request-log": {
             "version": "1.0.4",
             "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@octokit/plugin-rest-endpoint-methods": {
             "version": "2.4.0",
@@ -23850,8 +23853,8 @@
         "@prezly/slate-commons": {
             "version": "file:packages/slate-commons",
             "requires": {
-                "@prezly/slate-hyperscript": "^0.6.4",
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-hyperscript": "^0.9.1",
+                "@prezly/slate-types": "^0.9.1",
                 "@types/uuid": "^8.3.0",
                 "uuid": "^8.3.0"
             }
@@ -23865,12 +23868,13 @@
                 "@prezly/linear-partition": "^1.0.2",
                 "@prezly/progress-promise": "^1.0.1",
                 "@prezly/sdk": "^6.3.1",
-                "@prezly/slate-commons": "^0.6.4",
-                "@prezly/slate-hyperscript": "^0.6.4",
-                "@prezly/slate-lists": "^0.6.4",
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-commons": "^0.9.1",
+                "@prezly/slate-hyperscript": "^0.9.1",
+                "@prezly/slate-lists": "^0.9.1",
+                "@prezly/slate-types": "^0.9.1",
                 "@prezly/uploadcare": "^1.0.0",
                 "@types/classnames": "^2.2.11",
+                "@types/is-hotkey": "^0.1.5",
                 "@types/json-stable-stringify": "^1.0.32",
                 "@types/lodash": "^4.14.167",
                 "@types/react": "^16.14.2",
@@ -23922,9 +23926,9 @@
         "@prezly/slate-lists": {
             "version": "file:packages/slate-lists",
             "requires": {
-                "@prezly/slate-commons": "^0.6.4",
-                "@prezly/slate-hyperscript": "^0.6.4",
-                "@prezly/slate-types": "^0.6.4",
+                "@prezly/slate-commons": "^0.9.1",
+                "@prezly/slate-hyperscript": "^0.9.1",
+                "@prezly/slate-types": "^0.9.1",
                 "@types/uuid": "^8.3.0",
                 "uuid": "^8.3.0"
             }
@@ -24802,8 +24806,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -25350,8 +25353,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-imports/-/babel-plugin-transform-remove-imports-1.7.0.tgz",
             "integrity": "sha512-gprmWf6ry5qrnxMyiDaxZpXzZJP6R9FRA+p0AImLIWRmSEGtlKcFprHKeGMZYkII9rJR6Q1hYou+n1fk6rWf2g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "babel-preset-current-node-syntax": {
             "version": "1.0.1",
@@ -27532,8 +27534,7 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
             "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-import-resolver-node": {
             "version": "0.3.6",
@@ -27764,8 +27765,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
             "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -31366,8 +31366,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "27.0.6",
@@ -34073,8 +34072,7 @@
         "react-universal-interface": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-            "requires": {}
+            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
         },
         "react-use": {
             "version": "17.3.1",
@@ -34754,8 +34752,9 @@
             "dev": true
         },
         "slate": {
-            "version": "0.70.0",
-            "integrity": "sha512-mLBr20GW8VX0vWZBXv/DGz6Mj2wMHvlFld6NK+9wfMqjO9L/E5TuY6ytC30GGQSAHJAoVVmYYSpqwkwjbexMRQ==",
+            "version": "0.71.0",
+            "resolved": "https://registry.npmjs.org/slate/-/slate-0.71.0.tgz",
+            "integrity": "sha512-DKK7Fk9UzCgN31X7safnJE0i9CbXv9pdnwTyt3NYak9xDFTltv27U+z9NCyi9M5ahqEK2fO5hjjDzPBuPOSRLQ==",
             "requires": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",
@@ -34782,8 +34781,9 @@
             }
         },
         "slate-react": {
-            "version": "0.70.0",
-            "integrity": "sha512-7txteUdJZL46R7jaPzXiv9vN9/8ATPQtwf7irRb6/BclPwJ5kmg9Q35Rn2ETlWJCRX84eVtLTPX8u7p5kKwHkA==",
+            "version": "0.71.0",
+            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.71.0.tgz",
+            "integrity": "sha512-UgryclHduQyOUAtoCk/05/4z6CMSURV+WyTwNMJZB10QDVviI78LsLCWstSo0jDlewM8KAX150s3aC2EZwH70w==",
             "requires": {
                 "@types/is-hotkey": "^0.1.1",
                 "@types/lodash": "^4.14.149",
@@ -35945,7 +35945,8 @@
         },
         "tslib": {
             "version": "1.14.1",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -36717,8 +36718,7 @@
             "version": "7.5.5",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
             "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/packages/slate-commons/.npmrc
+++ b/packages/slate-commons/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/slate-commons/src/commands/index.ts
+++ b/packages/slate-commons/src/commands/index.ts
@@ -24,6 +24,7 @@ export { default as isValidLocation } from './isValidLocation';
 export { default as makeDirty } from './makeDirty';
 export { default as moveCursorToEndOfDocument } from './moveCursorToEndOfDocument';
 export { default as moveCursorToNextBlock } from './moveCursorToNextBlock';
+export { default as moveCursorToPreviousBlock } from './moveCursorToPreviousBlock';
 export { normalizeNestedElement } from './normalizeNestedElement';
 export { default as normalizeRedundantAttributes } from './normalizeRedundantAttributes';
 export { default as removeChildren } from './removeChildren';

--- a/packages/slate-commons/src/commands/moveCursorToNextBlock.ts
+++ b/packages/slate-commons/src/commands/moveCursorToNextBlock.ts
@@ -2,8 +2,8 @@ import { Editor, Transforms } from 'slate';
 
 const moveCursorToNextBlock = (editor: Editor): void => {
     if (editor.selection) {
-        const nextBlockPoint =
-            Editor.after(editor, editor.selection, { unit: 'block' }) || Editor.end(editor, []);
+        const next = Editor.after(editor, editor.selection, { unit: 'block' });
+        const nextBlockPoint = next ?? Editor.end(editor, []);
         Transforms.select(editor, nextBlockPoint);
     }
 };

--- a/packages/slate-commons/src/commands/moveCursorToPreviousBlock.test.tsx
+++ b/packages/slate-commons/src/commands/moveCursorToPreviousBlock.test.tsx
@@ -1,0 +1,75 @@
+/** @jsx jsx */
+
+import type { Editor } from 'slate';
+
+import jsx from '../jsx';
+
+import moveCursorToPreviousBlock from './moveCursorToPreviousBlock';
+
+describe('moveCursorToPreviousBlock', () => {
+    it('Moves the cursor to the previous block', () => {
+        const editor = (
+            <editor>
+                <h-p>
+                    <h-text>lorem ipsum</h-text>
+                </h-p>
+                <h-p>
+                    <h-text>
+                        <cursor />
+                        second block
+                    </h-text>
+                </h-p>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h-p>
+                    <h-text>lorem ipsum</h-text>
+                    <cursor />
+                </h-p>
+                <h-p>
+                    <h-text>second block</h-text>
+                </h-p>
+            </editor>
+        ) as unknown as Editor;
+
+        moveCursorToPreviousBlock(editor);
+
+        expect(editor.children).toEqual(expected.children);
+        expect(editor.selection).toEqual(expected.selection);
+    });
+
+    it('Moves the cursor to the start of document if at the first block', () => {
+        const editor = (
+            <editor>
+                <h-p>
+                    <h-text>lorem ipsum</h-text>
+                    <cursor />
+                </h-p>
+                <h-p>
+                    <h-text>second block</h-text>
+                </h-p>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h-p>
+                    <h-text>
+                        <cursor />
+                        lorem ipsum
+                    </h-text>
+                </h-p>
+                <h-p>
+                    <h-text>second block</h-text>
+                </h-p>
+            </editor>
+        ) as unknown as Editor;
+
+        moveCursorToPreviousBlock(editor);
+
+        expect(editor.children).toEqual(expected.children);
+        expect(editor.selection).toEqual(expected.selection);
+    });
+});

--- a/packages/slate-commons/src/commands/moveCursorToPreviousBlock.ts
+++ b/packages/slate-commons/src/commands/moveCursorToPreviousBlock.ts
@@ -1,0 +1,11 @@
+import { Editor, Transforms } from 'slate';
+
+const moveCursorToPreviousBlock = (editor: Editor): void => {
+    if (editor.selection) {
+        const before = Editor.before(editor, editor.selection, { unit: 'block' });
+        const prevBlockPoint = before ?? Editor.start(editor, []);
+        Transforms.select(editor, prevBlockPoint);
+    }
+};
+
+export default moveCursorToPreviousBlock;

--- a/packages/slate-editor/.npmrc
+++ b/packages/slate-editor/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -89,7 +89,7 @@
     },
     "devDependencies": {
         "@types/classnames": "^2.2.11",
-        "@types/is-hotkey": "^0.1.5",
+        "@types/is-hotkey": "^0.1.6",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.167",
         "@types/react": "^16.14.2",

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -89,6 +89,7 @@
     },
     "devDependencies": {
         "@types/classnames": "^2.2.11",
+        "@types/is-hotkey": "^0.1.5",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.167",
         "@types/react": "^16.14.2",

--- a/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
@@ -9,21 +9,17 @@ export const VoidExtension = (): Extension => ({
     onKeyDown: (event, editor) => {
         const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
 
-        if (!currentNode || !editor.selection) {
-            return;
-        }
-
-        if (!Editor.isVoid(editor, currentNode)) {
+        if (!currentNode || !editor.selection || !Editor.isVoid(editor, currentNode)) {
             return;
         }
 
         event.preventDefault();
 
-        if (isHotkey('up')(event)) {
+        if (isHotkey('up', event)) {
             EditorCommands.moveCursorToPreviousBlock(editor);
-        } else if (isHotkey('down')(event)) {
+        } else if (isHotkey('down', event)) {
             EditorCommands.moveCursorToNextBlock(editor);
-        } else if (isHotkey('enter')(event)) {
+        } else if (isHotkey('enter', event)) {
             EditorCommands.insertEmptyParagraph(editor);
         }
     },

--- a/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
@@ -1,0 +1,30 @@
+import { isHotkey } from 'is-hotkey';
+import { Editor } from 'slate';
+import type { Extension } from '@prezly/slate-commons';
+import { EditorCommands } from '@prezly/slate-commons';
+import { VOID_EXTENSION_ID } from './constants';
+
+export const VoidExtension = (): Extension => ({
+    id: VOID_EXTENSION_ID,
+    onKeyDown: (event, editor) => {
+        const [currentElement] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
+
+        if (!currentElement) {
+            return;
+        }
+
+        const isVoid = currentElement && Editor.isVoid(editor, currentElement);
+
+        if (!isVoid) {
+            return;
+        }
+
+        if (isHotkey('up')(event)) {
+            event.preventDefault();
+            EditorCommands.moveCursorToPreviousBlock(editor);
+        } else if (isHotkey('down')(event) || isHotkey('enter')(event)) {
+            event.preventDefault();
+            EditorCommands.moveCursorToNextBlock(editor);
+        }
+    },
+});

--- a/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
@@ -13,14 +13,21 @@ export const VoidExtension = (): Extension => ({
             return;
         }
 
-        event.preventDefault();
+        let hasBeenHandled = false;
 
         if (isHotkey('up', event)) {
+            hasBeenHandled = true;
             EditorCommands.moveCursorToPreviousBlock(editor);
         } else if (isHotkey('down', event)) {
+            hasBeenHandled = true;
             EditorCommands.moveCursorToNextBlock(editor);
         } else if (isHotkey('enter', event)) {
+            hasBeenHandled = true;
             EditorCommands.insertEmptyParagraph(editor);
+        }
+
+        if (hasBeenHandled) {
+            event.preventDefault();
         }
     },
 });

--- a/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
@@ -13,9 +13,7 @@ export const VoidExtension = (): Extension => ({
             return;
         }
 
-        const isVoid = currentNode && Editor.isVoid(editor, currentNode);
-
-        if (!isVoid) {
+        if (!Editor.isVoid(editor, currentNode)) {
             return;
         }
 

--- a/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-void/VoidExtension.tsx
@@ -7,24 +7,26 @@ import { VOID_EXTENSION_ID } from './constants';
 export const VoidExtension = (): Extension => ({
     id: VOID_EXTENSION_ID,
     onKeyDown: (event, editor) => {
-        const [currentElement] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
+        const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
 
-        if (!currentElement) {
+        if (!currentNode || !editor.selection) {
             return;
         }
 
-        const isVoid = currentElement && Editor.isVoid(editor, currentElement);
+        const isVoid = currentNode && Editor.isVoid(editor, currentNode);
 
         if (!isVoid) {
             return;
         }
 
+        event.preventDefault();
+
         if (isHotkey('up')(event)) {
-            event.preventDefault();
             EditorCommands.moveCursorToPreviousBlock(editor);
-        } else if (isHotkey('down')(event) || isHotkey('enter')(event)) {
-            event.preventDefault();
+        } else if (isHotkey('down')(event)) {
             EditorCommands.moveCursorToNextBlock(editor);
+        } else if (isHotkey('enter')(event)) {
+            EditorCommands.insertEmptyParagraph(editor);
         }
     },
 });

--- a/packages/slate-editor/src/modules/editor-v4-void/constants.ts
+++ b/packages/slate-editor/src/modules/editor-v4-void/constants.ts
@@ -1,0 +1,1 @@
+export const VOID_EXTENSION_ID = 'VoidExtension';

--- a/packages/slate-editor/src/modules/editor-v4-void/index.ts
+++ b/packages/slate-editor/src/modules/editor-v4-void/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './VoidExtension';

--- a/packages/slate-editor/src/modules/editor-v4/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor-v4/getEnabledExtensions.ts
@@ -16,6 +16,7 @@ import { RichFormattingExtension } from '../../modules/editor-v4-rich-formatting
 import { UserMentionsExtension } from '../../modules/editor-v4-user-mentions';
 import { WebBookmarkExtension } from '../editor-v4-web-bookmark';
 import { VideoExtension } from '../editor-v4-video';
+import { VoidExtension } from '../editor-v4-void';
 
 import {
     createHandleEditGallery,
@@ -127,6 +128,8 @@ function* getEnabledExtensions({
     yield DividerExtension({ containerRef });
 
     yield LoaderExtension({ onOperationEnd, onOperationStart });
+
+    yield VoidExtension();
 }
 
 export default getEnabledExtensions;

--- a/packages/slate-hyperscript/.npmrc
+++ b/packages/slate-hyperscript/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/slate-lists/.npmrc
+++ b/packages/slate-lists/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/packages/slate-types/.npmrc
+++ b/packages/slate-types/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Ticket: https://linear.app/prezly/issue/MT-4521/selecting-divider-node-with-mouse-and-then-pressing-enter-does-not

Demo:
![2021-12-14 14 28 48](https://user-images.githubusercontent.com/3620639/145990303-94633a01-ccfb-445d-aaaf-eda587142d83.gif)


There is an issue with image component, on Down it skips the image, but on up it focuses on the image label text