### PR TITLE
[MT-4673] Fix - Pressing UP key doesnt focus some void elements

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
@@ -4,11 +4,6 @@
 .block {
     @include editor-v4-block($void: false);
     position: relative;
-    white-space: normal;
-
-    &.void {
-        @include editor-v4-void-element;
-    }
 
     &.selected {
         @include editor-v4-block-active;
@@ -20,11 +15,19 @@
         margin-top: $editor-v4-block-spacing-vertical - $area-vertical-expansion;
         margin-bottom: $editor-v4-block-spacing-vertical - $area-vertical-expansion;
 
-        .container {
+        > .container {
             padding-top: $area-vertical-expansion;
             padding-bottom: $area-vertical-expansion;
         }
     }
+
+    &.void > .container {
+        @include editor-v4-void-element;
+    }
+}
+
+.container {
+    white-space: normal;
 }
 
 .overlay {

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -26,7 +26,7 @@ interface Props extends Omit<RenderElementProps, 'attributes'>, SlateInternalAtt
      * Useful for extremely thin blocks like Divider.
      */
     extendedHitArea?: boolean;
-    renderBlock: () => ReactNode;
+    renderBlock: (props: { isSelected: boolean }) => ReactNode;
     renderMenu?: () => ReactNode;
     overlay?: OverlayMode;
     void?: boolean;
@@ -69,7 +69,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                     </Menu>
                 )}
                 <Overlay selected={isSelected} mode={overlay} />
-                {renderBlock()}
+                {renderBlock({ isSelected })}
             </div>
 
             {/* We have to render children or Slate will fail when trying to find the node. */}

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -15,6 +15,10 @@ import { Overlay } from './Overlay';
 type SlateInternalAttributes = RenderElementProps['attributes'];
 
 interface Props extends Omit<RenderElementProps, 'attributes'>, SlateInternalAttributes {
+    /**
+     * Children nodes provided by Slate, required for Slate internals.
+     */
+    children: ReactNode;
     className?: string;
     element: ElementNode;
     /**
@@ -22,12 +26,9 @@ interface Props extends Omit<RenderElementProps, 'attributes'>, SlateInternalAtt
      * Useful for extremely thin blocks like Divider.
      */
     extendedHitArea?: boolean;
+    renderBlock: () => ReactNode;
     renderMenu?: () => ReactNode;
     overlay?: OverlayMode;
-    /**
-     * Children nodes provided by Slate, required for Slate internals.
-     */
-    slateInternalsChildren: ReactNode;
     void?: boolean;
 }
 
@@ -37,8 +38,8 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
         className,
         element,
         extendedHitArea,
+        renderBlock,
         renderMenu,
-        slateInternalsChildren,
         overlay = false,
         void: isVoid,
         ...attributes
@@ -68,11 +69,11 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                     </Menu>
                 )}
                 <Overlay selected={isSelected} mode={overlay} />
-                {children}
+                {renderBlock()}
             </div>
 
             {/* We have to render children or Slate will fail when trying to find the node. */}
-            {slateInternalsChildren}
+            {children}
         </div>
     );
 });

