### PR TITLE
Fix - Selecting all caption in Image block and pressing Backspace removes whole block

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-image/ImageExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/ImageExtension.tsx
@@ -15,7 +15,6 @@ import {
     createImageCandidate,
     getAncestorAnchor,
     isDeleting,
-    isDeletingBackward,
     normalizeChildren,
     normalizeImageCandidate,
     normalizeRedundantImageAttributes,
@@ -99,15 +98,6 @@ const ImageExtension = ({
                 event.preventDefault();
                 event.stopPropagation();
                 return;
-            }
-
-            if (isDeletingBackward(event) && EditorCommands.isSelectionAtBlockStart(editor)) {
-                EditorCommands.removeNode(editor, {
-                    at: nodeEntry[1],
-                    match: isImageNode,
-                });
-                event.preventDefault();
-                event.stopPropagation();
             }
         }
     },

--- a/packages/slate-editor/src/modules/editor-v4-image/ImageExtension.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/ImageExtension.tsx
@@ -15,6 +15,7 @@ import {
     createImageCandidate,
     getAncestorAnchor,
     isDeleting,
+    isDeletingBackward,
     normalizeChildren,
     normalizeImageCandidate,
     normalizeRedundantImageAttributes,
@@ -98,6 +99,19 @@ const ImageExtension = ({
                 event.preventDefault();
                 event.stopPropagation();
                 return;
+            }
+
+            if (
+                isDeletingBackward(event) &&
+                EditorCommands.isSelectionAtBlockStart(editor) &&
+                EditorCommands.isSelectionEmpty(editor)
+            ) {
+                EditorCommands.removeNode(editor, {
+                    at: nodeEntry[1],
+                    match: isImageNode,
+                });
+                event.preventDefault();
+                event.stopPropagation();
             }
         }
     },


### PR DESCRIPTION
Ticket: https://linear.app/prezly/issue/MT-4531/selecting-all-caption-in-image-block-and-pressing-backspace-removes

Demo:
![2021-12-16 17 53 22](https://user-images.githubusercontent.com/3620639/146394502-f1b395f2-68ae-4c3d-921b-ed243c196cae.gif)



