### PR TITLE
[MT-4664] Fix - Web Bookmark node selection

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.scss
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.scss
@@ -2,7 +2,7 @@
 @import "styles/variables";
 
 .editor-v4-web-bookmark-element {
-    @include editor-v4-block($void: false);
+    @include editor-v4-block($void: true);
 
     position: relative;
     white-space: normal;
@@ -18,10 +18,6 @@
         width: 100%;
         height: 100%;
         z-index: $editor-v4-embed-element-overlay-z-index;
-
-        &--hidden {
-            display: none;
-        }
     }
 
     &__card {
@@ -30,8 +26,6 @@
         border: 1px solid $grey-200;
         border-radius: $border-radius-base;
         justify-content: stretch;
-
-        @include editor-v4-void-element();
 
         .editor-v4-web-bookmark-element--vertical & {
             flex-flow: column;

--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
@@ -113,11 +113,7 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, child
             ref={ref}
         >
             <div contentEditable={false}>
-                <div
-                    className={classNames('editor-v4-web-bookmark-element__overlay', {
-                        'editor-v4-web-bookmark-element__overlay--hidden': isSelected,
-                    })}
-                />
+                <div className="editor-v4-web-bookmark-element__overlay" />
                 <div className="editor-v4-web-bookmark-element__card">
                     {showThumbnail && oembed.thumbnail_url && (
                         <Thumbnail

--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
@@ -77,7 +77,7 @@ const Provider: FunctionComponent<{ oembed: BookmarkNode['oembed']; showUrl: boo
 
 export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, children, element }) => {
     const isSelected = useSelected();
-    const ref = useRef<HTMLDivElement | null>(null);
+    const card = useRef<HTMLDivElement | null>(null);
     const [isSmallViewport, setSmallViewport] = useState(false);
 
     const { url, oembed, layout } = element;
@@ -90,7 +90,7 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, child
         ? BookmarkCardLayout.VERTICAL
         : layout;
 
-    useResizeObserver(ref.current, function (entries) {
+    useResizeObserver(card.current, function (entries) {
         entries.forEach(function (entry) {
             setSmallViewport(entry.contentRect.width < HORIZONTAL_LAYOUT_MIN_WIDTH);
         });
@@ -110,11 +110,11 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, child
             })}
             data-slate-type={element.type}
             data-slate-value={JSON.stringify(element)}
-            ref={ref}
+            ref={attributes.ref}
         >
             <div contentEditable={false}>
                 <div className="editor-v4-web-bookmark-element__overlay" />
-                <div className="editor-v4-web-bookmark-element__card">
+                <div className="editor-v4-web-bookmark-element__card" ref={card}>
                     {showThumbnail && oembed.thumbnail_url && (
                         <Thumbnail
                             href={url}


### PR DESCRIPTION
The reason it didn't work was that the in-component `ref` was overwriting the `ref` coming from above via the `attributes` object. Attributes `ref` is vital for editor selection working.