--- a/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.tsx
@@ -17,6 +17,7 @@ export function DividerElement({ attributes, children, element }: PropsWithChild
             element={element}
             extendedHitArea
             slateInternalsChildren={children}
+            void
             {...attributes}
         >
             <hr className={styles.divider} />

--- a/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-divider/components/DividerElement.tsx
@@ -14,13 +14,14 @@ interface Props extends RenderElementProps {
 export function DividerElement({ attributes, children, element }: PropsWithChildren<Props>) {
     return (
         <EditorBlock
+            {...attributes} // contains `ref`
             element={element}
             extendedHitArea
-            slateInternalsChildren={children}
+            renderBlock={() => <hr className={styles.divider} />}
             void
-            {...attributes}
         >
-            <hr className={styles.divider} />
+            {/* We have to render children or Slate will fail when trying to find the node. */}
+            {children}
         </EditorBlock>
     );
 }

--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.module.scss
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.module.scss
@@ -15,6 +15,10 @@
     &.horizontal {
         flex-flow: row;
     }
+    &.selected {
+        border-radius: 0;
+        border-color: $editor-v4-block-focus-color;
+    }
 }
 
 .details {

--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
@@ -92,9 +92,10 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, child
             {...attributes} // contains `ref`
             element={element}
             overlay="always"
-            renderBlock={() => (
+            renderBlock={({ isSelected }) => (
                 <div
                     className={classNames(styles.card, {
+                        [styles.selected]: isSelected,
                         [styles.vertical]: actualLayout === BookmarkCardLayout.VERTICAL,
                         [styles.horizontal]: actualLayout === BookmarkCardLayout.HORIZONTAL,
                     })}

--- a/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-web-bookmark/components/WebBookmarkElement/WebBookmarkElement.tsx
@@ -89,44 +89,47 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({ attributes, child
 
     return (
         <EditorBlock
-            {...attributes}
+            {...attributes} // contains `ref`
             element={element}
             overlay="always"
-            slateInternalsChildren={children}
-            void={true}
-        >
-            <div
-                className={classNames(styles.card, {
-                    [styles.vertical]: actualLayout === BookmarkCardLayout.VERTICAL,
-                    [styles.horizontal]: actualLayout === BookmarkCardLayout.HORIZONTAL,
-                })}
-                ref={card}
-            >
-                {showThumbnail && oembed.thumbnail_url && (
-                    <Thumbnail
-                        href={url}
-                        src={oembed.thumbnail_url}
-                        width={oembed.thumbnail_width}
-                        height={oembed.thumbnail_height}
-                    />
-                )}
-                <div className={styles.details}>
-                    {!isEmptyText(oembed.title) && (
-                        <a
-                            className={styles.title}
+            renderBlock={() => (
+                <div
+                    className={classNames(styles.card, {
+                        [styles.vertical]: actualLayout === BookmarkCardLayout.VERTICAL,
+                        [styles.horizontal]: actualLayout === BookmarkCardLayout.HORIZONTAL,
+                    })}
+                    ref={card}
+                >
+                    {showThumbnail && oembed.thumbnail_url && (
+                        <Thumbnail
                             href={url}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                        >
-                            {oembed.title}
-                        </a>
+                            src={oembed.thumbnail_url}
+                            width={oembed.thumbnail_width}
+                            height={oembed.thumbnail_height}
+                        />
                     )}
-                    {!isEmptyText(oembed.description) && (
-                        <div className={styles.description}>{oembed.description}</div>
-                    )}
-                    <Provider oembed={oembed} showUrl={isEmpty} />
+                    <div className={styles.details}>
+                        {!isEmptyText(oembed.title) && (
+                            <a
+                                className={styles.title}
+                                href={url}
+                                rel="noopener noreferrer"
+                                target="_blank"
+                            >
+                                {oembed.title}
+                            </a>
+                        )}
+                        {!isEmptyText(oembed.description) && (
+                            <div className={styles.description}>{oembed.description}</div>
+                        )}
+                        <Provider oembed={oembed} showUrl={isEmpty} />
+                    </div>
                 </div>
-            </div>
+            )}
+            void
+        >
+            {/* We have to render children or Slate will fail when trying to find the node. */}
+            {children}
         </EditorBlock>
     );
 };

--- a/packages/slate-editor/src/styles/shared.scss
+++ b/packages/slate-editor/src/styles/shared.scss
@@ -1,4 +1,4 @@
-@import "styles/colors";
+@import "./colors";
 
 $editor-v4-block-focus-color: $yellow-300;
 $editor-v4-block-spacing-vertical: 44px;

--- a/packages/slate-editor/src/styles/shared.scss
+++ b/packages/slate-editor/src/styles/shared.scss
@@ -1,3 +1,5 @@
+@import "styles/colors";
+
 $editor-v4-block-focus-color: $yellow-300;
 $editor-v4-block-spacing-vertical: 44px;
 $editor-v4-paragraph-font-size: 16px;

--- a/packages/slate-editor/src/styles/shared.scss
+++ b/packages/slate-editor/src/styles/shared.scss
@@ -1,3 +1,4 @@
+$editor-v4-block-focus-color: $yellow-300;
 $editor-v4-block-spacing-vertical: 44px;
 $editor-v4-paragraph-font-size: 16px;
 $editor-v4-paragraph-line-height: 22px;
@@ -33,7 +34,7 @@ $editor-v4-floating-container-z-index: $editor-v4-embed-element-overlay-z-index 
 }
 
 @mixin editor-v4-block-active {
-    outline: solid 6px $yellow-300;
+    outline: solid 6px $editor-v4-block-focus-color;
     border-radius: 1px;
 }
 

--- a/packages/slate-editor/src/styles/variables.scss
+++ b/packages/slate-editor/src/styles/variables.scss
@@ -1,6 +1,6 @@
-@import "./shared";
 @import "./colors";
 @import "./legacy-colors";
+@import "./shared";
 
 $spacing-base: 8px;
 $spacing-half: 0.5 * $spacing-base;


### PR DESCRIPTION
Based on #104 

- Fix selection of Divider and Bookmark blocks with keyboard UP/DOWN navigation
- Fix Bookmark block selection state to match the designs (no rounded borders; no gray border)
- Refactor `EditorBlock` to pass Slate internal children as `children`