### PR TITLE
MT-4532: Wrong behaviour when you do Backspace on a paragraph

### DIFF
--- a/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.test.tsx
+++ b/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.test.tsx
@@ -169,4 +169,35 @@ describe('withUserFriendlyDeleteBehavior', () => {
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
     });
+
+    it('should have a block above and removing by backspace a node below should move the focus upper', () => {
+        const editor = createEditor(
+            <editor>
+                <h-some-element-1>1</h-some-element-1>
+                <h-p>
+                    <h-text />
+                    <cursor />
+                </h-p>
+                <h-p>
+                    <h-text>3</h-text>
+                </h-p>
+            </editor>,
+        );
+
+        const expected = (
+            <editor>
+                <h-some-element-1>
+                    1<cursor />
+                </h-some-element-1>
+                <h-p>
+                    <h-text>3</h-text>
+                </h-p>
+            </editor>
+        ) as unknown as Editor;
+
+        simulateBackspace(editor);
+
+        expect(editor.children).toEqual(expected.children);
+        expect(editor.selection).toEqual(expected.selection);
+    });
 });

--- a/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.ts
+++ b/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.ts
@@ -9,7 +9,7 @@ export function withUserFriendlyDeleteBehavior<T extends Editor>(editor: T): T {
     const { deleteBackward, deleteForward } = editor;
 
     editor.deleteBackward = (unit) => {
-        const selectionBeforeDeleting = saveSelection(
+        const previousBlockSelection = saveSelection(
             editor,
             (location) => Editor.before(editor, location) ?? location,
         );
@@ -17,7 +17,7 @@ export function withUserFriendlyDeleteBehavior<T extends Editor>(editor: T): T {
         const isRemoved = deleteCurrentNodeIfEmpty(editor, { reverse: true, unit });
 
         if (isRemoved) {
-            selectionBeforeDeleting.restore(editor);
+            previousBlockSelection.restore(editor);
         } else {
             // The custom delete could not be applied, fall back to the default editor action.
             deleteBackward(unit);
@@ -25,7 +25,7 @@ export function withUserFriendlyDeleteBehavior<T extends Editor>(editor: T): T {
     };
 
     editor.deleteForward = (unit) => {
-        const selectionBeforeDeleting = saveSelection(editor);
+        const previousBlockSelection = saveSelection(editor);
 
         const isRemoved = deleteCurrentNodeIfEmpty(editor, { reverse: false, unit });
         if (!isRemoved) {
@@ -41,7 +41,7 @@ export function withUserFriendlyDeleteBehavior<T extends Editor>(editor: T): T {
          * The fix is to store the selection before removing and then restoring it.
          * This will ensure the cursor stays in the same location.
          */
-        selectionBeforeDeleting.restore(editor);
+        previousBlockSelection.restore(editor);
     };
 
     return editor;

--- a/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.ts
+++ b/packages/slate-commons/src/plugins/withUserFriendlyDeleteBehavior/withUserFriendlyDeleteBehavior.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import type { Editor } from 'slate';
+import { Editor } from 'slate';
 
 import { saveSelection } from '../../commands';
 
@@ -9,8 +9,16 @@ export function withUserFriendlyDeleteBehavior<T extends Editor>(editor: T): T {
     const { deleteBackward, deleteForward } = editor;
 
     editor.deleteBackward = (unit) => {
+        const selectionBeforeDeleting = saveSelection(
+            editor,
+            (location) => Editor.before(editor, location) ?? location,
+        );
+
         const isRemoved = deleteCurrentNodeIfEmpty(editor, { reverse: true, unit });
-        if (!isRemoved) {
+
+        if (isRemoved) {
+            selectionBeforeDeleting.restore(editor);
+        } else {
             // The custom delete could not be applied, fall back to the default editor action.
             deleteBackward(unit);
         }


### PR DESCRIPTION
Ticket: https://linear.app/prezly/issue/MT-4532/wrong-behaviour-when-you-do-backspace-on-a-paragraph
![2022-01-24 21 49 19](https://user-images.githubusercontent.com/3620639/150845222-814f992a-895c-497d-87e4-7436dfa43783.gif)

