### PR TITLE
Refactor - Deprecate ImageNode `width_factor` property

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-image/components/ImageElement/ImageElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/components/ImageElement/ImageElement.tsx
@@ -62,9 +62,8 @@ export const ImageElement: FunctionComponent<Props> = ({
         : ImageLayout.CONTAINED;
     const imageWidth =
         typeof image.originalWidth !== 'undefined' ? image.originalWidth : availableWidth;
-    const defaultWidthFactor = `${Math.round(100 * Math.min(1, imageWidth / availableWidth))}%`;
-    const imageWidthFactor = element.width_factor || defaultWidthFactor;
-    const imageWidthPercent = element.width || '100%';
+    const defaultWidth = `${Math.round(100 * Math.min(1, imageWidth / availableWidth))}%`;
+    const imageWidthPercent = element.width || defaultWidth;
 
     const editor = useSlate();
     const isSelected = useSelected();
@@ -82,15 +81,8 @@ export const ImageElement: FunctionComponent<Props> = ({
         Transforms.select(editor, path);
     }
 
-    function handleResize(widthPercent: string, widthFactor: string) {
-        Transforms.setNodes(
-            editor,
-            {
-                width: widthPercent,
-                width_factor: widthFactor,
-            },
-            { match: isImageNode },
-        );
+    function handleResize(width: string) {
+        Transforms.setNodes(editor, { width }, { match: isImageNode });
     }
 
     function handleResizeStop() {
@@ -139,7 +131,6 @@ export const ImageElement: FunctionComponent<Props> = ({
                     resizingClassName="editor-v4-image-element__resizable-container--resizing"
                     style={isContainedLayout ? null : { width: '100%' }}
                     width={imageWidth}
-                    widthFactor={imageWidthFactor}
                     widthPercent={imageWidthPercent}
                 >
                     <LinkWithTooltip enabled={element.href !== ''} href={element.href}>

--- a/packages/slate-editor/src/modules/editor-v4-image/components/ResizableContainer/ResizableContainer.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/components/ResizableContainer/ResizableContainer.tsx
@@ -16,12 +16,11 @@ interface Props {
     enabled: boolean;
     maxWidth: number;
     minWidth: number;
-    onResize: (widthPercent: string, widthFactor: string) => void;
+    onResize: (widthPercent: string) => void;
     onResizeStop?: () => void;
     resizingClassName?: string;
     style?: CSSProperties | null;
     width: number;
-    widthFactor: string;
     widthPercent: string;
 }
 
@@ -57,7 +56,7 @@ export class ResizableContainer extends Component<Props, State> {
     }
 
     componentDidMount() {
-        this.props.onResize(this.state.widthPercent, this.props.widthFactor);
+        this.props.onResize(this.state.widthPercent);
     }
 
     getMaximumWidth = () => Math.min(this.props.width, this.props.maxWidth);
@@ -92,7 +91,7 @@ export class ResizableContainer extends Component<Props, State> {
             },
             () => {
                 if (this.state.widthPercent !== this.props.widthPercent) {
-                    this.props.onResize(this.state.widthPercent, this.props.widthFactor);
+                    this.props.onResize(this.state.widthPercent);
                 }
             },
         );

--- a/packages/slate-editor/src/modules/editor-v4-image/jsx.ts
+++ b/packages/slate-editor/src/modules/editor-v4-image/jsx.ts
@@ -20,7 +20,6 @@ declare global {
                 href: string;
                 layout: ImageLayout;
                 width: string;
-                width_factor: string;
             };
             'h-image-candidate': {
                 children?: ReactNode;

--- a/packages/slate-editor/src/modules/editor-v4-image/lib/createImage.ts
+++ b/packages/slate-editor/src/modules/editor-v4-image/lib/createImage.ts
@@ -9,8 +9,7 @@ export function createImage(
         href = '',
         layout = ImageLayout.CONTAINED,
         width = '100%',
-        width_factor = '100%',
-    }: Partial<Omit<ImageNode, 'file' | 'type'>>,
+    }: Partial<Omit<ImageNode, 'file' | 'type' | 'width_factor'>>,
 ): ImageNode {
     return {
         type: IMAGE_NODE_TYPE,
@@ -18,7 +17,7 @@ export function createImage(
         file,
         href,
         layout,
-        width_factor,
         width,
+        width_factor: '100%',
     };
 }

--- a/packages/slate-editor/src/modules/editor-v4-image/lib/createImage.ts
+++ b/packages/slate-editor/src/modules/editor-v4-image/lib/createImage.ts
@@ -9,7 +9,7 @@ export function createImage(
         href = '',
         layout = ImageLayout.CONTAINED,
         width = '100%',
-    }: Partial<Omit<ImageNode, 'file' | 'type' | 'width_factor'>>,
+    }: Partial<Omit<ImageNode, 'file' | 'type'>>,
 ): ImageNode {
     return {
         type: IMAGE_NODE_TYPE,
@@ -18,6 +18,5 @@ export function createImage(
         href,
         layout,
         width,
-        width_factor: '100%',
     };
 }

--- a/packages/slate-editor/src/modules/editor-v4-image/lib/normalizeRedundantImageAttributes.ts
+++ b/packages/slate-editor/src/modules/editor-v4-image/lib/normalizeRedundantImageAttributes.ts
@@ -9,7 +9,6 @@ const shape: Record<keyof ImageNode, true> = {
     href: true,
     layout: true,
     width: true,
-    width_factor: true,
     children: true,
 };
 

--- a/packages/slate-editor/src/modules/editor-v4-image/lib/parseSerializedElement.ts
+++ b/packages/slate-editor/src/modules/editor-v4-image/lib/parseSerializedElement.ts
@@ -11,7 +11,6 @@ export function parseSerializedElement(serialized: string): ImageNode | undefine
             children: parsed.children,
             href: parsed.href,
             layout: parsed.layout,
-            width_factor: parsed.width_factor,
             width: parsed.width,
         });
     }

--- a/packages/slate-editor/src/modules/editor-v4-image/transforms/removeImage.test.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/transforms/removeImage.test.tsx
@@ -34,7 +34,6 @@ describe('removeImage', () => {
                     href=""
                     layout={ImageLayout.CONTAINED}
                     width="100%"
-                    width_factor="100%"
                 >
                     <h-text>
                         <cursor />
@@ -78,7 +77,6 @@ describe('removeImage', () => {
                     href=""
                     layout={ImageLayout.CONTAINED}
                     width="100%"
-                    width_factor="100%"
                 >
                     <h-text />
                 </h-image>
@@ -99,7 +97,6 @@ describe('removeImage', () => {
                     href=""
                     layout={ImageLayout.CONTAINED}
                     width="100%"
-                    width_factor="100%"
                 >
                     <h-text />
                 </h-image>

--- a/packages/slate-editor/src/modules/editor-v4-image/withImages.test.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/withImages.test.tsx
@@ -40,7 +40,6 @@ describe('withImages - normalizeChildren', () => {
                     href=""
                     layout={ImageLayout.CONTAINED}
                     width="100%"
-                    width_factor="100%"
                 >
                     <fragment>
                         <fragment>
@@ -63,7 +62,6 @@ describe('withImages - normalizeChildren', () => {
                     href=""
                     layout={ImageLayout.CONTAINED}
                     width="100%"
-                    width_factor="100%"
                 >
                     <h-text>lorem ipsum</h-text>
                     <cursor />

--- a/packages/slate-editor/src/modules/editor-v4-image/withImages.test.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-image/withImages.test.tsx
@@ -35,12 +35,7 @@ describe('withImages - normalizeChildren', () => {
     it('unwraps deeply nested text objects', () => {
         const editor = createEditor(
             <editor>
-                <h-image
-                    file={file}
-                    href=""
-                    layout={ImageLayout.CONTAINED}
-                    width="100%"
-                >
+                <h-image file={file} href="" layout={ImageLayout.CONTAINED} width="100%">
                     <fragment>
                         <fragment>
                             <h-text />
@@ -57,12 +52,7 @@ describe('withImages - normalizeChildren', () => {
 
         const expected = createEditor(
             <editor>
-                <h-image
-                    file={file}
-                    href=""
-                    layout={ImageLayout.CONTAINED}
-                    width="100%"
-                >
+                <h-image file={file} href="" layout={ImageLayout.CONTAINED} width="100%">
                     <h-text>lorem ipsum</h-text>
                     <cursor />
                 </h-image>

--- a/packages/slate-editor/src/modules/editor-v4/json.ts
+++ b/packages/slate-editor/src/modules/editor-v4/json.ts
@@ -91,8 +91,10 @@ export interface ImageNode {
     type: 'image-block';
     /** matches this regexp: /^\d+(\.\d+)?%$/ */
     width: string;
-    /** matches this regexp: /^\d+(\.\d+)?%$/ */
-    width_factor: string;
+    /**
+     * @deprecated No longer used. Will be dropped in the future.
+     */
+    width_factor: '100%';
 }
 
 export interface ListNode {

--- a/packages/slate-editor/src/modules/editor-v4/json.ts
+++ b/packages/slate-editor/src/modules/editor-v4/json.ts
@@ -91,10 +91,6 @@ export interface ImageNode {
     type: 'image-block';
     /** matches this regexp: /^\d+(\.\d+)?%$/ */
     width: string;
-    /**
-     * @deprecated No longer used. Will be dropped in the future.
-     */
-    width_factor: '100%';
 }
 
 export interface ListNode {

--- a/packages/slate-editor/src/modules/editor-v4/lib/images/createHandleEditImage.ts
+++ b/packages/slate-editor/src/modules/editor-v4/lib/images/createHandleEditImage.ts
@@ -48,7 +48,6 @@ export function createHandleEditImage(withImages: ImageExtensionParameters) {
                     children: [{ text: caption }],
                     href: imageElement.href,
                     layout: imageElement.layout,
-                    width_factor: imageElement.width_factor,
                     width: imageElement.width,
                 });
             },

--- a/packages/slate-types/src/nodes/ImageNode.ts
+++ b/packages/slate-types/src/nodes/ImageNode.ts
@@ -20,10 +20,6 @@ export interface ImageNode extends ElementNode {
     layout: ImageLayout;
     /** matches this regexp: /^\d+(\.\d+)?%$/ */
     width: string;
-    /**
-     * @deprecated No longer used. Will be dropped in the future.
-     */
-    width_factor: '100%';
 }
 
 export function isImageNode(value: any): value is ImageNode {

--- a/packages/slate-types/src/nodes/ImageNode.ts
+++ b/packages/slate-types/src/nodes/ImageNode.ts
@@ -20,8 +20,10 @@ export interface ImageNode extends ElementNode {
     layout: ImageLayout;
     /** matches this regexp: /^\d+(\.\d+)?%$/ */
     width: string;
-    /** matches this regexp: /^\d+(\.\d+)?%$/ */
-    width_factor: string;
+    /**
+     * @deprecated No longer used. Will be dropped in the future.
+     */
+    width_factor: '100%';
 }
 
 export function isImageNode(value: any): value is ImageNode {


### PR DESCRIPTION
The attribute does not seem to be used at all. I've checked the database and there are only a few image nodes having `width_factor` set to anything else except `100%`. All used in a few fairly old stories dating to 2018.

