### PR TITLE
[MT-4966] Fix scroll-into-view behavior for tall galleries

### DIFF
--- a/packages/slate-editor/src/lib/scrollIntoView.ts
+++ b/packages/slate-editor/src/lib/scrollIntoView.ts
@@ -56,7 +56,7 @@ export function scrollIntoView(
         // This is critical for tall elements, like big galleries.
         const y = Math.min(
             parent.scrollTop + elementTop - minTop,
-            parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom
+            parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom,
         );
         scrollTo(parent, parent.scrollLeft, y);
         return;

--- a/packages/slate-editor/src/lib/scrollIntoView.ts
+++ b/packages/slate-editor/src/lib/scrollIntoView.ts
@@ -3,8 +3,8 @@ import type { Rect } from 'rangefix';
 import { scrollTo } from './scrollTo';
 
 export interface Options {
-    minBottom: number;
-    minTop: number;
+    minBottom?: number;
+    minTop?: number;
     skipWhenDoesNotFitView?: boolean;
 }
 
@@ -25,7 +25,7 @@ export interface Options {
 export function scrollIntoView(
     parent: HTMLElement,
     rect: ClientRect | Rect,
-    { minBottom, minTop, skipWhenDoesNotFitView = false }: Options,
+    { minTop = 0, minBottom = 0, skipWhenDoesNotFitView = false }: Options,
 ) {
     const { height: parentHeight } = parent.getBoundingClientRect();
     const { height: elementHeight, top: elementTop } = rect;

--- a/packages/slate-editor/src/lib/scrollIntoView.ts
+++ b/packages/slate-editor/src/lib/scrollIntoView.ts
@@ -5,6 +5,7 @@ import { scrollTo } from './scrollTo';
 export interface Options {
     minBottom?: number;
     minTop?: number;
+    padding?: number;
     skipWhenDoesNotFitView?: boolean;
 }
 
@@ -25,7 +26,7 @@ export interface Options {
 export function scrollIntoView(
     parent: HTMLElement,
     rect: ClientRect | Rect,
-    { minTop = 0, minBottom = 0, skipWhenDoesNotFitView = false }: Options,
+    { minTop = 0, minBottom = 0, padding = 16, skipWhenDoesNotFitView = false }: Options,
 ) {
     const { height: parentHeight } = parent.getBoundingClientRect();
     const { height: elementHeight, top: elementTop } = rect;
@@ -45,7 +46,7 @@ export function scrollIntoView(
     }
 
     if (isChildAboveVisibleArea) {
-        const y = parent.scrollTop + elementTop - minTop;
+        const y = parent.scrollTop + elementTop - minTop - padding;
         scrollTo(parent, parent.scrollLeft, y);
         return;
     }
@@ -55,8 +56,8 @@ export function scrollIntoView(
         // but disallow the element TOP EDGE to leave the viewport.
         // This is critical for tall elements, like big galleries.
         const y = Math.min(
-            parent.scrollTop + elementTop - minTop,
-            parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom,
+            parent.scrollTop + elementTop - minTop - padding,
+            parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom + padding,
         );
         scrollTo(parent, parent.scrollLeft, y);
         return;

--- a/packages/slate-editor/src/lib/scrollIntoView.ts
+++ b/packages/slate-editor/src/lib/scrollIntoView.ts
@@ -47,8 +47,18 @@ export function scrollIntoView(
     if (isChildAboveVisibleArea) {
         const y = parent.scrollTop + elementTop - minTop;
         scrollTo(parent, parent.scrollLeft, y);
-    } else if (isChildBelowVisibleArea) {
-        const y = parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom;
+        return;
+    }
+
+    if (isChildBelowVisibleArea) {
+        // Scroll to align the BOTTOM EDGE of the element with the viewport,
+        // but disallow the element TOP EDGE to leave the viewport.
+        // This is critical for tall elements, like big galleries.
+        const y = Math.min(
+            parent.scrollTop + elementTop - minTop,
+            parent.scrollTop + elementTop + elementHeight - parentHeight + minBottom
+        );
         scrollTo(parent, parent.scrollLeft, y);
+        return;
     }
 }


### PR DESCRIPTION
- Fix scroll-into-view logic for tall blocks
- Add an extra padding to the calculations, so there is some space between the block edge and the viewport edge

Before:
![Peek 2022-05-13 16-50](https://user-images.githubusercontent.com/370680/168305333-b5219752-8009-4dfe-9aba-b1edfd7e98dd.gif)

After:

https://user-images.githubusercontent.com/370680/168305763-177d189d-c578-4a43-b4de-6cf25e22d228.mp4

