### PR TITLE
[MT-4965] Fix - Image menu overlapping with caption

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -98,12 +98,6 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
         [editor, element],
     );
 
-    const handleNonVoidChildrenClick = useCallback(
-        function () {
-            setMenuOpen(false);
-        },
-        [],
-    );
 
     useEffect(
         function () {
@@ -123,7 +117,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
             data-slate-type={element.type}
             data-slate-value={JSON.stringify(element)}
             data-element-layout={layout}
-            onClick={isVoid ? undefined : handleNonVoidChildrenClick}
+            onClick={isVoid ? undefined : closeMenu}
             ref={ref}
         >
             <div

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -85,8 +85,10 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
     const openMenu = useCallback(() => setMenuOpen(true), [setMenuOpen]);
     const closeMenu = useCallback(() => setMenuOpen(false), [setMenuOpen]);
 
-    const handleClick = useCallback(
-        function () {
+    const handleBlockClick = useCallback(
+        function (event) {
+            event.stopPropagation();
+
             openMenu();
 
             if (!isVoid) {
@@ -97,9 +99,19 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
         [editor, element, openMenu, isVoid],
     );
 
+    const handleTextClick = useCallback(
+        function () {
+            if (!isVoid) {
+                setMenuOpen(false);
+            }
+        },
+        [isVoid],
+    );
+
     useEffect(
         function () {
-            if (isOnlyBlockSelected) setMenuOpen(true);
+            if (isVoid && isOnlyBlockSelected) setMenuOpen(true);
+            if (!isOnlyBlockSelected) setMenuOpen(false);
         },
         [isOnlyBlockSelected],
     );
@@ -114,6 +126,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
             data-slate-type={element.type}
             data-slate-value={JSON.stringify(element)}
             data-element-layout={layout}
+            onClick={handleTextClick}
             ref={ref}
         >
             <div
@@ -124,7 +137,6 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                 })}
                 contentEditable={false}
                 ref={setContainer}
-                onClick={handleClick}
                 style={{ width }}
             >
                 {isOnlyBlockSelected && renderMenu && container && editorElement && (
@@ -137,7 +149,12 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                         {renderMenu({ onClose: closeMenu })}
                     </Menu>
                 )}
-                <Overlay className={styles.overlay} selected={isSelected} mode={overlay} />
+                <Overlay
+                    className={styles.overlay}
+                    selected={isSelected}
+                    mode={overlay}
+                    onClick={handleBlockClick}
+                />
                 <div
                     className={classNames(styles.content, {
                         [styles.selected]: isSelected,
@@ -145,6 +162,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                         [styles.border]: border,
                         [styles.rounded]: rounded,
                     })}
+                    onClick={handleBlockClick}
                 >
                     {renderBlock({ isSelected })}
                 </div>

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -98,7 +98,6 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
         [editor, element],
     );
 
-
     useEffect(
         function () {
             if (isVoid && isOnlyBlockSelected) setMenuOpen(true);

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -82,21 +82,20 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
 
     const [menuOpen, setMenuOpen] = useState(true);
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
-    const openMenu = useCallback(() => setMenuOpen(true), [setMenuOpen]);
-    const closeMenu = useCallback(() => setMenuOpen(false), [setMenuOpen]);
+    const closeMenu = useCallback(() => setMenuOpen(false), []);
 
     const handleBlockClick = useCallback(
         function (event) {
             event.stopPropagation();
 
-            openMenu();
+            setMenuOpen(true);
 
             if (!isVoid) {
                 const path = ReactEditor.findPath(editor, element);
                 Transforms.select(editor, path);
             }
         },
-        [editor, element, openMenu, isVoid],
+        [editor, element, isVoid],
     );
 
     const handleTextClick = useCallback(

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -100,11 +100,9 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
 
     const handleNonVoidChildrenClick = useCallback(
         function () {
-            if (!isVoid) {
-                setMenuOpen(false);
-            }
+            setMenuOpen(false);
         },
-        [isVoid],
+        [],
     );
 
     useEffect(

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -85,12 +85,11 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
     const closeMenu = useCallback(() => setMenuOpen(false), []);
 
     const handleBlockClick = useCallback(
-        function (event) {
-            event.stopPropagation();
-
+        function (event: MouseEvent) {
             setMenuOpen(true);
 
             if (!isVoid) {
+                event.stopPropagation();
                 const path = ReactEditor.findPath(editor, element);
                 Transforms.select(editor, path);
             }
@@ -125,7 +124,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
             data-slate-type={element.type}
             data-slate-value={JSON.stringify(element)}
             data-element-layout={layout}
-            onClick={handleTextClick}
+            onClick={!isVoid ? handleTextClick : undefined}
             ref={ref}
         >
             <div

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -84,20 +84,21 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
     const closeMenu = useCallback(() => setMenuOpen(false), []);
 
-    const handleBlockClick = useCallback(
+    const handleVoidBlockClick = useCallback(function () {
+        setMenuOpen(true);
+    }, []);
+
+    const handleNonVoidBlockClick = useCallback(
         function (event: MouseEvent) {
             setMenuOpen(true);
-
-            if (!isVoid) {
-                event.stopPropagation();
-                const path = ReactEditor.findPath(editor, element);
-                Transforms.select(editor, path);
-            }
+            event.stopPropagation();
+            const path = ReactEditor.findPath(editor, element);
+            Transforms.select(editor, path);
         },
-        [editor, element, isVoid],
+        [editor, element],
     );
 
-    const handleTextClick = useCallback(
+    const handleNonVoidChildrenClick = useCallback(
         function () {
             if (!isVoid) {
                 setMenuOpen(false);
@@ -124,7 +125,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
             data-slate-type={element.type}
             data-slate-value={JSON.stringify(element)}
             data-element-layout={layout}
-            onClick={!isVoid ? handleTextClick : undefined}
+            onClick={isVoid ? undefined : handleNonVoidChildrenClick}
             ref={ref}
         >
             <div
@@ -151,7 +152,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                     className={styles.overlay}
                     selected={isSelected}
                     mode={overlay}
-                    onClick={handleBlockClick}
+                    onClick={isVoid ? handleVoidBlockClick : handleNonVoidBlockClick}
                 />
                 <div
                     className={classNames(styles.content, {
@@ -160,7 +161,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                         [styles.border]: border,
                         [styles.rounded]: rounded,
                     })}
-                    onClick={handleBlockClick}
+                    onClick={isVoid ? handleVoidBlockClick : handleNonVoidBlockClick}
                 >
                     {renderBlock({ isSelected })}
                 </div>

--- a/packages/slate-editor/src/components/EditorBlock/Overlay.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/Overlay.tsx
@@ -9,7 +9,7 @@ interface Props {
     className?: string;
     selected: boolean;
     mode: OverlayMode;
-    onClick?: () => void;
+    onClick?: (event: React.MouseEvent) => void;
 }
 
 export function Overlay({ className, mode, onClick, selected }: Props) {


### PR DESCRIPTION
Improve Image menu behavior vs caption-text selection

- Do not open the menu every time image caption text is focused
- Automatically close the menu when caption text is clicked