### PR TITLE
Fix - Image block selection with keyboard arrows

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-image/components/ImageElement/ImageElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-image/components/ImageElement/ImageElement.scss
@@ -37,7 +37,7 @@
     }
 
     &__caption {
-        display: none;
+        height: 0;
         margin: 0 auto;
         padding: 12px 0 0;
         color: #767676;
@@ -46,7 +46,7 @@
         text-align: center;
 
         &--visible {
-            display: block;
+            height: auto;
         }
     }
 }


### PR DESCRIPTION
ticket: https://linear.app/prezly/issue/MT-4530/pressing-up-or-down-on-image-blocks-doesnt-work-correctly

Demo:
![2021-12-16 14 07 35](https://user-images.githubusercontent.com/3620639/146360893-aed3ba86-0d36-4e7b-a60f-79672bcb451f.gif)

