### PR TITLE
[MT-4866] Fix arrow position at the beginning of target

### DIFF
--- a/packages/slate-editor/src/components/Portals/BasePortalV2.tsx
+++ b/packages/slate-editor/src/components/Portals/BasePortalV2.tsx
@@ -73,7 +73,7 @@ export const BasePortalV2: FunctionComponent<Props> = ({
             enabled: true,
             options: {
                 element: arrowElement,
-                placement: 'top-start',
+                padding: 12,
             },
         });
     }


### PR DESCRIPTION
Before:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/3620639/157254355-3797a2cd-9daa-44a5-b058-ccfdae828c93.png">
After:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/3620639/157254420-900685f9-ce67-4b1f-9f16-c0c6544e46a7.png">

There is still issue with arrow position when the target is huge, it is placed in the middle, but according to the designs it should be always on the left, thoughts?
<img width="466" alt="image" src="https://user-images.githubusercontent.com/3620639/157254633-dccdb9d9-f8af-4cd0-848f-c9402950f0ab.png">
