### PR TITLE
[MT-4866] Fix Link Menu arrow positionioning

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-rich-formatting-menu/RichFormattingMenu.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-rich-formatting-menu/RichFormattingMenu.tsx
@@ -159,6 +159,7 @@ export const RichFormattingMenu: FunctionComponent<Props> = ({
             <TextSelectionPortalV2
                 containerElement={containerElement}
                 modifiers={[LINK_MENU_OFFSET_MODIFIER]}
+                modifySelectionRect={getTextSelectionLeftTopCornerRect}
                 placement="bottom-start"
                 arrowClassName={styles['link-menu']}
             >
@@ -222,4 +223,14 @@ export const RichFormattingMenu: FunctionComponent<Props> = ({
 function getCurrentLinkNode(editor: Editor, options: { at: Range }): LinkNode | null {
     const entries = Array.from(Editor.nodes(editor, { match: isLinkNode, at: options.at }));
     return entries.length > 0 ? entries[0][0] : null;
+}
+
+const TEXT_SELECTION_CORNER_SIZE = 24;
+
+function getTextSelectionLeftTopCornerRect(rect: ClientRect): ClientRect | null {
+    return {
+        ...rect,
+        width: TEXT_SELECTION_CORNER_SIZE,
+        right: rect.left + TEXT_SELECTION_CORNER_SIZE,
+    };
 }


### PR DESCRIPTION
https://github.com/prezly/slate/pull/126#issue-1162705401

> There is still issue with arrow position when the target is huge, it is placed in the middle, but according to the designs it should be always on the left, thoughts?