### PR TITLE
Fix CoverageNode model mismatch between frontend and backend

### DIFF
--- a/packages/slate-editor/src/modules/editor-v4-coverage/lib/createCoverage.ts
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/lib/createCoverage.ts
@@ -1,13 +1,19 @@
-import type { Coverage } from '@prezly/sdk';
 import type { CoverageNode } from '@prezly/slate-types';
-import { COVERAGE_NODE_TYPE } from '@prezly/slate-types';
+import { COVERAGE_NODE_TYPE, CoverageLayout } from '@prezly/slate-types';
 import { v4 as uuidV4 } from 'uuid';
 
-export function createCoverage(id: Coverage['id']): CoverageNode {
+export function createCoverage(
+    id: CoverageNode['coverage']['id'],
+    props: Partial<Omit<CoverageNode, 'type' | 'children' | 'coverage'>> = {},
+): CoverageNode {
     return {
-        children: [{ text: '' }],
+        uuid: uuidV4(),
+        layout: CoverageLayout.HORIZONTAL,
+        new_tab: true,
+        show_thumbnail: true,
+        ...props,
         coverage: { id },
         type: COVERAGE_NODE_TYPE,
-        uuid: uuidV4(),
+        children: [{ text: '' }],
     };
 }

--- a/packages/slate-editor/src/modules/editor-v4-coverage/lib/normalizeRedundantCoverageAttributes.ts
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/lib/normalizeRedundantCoverageAttributes.ts
@@ -1,10 +1,18 @@
 import { EditorCommands } from '@prezly/slate-commons';
+import type { CoverageNode } from '@prezly/slate-types';
 import { isCoverageNode } from '@prezly/slate-types';
 import type { Editor, NodeEntry } from 'slate';
 
-import { createCoverage } from './createCoverage';
-
-const ALLOWED_ATTRIBUTES = Object.keys(createCoverage(0));
+const SHAPE: Record<keyof CoverageNode, boolean> = {
+    type: true,
+    uuid: true,
+    coverage: true,
+    children: true,
+    layout: true,
+    new_tab: true,
+    show_thumbnail: true,
+};
+const ALLOWED_ATTRIBUTES = Object.keys(SHAPE);
 
 export function normalizeRedundantCoverageAttributes(
     editor: Editor,

--- a/packages/slate-editor/src/modules/editor-v4-coverage/lib/parseSerializedElement.ts
+++ b/packages/slate-editor/src/modules/editor-v4-coverage/lib/parseSerializedElement.ts
@@ -1,13 +1,13 @@
 import type { CoverageNode } from '@prezly/slate-types';
-import { isCoverageNode } from '@prezly/slate-types';
+import { validateCoverageNode } from '@prezly/slate-types';
 
 import { createCoverage } from './createCoverage';
 
 export function parseSerializedElement(serialized: string): CoverageNode | undefined {
-    const parsed = JSON.parse(serialized);
+    const parsed = validateCoverageNode(JSON.parse(serialized));
 
-    if (isCoverageNode(parsed)) {
-        return createCoverage(parsed.coverage.id);
+    if (parsed) {
+        return createCoverage(parsed.coverage.id, parsed);
     }
 
     return undefined;

--- a/packages/slate-types/src/nodes/CoverageNode.ts
+++ b/packages/slate-types/src/nodes/CoverageNode.ts
@@ -27,8 +27,9 @@ export function isCoverageNode(value: any): value is CoverageNode {
 }
 
 export function validateCoverageNode(value: any): CoverageNode | null {
-    const isValid = isCoverageNode(value);
-    isUuid(value.uuid) &&
+    const isValid =
+        isCoverageNode(value) &&
+        isUuid(value.uuid) &&
         isEnum(value.layout, CoverageLayout) &&
         isBoolean(value.new_tab) &&
         isBoolean(value.show_thumbnail) &&

--- a/packages/slate-types/src/nodes/CoverageNode.ts
+++ b/packages/slate-types/src/nodes/CoverageNode.ts
@@ -2,17 +2,38 @@ import type { Coverage } from '@prezly/sdk';
 
 import type { ElementNode } from './ElementNode';
 import { isElementNode } from './ElementNode';
+import { isBoolean, isEnum, isNonZeroInteger, isObject, isUuid } from './validation';
 
 export const COVERAGE_NODE_TYPE = 'coverage';
 
+export enum CoverageLayout {
+    VERTICAL = 'vertical',
+    HORIZONTAL = 'horizontal',
+}
+
 export interface CoverageNode extends ElementNode {
     type: typeof COVERAGE_NODE_TYPE;
+    uuid: string;
     coverage: {
         id: Coverage['id'];
     };
-    uuid: string;
+    layout: CoverageLayout;
+    new_tab: boolean;
+    show_thumbnail: boolean;
 }
 
 export function isCoverageNode(value: any): value is CoverageNode {
     return isElementNode<CoverageNode>(value, COVERAGE_NODE_TYPE);
+}
+
+export function validateCoverageNode(value: any): CoverageNode | null {
+    const isValid = isCoverageNode(value);
+    isUuid(value.uuid) &&
+        isEnum(value.layout, CoverageLayout) &&
+        isBoolean(value.new_tab) &&
+        isBoolean(value.show_thumbnail) &&
+        isObject(value.coverage) &&
+        (isNonZeroInteger(value.coverage.id) || isUuid(value.coverage.id));
+
+    return isValid ? value : null;
 }


### PR DESCRIPTION
As mentioned in https://github.com/prezly/prezly/pull/10959#issuecomment-1125776566, 
there was a bug that lead to email editor content being constantly marked as modified.

I've narrowed it down to the mismatch between CoverageNode backend and frontend models:
- `new_tab`, `layout`, `show_thumbnail` attributes were sent from backend
- then frontend was automatically removing unknown attributes during the normalization process
- this made the in-editor content differ from the backend model, and marked the content as modified, triggering autosave
- ... repeating forever