### PR TITLE
[MT-4960] Fix - Menu positioning

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -130,7 +130,6 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                 {isOnlyBlockSelected && renderMenu && container && editorElement && (
                     <Menu
                         className={styles.menu}
-                        editorElement={editorElement}
                         open={menuOpen}
                         reference={container}
                         onClick={preventBubbling}

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -17,7 +17,11 @@ import { Overlay } from './Overlay';
 
 type SlateInternalAttributes = RenderElementProps['attributes'];
 
-type Layout = 'contained' | 'expanded' | 'full-width';
+enum Layout {
+    CONTAINED = 'contained',
+    EXPANDED = 'expanded',
+    FULL_WIDTH = 'full-width',
+}
 
 export interface Props extends Omit<RenderElementProps, 'attributes'>, SlateInternalAttributes {
     align?: Alignment;
@@ -37,7 +41,7 @@ export interface Props extends Omit<RenderElementProps, 'attributes'>, SlateInte
      * Mark the block having an error.
      */
     hasError?: boolean;
-    layout?: Layout;
+    layout?: `${Layout}`;
     overlay?: OverlayMode;
     renderBlock: (props: { isSelected: boolean }) => ReactNode;
     renderMenu?: (props: { onClose: () => void }) => ReactNode;

--- a/packages/slate-editor/src/components/EditorBlock/Menu.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/Menu.tsx
@@ -43,7 +43,7 @@ const MODIFIERS: Modifier<string>[] = [
         options: {
             altAxis: true,
             mainAxis: false,
-            boundary: document.body,
+            rootBoundary: 'document',
             padding: {
                 right: 4,
             },

--- a/packages/slate-editor/src/components/EditorBlock/Menu.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/Menu.tsx
@@ -1,4 +1,3 @@
-import { preventOverflow } from '@popperjs/core';
 import classNames from 'classnames';
 import type { MouseEvent, ReactNode } from 'react';
 import React, { Component } from 'react';
@@ -12,7 +11,6 @@ import styles from './Menu.module.scss';
 interface Props {
     children: ReactNode;
     className?: string;
-    editorElement: HTMLElement;
     onClick?: (event: MouseEvent) => void;
     open: boolean;
     reference: HTMLElement;
@@ -40,6 +38,18 @@ const MODIFIERS: Modifier<string>[] = [
         },
     },
     {
+        name: 'preventOverflow',
+        enabled: true,
+        options: {
+            altAxis: true,
+            mainAxis: false,
+            boundary: document.body,
+            padding: {
+                right: 4,
+            },
+        },
+    },
+    {
         name: 'prezly:autoHideArrow',
         enabled: true,
         phase: 'write',
@@ -47,7 +57,7 @@ const MODIFIERS: Modifier<string>[] = [
             const { arrow } = state.elements;
 
             if (arrow) {
-                if (state.modifiersData['prezly:preventEditorOverflow']?.x) {
+                if (state.modifiersData.preventOverflow?.x) {
                     arrow.classList.add(styles.hidden);
                 } else {
                     arrow.classList.remove(styles.hidden);
@@ -82,7 +92,7 @@ export class Menu extends Component<Props> {
     };
 
     render() {
-        const { children, className, editorElement, onClick, open } = this.props;
+        const { children, className, onClick, open } = this.props;
 
         if (!open) {
             return null;
@@ -93,7 +103,7 @@ export class Menu extends Component<Props> {
                 referenceElement={{
                     getBoundingClientRect: this.getVirtualReferenceClientRect,
                 }}
-                modifiers={[...MODIFIERS, keepPopoverInEditor(editorElement)]}
+                modifiers={MODIFIERS}
                 placement="right-start"
             >
                 {({ ref, style, arrowProps, placement }) => (
@@ -118,20 +128,4 @@ export class Menu extends Component<Props> {
             </Popper>
         );
     }
-}
-
-function keepPopoverInEditor(editorElement: HTMLElement): Modifier<string> {
-    return {
-        ...preventOverflow,
-        name: 'prezly:preventEditorOverflow',
-        enabled: true,
-        options: {
-            altAxis: true,
-            mainAxis: false,
-            boundary: editorElement,
-            padding: {
-                right: 4,
-            },
-        },
-    };
 }


### PR DESCRIPTION
- Allow editor block menu to leave the editor frame

Before:
![Screenshot-2022-05-03,12-09-21](https://user-images.githubusercontent.com/370680/168284011-75a8a6a7-bb24-4b69-8eb7-8de4b32dad79.png)


After: 
![Screenshot-2022-05-13,15-31-51](https://user-images.githubusercontent.com/370680/168283937-d106c66a-810f-47f2-b0a3-9dac1a5fed24.png)
