### PR TITLE
Feature - Coverage block nice placeholder for error state

### DIFF
--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.module.scss
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.module.scss
@@ -26,7 +26,22 @@
     color: #9ca3af;
 }
 
-.closeIcon {
+.clickArea {
+    cursor: pointer;
+    opacity: 0;
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.closeButton {
     position: absolute;
     right: $spacing-1;
     top: $spacing-1;

--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.module.scss
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.module.scss
@@ -3,7 +3,6 @@
 .container {
     position: relative;
     background: $grey-100;
-    border-radius: $border-radius-base;
     padding: 50px $spacing-1;
     display: flex;
     flex-flow: column;

--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
@@ -26,9 +26,9 @@ export function ElementPlaceholder({ onClick, title, subtitle, illustration }: P
                 onClick={onClick}
             />
             <VStack spacing="2">
-                <div className={styles.illustration}>{illustration}</div>;
+                <div className={styles.illustration}>{illustration}</div>
                 <VStack spacing="1">
-                    <div className={styles.title}>{title}</div>;
+                    <div className={styles.title}>{title}</div>
                     {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
                 </VStack>
             </VStack>

--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
@@ -11,15 +11,29 @@ import styles from './ElementPlaceholder.module.scss';
 interface Props {
     title: string;
     illustration: ReactNode;
+    onClick?: () => void;
+    onClickLabel?: string;
     onDismiss?: () => void;
     subtitle?: string;
 }
 
-export function ElementPlaceholder({ onDismiss, title, subtitle, illustration }: Props) {
+export function ElementPlaceholder({
+    title,
+    subtitle,
+    illustration,
+    onClick,
+    onClickLabel = ' ',
+    onDismiss,
+}: Props) {
     return (
         <div className={styles.container}>
+            {onClick && (
+                <button className={styles.clickArea} onClick={onClick}>
+                    {onClickLabel}
+                </button>
+            )}
             <Button
-                className={styles.closeIcon}
+                className={styles.closeButton}
                 variant="secondary"
                 icon={Cross}
                 round

--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
@@ -11,11 +11,11 @@ import styles from './ElementPlaceholder.module.scss';
 interface Props {
     title: string;
     illustration: ReactNode;
-    onClick?: () => void;
+    onDismiss?: () => void;
     subtitle?: string;
 }
 
-export function ElementPlaceholder({ onClick, title, subtitle, illustration }: Props) {
+export function ElementPlaceholder({ onDismiss, title, subtitle, illustration }: Props) {
     return (
         <div className={styles.container}>
             <Button
@@ -23,7 +23,7 @@ export function ElementPlaceholder({ onClick, title, subtitle, illustration }: P
                 variant="secondary"
                 icon={Cross}
                 round
-                onClick={onClick}
+                onClick={onDismiss}
             />
             <VStack spacing="2">
                 <div className={styles.illustration}>{illustration}</div>

--- a/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
+++ b/packages/slate-editor/src/components/ElementPlaceholder/ElementPlaceholder.tsx
@@ -14,6 +14,7 @@ interface Props {
     onClick?: () => void;
     onClickLabel?: string;
     onDismiss?: () => void;
+    onDismissLabel?: string;
     subtitle?: string;
 }
 
@@ -22,8 +23,9 @@ export function ElementPlaceholder({
     subtitle,
     illustration,
     onClick,
-    onClickLabel = ' ',
+    onClickLabel,
     onDismiss,
+    onDismissLabel,
 }: Props) {
     return (
         <div className={styles.container}>
@@ -38,6 +40,7 @@ export function ElementPlaceholder({
                 icon={Cross}
                 round
                 onClick={onDismiss}
+                title={onDismissLabel}
             />
             <VStack spacing="2">
                 <div className={styles.illustration}>{illustration}</div>

--- a/packages/slate-editor/src/components/ElementPlaceholder/index.ts
+++ b/packages/slate-editor/src/components/ElementPlaceholder/index.ts
@@ -1,1 +1,1 @@
-export * from './ElementPlaceholder';
+export { ElementPlaceholder } from './ElementPlaceholder';

--- a/packages/slate-editor/src/components/index.ts
+++ b/packages/slate-editor/src/components/index.ts
@@ -14,7 +14,7 @@ export { ElementPortalV2, TextSelectionPortalV2 } from './Portals';
 export { FancyScrollbars } from './FancyScrollbars';
 export * as TooltipV2 from './TooltipV2';
 export * as Toolbox from './Toolbox';
-export * from './ElementPlaceholder';
+export { ElementPlaceholder } from './ElementPlaceholder';
 export * from './Stack';
 export * from './Button';
 export * from './ButtonGroup';

--- a/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.tsx
@@ -44,7 +44,7 @@ export function CoverageElement({
     return (
         <EditorBlock
             {...attributes}
-            border
+            border={Boolean(coverage)}
             element={element}
             renderBlock={function () {
                 if (loading) {

--- a/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/components/CoverageElement/CoverageElement.tsx
@@ -84,21 +84,23 @@ export function CoverageElement({
                 if (error && isNotFoundError(error)) {
                     return (
                         <ElementPlaceholder
-                            onDismiss={remove}
-                            illustration={<ChickenNoSignalIllustration />}
                             title="The selected coverage no longer exists and will not be displayed"
+                            illustration={<ChickenNoSignalIllustration />}
+                            onDismiss={remove}
+                            onDismissLabel="Remove this coverage"
                         />
                     );
                 }
 
                 return (
                     <ElementPlaceholder
+                        title="We have encountered a problem when loading your coverage"
+                        subtitle="Click to try again"
+                        illustration={<ChickenNoSignalIllustration />}
                         onClick={loadCoverage}
                         onClickLabel="Click to try again"
                         onDismiss={remove}
-                        illustration={<ChickenNoSignalIllustration />}
-                        title="We have encountered a problem when loading your coverage"
-                        subtitle="Click to try again"
+                        onDismissLabel="Remove this coverage"
                     />
                 );
             }}

--- a/packages/slate-editor/src/modules/editor-v4-coverage/lib/removeCoverage.ts
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/lib/removeCoverage.ts
@@ -3,8 +3,8 @@ import type { CoverageNode } from '@prezly/slate-types';
 import { isCoverageNode } from '@prezly/slate-types';
 import type { Editor } from 'slate';
 
-export function removeCoverage(editor: Editor): CoverageNode | null {
+export function removeCoverage(editor: Editor, coverage?: CoverageNode): CoverageNode | null {
     return EditorCommands.removeNode<CoverageNode>(editor, {
-        match: isCoverageNode,
+        match: coverage ? (node) => node === coverage : isCoverageNode,
     });
 }

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
@@ -100,9 +100,9 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
 
                 return (
                     <ElementPlaceholder
-                        onClick={remove}
                         illustration={<ChickenNoSignalIllustration />}
                         title="The selected Prezly Story is no longer available"
+                        onDismiss={remove}
                     />
                 );
             }}

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
@@ -30,11 +30,11 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
     }, [params.loadStory, element.story.uuid]);
 
     function remove() {
-        const removedElement = removeStoryBookmark(editor);
+        const removed = removeStoryBookmark(editor);
 
-        if (removedElement) {
+        if (removed) {
             EventsEditor.dispatchEvent(editor, 'web-bookmark-removed', {
-                uuid: removedElement.uuid,
+                uuid: removed.uuid,
             });
         }
     }

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
@@ -9,7 +9,7 @@ import { useAsyncFn } from '#lib';
 
 import { EventsEditor } from '#modules/editor-v4-events';
 
-import { removeStoryBookmark, updateImage } from '../../transforms';
+import { removeStoryBookmark, updateStoryBookmark } from '../../transforms';
 import type { StoryBookmarkExtensionParameters } from '../../types';
 import { StoryBookmarkMenu } from '../StoryBookmarkMenu';
 
@@ -29,7 +29,7 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
         return params.loadStory(element.story.uuid);
     }, [params.loadStory, element.story.uuid]);
 
-    const remove = () => {
+    function remove() {
         const removedElement = removeStoryBookmark(editor);
 
         if (removedElement) {
@@ -37,7 +37,7 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
                 uuid: removedElement.uuid,
             });
         }
-    };
+    }
 
     useEffect(() => {
         loadStory();
@@ -68,7 +68,7 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
                               element={element}
                               story={story}
                               withNewTabOption={params.withNewTabOption}
-                              onUpdate={(attrs) => updateImage(editor, attrs)}
+                              onUpdate={(attrs) => updateStoryBookmark(editor, attrs)}
                               onRemove={remove}
                           />
                       )

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/components/StoryBookmarkElement/StoryBookmarkElement.tsx
@@ -103,6 +103,7 @@ export function StoryBookmarkElement({ attributes, children, element, params }: 
                         illustration={<ChickenNoSignalIllustration />}
                         title="The selected Prezly Story is no longer available"
                         onDismiss={remove}
+                        onDismissLabel="Remove this Story Bookmark"
                     />
                 );
             }}

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/transforms/index.ts
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/transforms/index.ts
@@ -1,2 +1,2 @@
-export * from './removeStoryBookmark';
-export * from './updateStoryBookmark';
+export { removeStoryBookmark } from './removeStoryBookmark';
+export { updateStoryBookmark } from './updateStoryBookmark';

--- a/packages/slate-editor/src/modules/editor-v4-story-bookmark/transforms/updateStoryBookmark.ts
+++ b/packages/slate-editor/src/modules/editor-v4-story-bookmark/transforms/updateStoryBookmark.ts
@@ -5,7 +5,7 @@ import { Transforms } from 'slate';
 
 import { pick } from '#lodash';
 
-export function updateImage(
+export function updateStoryBookmark(
     editor: Editor,
     attrs: Partial<Pick<StoryBookmarkNode, 'show_thumbnail' | 'layout' | 'new_tab'>>,
 ) {


### PR DESCRIPTION
As discussed in #168 

- Implement a nice placeholder for coverage fetching errors from #161 
- Implement click-on-placeholder functionality
- Improve a11y for ElementPlaceholder actions

![Screenshot-2022-05-13,01-54-19](https://user-images.githubusercontent.com/370680/168180425-12b983c9-a447-4f6e-831f-bd31e39eb1b8.png)
