### PR TITLE
Refactor - Extensions inline/void checks

### DIFF
--- a/packages/slate-commons/src/plugins/withInlineVoid.ts
+++ b/packages/slate-commons/src/plugins/withInlineVoid.ts
@@ -8,18 +8,18 @@ export function withInlineVoid(getExtensions: () => Extension[]) {
         const { isInline, isVoid } = editor;
 
         editor.isInline = (element) => {
-            const anyElement: Record<string, unknown> = element as unknown as Record<
-                string,
-                unknown
-            >;
-            const extensions = getExtensions();
-            const inlineTypes = extensions.flatMap((extension) => extension.inlineTypes || []);
-            return inlineTypes.includes(anyElement.type as string) ? true : isInline(element);
+            for (const extension of getExtensions()) {
+                if (extension.isInline?.(element)) {
+                    return true;
+                }
+            }
+
+            return isInline(element);
         };
 
         editor.isVoid = (element) => {
-            for (const { isVoid } of getExtensions()) {
-                if (isVoid?.(element)) {
+            for (const extension of getExtensions()) {
+                if (extension.isVoid?.(element)) {
                     return true;
                 }
             }

--- a/packages/slate-commons/src/plugins/withInlineVoid.ts
+++ b/packages/slate-commons/src/plugins/withInlineVoid.ts
@@ -18,13 +18,13 @@ export function withInlineVoid(getExtensions: () => Extension[]) {
         };
 
         editor.isVoid = (element) => {
-            const anyElement: Record<string, unknown> = element as unknown as Record<
-                string,
-                unknown
-            >;
-            const extensions = getExtensions();
-            const voidTypes = extensions.flatMap((extension) => extension.voidTypes || []);
-            return voidTypes.includes(anyElement.type as string) ? true : isVoid(element);
+            for (const { isVoid } of getExtensions()) {
+                if (isVoid?.(element)) {
+                    return true;
+                }
+            }
+
+            return isVoid(element);
         };
 
         return editor;

--- a/packages/slate-commons/src/plugins/withNormalization.ts
+++ b/packages/slate-commons/src/plugins/withNormalization.ts
@@ -8,7 +8,7 @@ export function withNormalization(getExtensions: () => Extension[]) {
         const { normalizeNode } = editor;
 
         editor.normalizeNode = (entry) => {
-            const normalizers = getExtensions().flatMap((extension) => extension.normalizers || []);
+            const normalizers = getExtensions().flatMap(({ normalizeNode = [] }) => normalizeNode);
 
             for (const normalizer of normalizers) {
                 const normalized = normalizer(editor, entry);

--- a/packages/slate-commons/src/types/Extension.ts
+++ b/packages/slate-commons/src/types/Extension.ts
@@ -13,7 +13,7 @@ export interface Extension {
     id: string;
     decorate?: DecorateFactory;
     deserialize?: DeserializeHtml;
-    inlineTypes?: string[];
+    isInline?: (node: Node) => boolean;
     isRichBlock?: (node: Node) => boolean;
     isVoid?: (node: Node) => boolean;
     normalizers?: Normalize[];

--- a/packages/slate-commons/src/types/Extension.ts
+++ b/packages/slate-commons/src/types/Extension.ts
@@ -16,7 +16,7 @@ export interface Extension {
     isInline?: (node: Node) => boolean;
     isRichBlock?: (node: Node) => boolean;
     isVoid?: (node: Node) => boolean;
-    normalizers?: Normalize[];
+    normalizeNode?: Normalize | Normalize[];
     onDOMBeforeInput?: OnDOMBeforeInput;
     onKeyDown?: OnKeyDown | null;
     renderElement?: RenderElement;

--- a/packages/slate-commons/src/types/Extension.ts
+++ b/packages/slate-commons/src/types/Extension.ts
@@ -15,6 +15,7 @@ export interface Extension {
     deserialize?: DeserializeHtml;
     inlineTypes?: string[];
     isRichBlock?: (node: Node) => boolean;
+    isVoid?: (node: Node) => boolean;
     normalizers?: Normalize[];
     onDOMBeforeInput?: OnDOMBeforeInput;
     onKeyDown?: OnKeyDown | null;
@@ -28,5 +29,4 @@ export interface Extension {
      * they will be lifted up to the root of the editor.
      */
     rootTypes?: string[];
-    voidTypes?: string[];
 }

--- a/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
+++ b/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
@@ -19,7 +19,7 @@ export const CoverageExtension = ({ dateFormat, fetchCoverage }: Parameters): Ex
     },
     isRichBlock: isCoverageNode,
     isVoid: isCoverageNode,
-    normalizers: [normalizeRedundantCoverageAttributes],
+    normalizeNode: normalizeRedundantCoverageAttributes,
     renderElement: ({ attributes, children, element }) => {
         if (isCoverageNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
+++ b/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
@@ -18,6 +18,7 @@ export const CoverageExtension = ({ dateFormat, fetchCoverage }: Parameters): Ex
         },
     },
     isRichBlock: isCoverageNode,
+    isVoid: isCoverageNode,
     normalizers: [normalizeRedundantCoverageAttributes],
     renderElement: ({ attributes, children, element }) => {
         if (isCoverageNode(element)) {
@@ -36,5 +37,4 @@ export const CoverageExtension = ({ dateFormat, fetchCoverage }: Parameters): Ex
         return undefined;
     },
     rootTypes: [COVERAGE_NODE_TYPE],
-    voidTypes: [COVERAGE_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
+++ b/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
@@ -23,7 +23,7 @@ export const DividerExtension = (): Extension => ({
     },
     id: DIVIDER_EXTENSION_ID,
     isVoid: isDividerNode,
-    normalizers: [normalizeRedundantDividerAttributes],
+    normalizeNode: normalizeRedundantDividerAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isDividerNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
+++ b/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
@@ -22,6 +22,7 @@ export const DividerExtension = (): Extension => ({
         },
     },
     id: DIVIDER_EXTENSION_ID,
+    isVoid: isDividerNode,
     normalizers: [normalizeRedundantDividerAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isDividerNode(element)) {
@@ -35,5 +36,4 @@ export const DividerExtension = (): Extension => ({
         return undefined;
     },
     rootTypes: [DIVIDER_NODE_TYPE],
-    voidTypes: [DIVIDER_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
@@ -21,6 +21,7 @@ export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters)
         },
     },
     isRichBlock: isEmbedNode,
+    isVoid: isEmbedNode,
     normalizers: [normalizeRedundantEmbedAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isEmbedNode(element)) {
@@ -41,5 +42,4 @@ export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters)
         return undefined;
     },
     rootTypes: [EMBED_TYPE],
-    voidTypes: [EMBED_TYPE],
 });

--- a/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
@@ -22,7 +22,7 @@ export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters)
     },
     isRichBlock: isEmbedNode,
     isVoid: isEmbedNode,
-    normalizers: [normalizeRedundantEmbedAttributes],
+    normalizeNode: normalizeRedundantEmbedAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isEmbedNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
+++ b/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
@@ -29,6 +29,7 @@ export const FileAttachmentExtension = ({
         },
     },
     isRichBlock: isAttachmentNode,
+    isVoid: isAttachmentNode,
     normalizers: [normalizeRedundantFileAttachmentAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isAttachmentNode(element)) {
@@ -57,5 +58,4 @@ export const FileAttachmentExtension = ({
         return undefined;
     },
     rootTypes: [ATTACHMENT_NODE_TYPE],
-    voidTypes: [ATTACHMENT_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
+++ b/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
@@ -30,7 +30,7 @@ export const FileAttachmentExtension = ({
     },
     isRichBlock: isAttachmentNode,
     isVoid: isAttachmentNode,
-    normalizers: [normalizeRedundantFileAttachmentAttributes],
+    normalizeNode: normalizeRedundantFileAttachmentAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isAttachmentNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
+++ b/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
@@ -27,7 +27,7 @@ export const GalleriesExtension = ({ availableWidth, onEdit }: Parameters): Exte
     },
     isRichBlock: isGalleryNode,
     isVoid: isGalleryNode,
-    normalizers: [normalizeInvalidGallery, normalizeRedundantGalleryAttributes],
+    normalizeNode: [normalizeInvalidGallery, normalizeRedundantGalleryAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isGalleryNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
+++ b/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
@@ -26,6 +26,7 @@ export const GalleriesExtension = ({ availableWidth, onEdit }: Parameters): Exte
         },
     },
     isRichBlock: isGalleryNode,
+    isVoid: isGalleryNode,
     normalizers: [normalizeInvalidGallery, normalizeRedundantGalleryAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isGalleryNode(element)) {
@@ -44,5 +45,4 @@ export const GalleriesExtension = ({ availableWidth, onEdit }: Parameters): Exte
         return undefined;
     },
     rootTypes: [GALLERY_NODE_TYPE],
-    voidTypes: [GALLERY_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
+++ b/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
@@ -16,7 +16,7 @@ export const HtmlExtension = (): Extension => ({
     },
     id: HTML_EXTENSION_ID,
     isVoid: isHtmlNode,
-    normalizers: [normalizeRedundantHtmlBlockAttributes],
+    normalizeNode: normalizeRedundantHtmlBlockAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isHtmlNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
+++ b/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
@@ -15,6 +15,7 @@ export const HtmlExtension = (): Extension => ({
         },
     },
     id: HTML_EXTENSION_ID,
+    isVoid: isHtmlNode,
     normalizers: [normalizeRedundantHtmlBlockAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isHtmlNode(element)) {
@@ -28,5 +29,4 @@ export const HtmlExtension = (): Extension => ({
         return undefined;
     },
     rootTypes: [HTML_NODE_TYPE],
-    voidTypes: [HTML_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/image/ImageExtension.tsx
+++ b/packages/slate-editor/src/extensions/image/ImageExtension.tsx
@@ -70,7 +70,7 @@ export const ImageExtension = ({
         }
         return isImageCandidateElement(node) || isImageNode(node);
     },
-    normalizers: [
+    normalizeNode: [
         normalizeRedundantImageAttributes,
         normalizeChildren,
         // normalizeImageCandidate needs to be last because it removes the image candidate element

--- a/packages/slate-editor/src/extensions/image/ImageExtension.tsx
+++ b/packages/slate-editor/src/extensions/image/ImageExtension.tsx
@@ -19,6 +19,7 @@ import { IMAGE_CANDIDATE_TYPE, IMAGE_EXTENSION_ID } from './constants';
 import {
     createImageCandidate,
     getAncestorAnchor,
+    isImageCandidateElement,
     normalizeChildren,
     normalizeImageCandidate,
     normalizeRedundantImageAttributes,
@@ -63,6 +64,12 @@ export const ImageExtension = ({
         },
     },
     isRichBlock: isImageNode,
+    isVoid: (node) => {
+        if (captions) {
+            return isImageCandidateElement(node);
+        }
+        return isImageCandidateElement(node) || isImageNode(node);
+    },
     normalizers: [
         normalizeRedundantImageAttributes,
         normalizeChildren,
@@ -149,5 +156,4 @@ export const ImageExtension = ({
         return undefined;
     },
     rootTypes: [IMAGE_CANDIDATE_TYPE, IMAGE_NODE_TYPE],
-    voidTypes: captions ? [IMAGE_CANDIDATE_TYPE] : [IMAGE_CANDIDATE_TYPE, IMAGE_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
+++ b/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
@@ -32,7 +32,7 @@ export const InlineLinksExtension = (): Extension => ({
             },
         },
     },
-    inlineTypes: [LINK_NODE_TYPE],
+    isInline: isLinkNode,
     normalizers: [normalizeEmptyLink, normalizeNestedLink, normalizeRedundantLinkAttributes],
     onKeyDown: function (event, editor) {
         escapeLinksBoundaries(event, editor);

--- a/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
+++ b/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
@@ -33,7 +33,7 @@ export const InlineLinksExtension = (): Extension => ({
         },
     },
     isInline: isLinkNode,
-    normalizers: [normalizeEmptyLink, normalizeNestedLink, normalizeRedundantLinkAttributes],
+    normalizeNode: [normalizeEmptyLink, normalizeNestedLink, normalizeRedundantLinkAttributes],
     onKeyDown: function (event, editor) {
         escapeLinksBoundaries(event, editor);
     },

--- a/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
+++ b/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
@@ -14,7 +14,7 @@ export const LoaderExtension = ({
     id: LOADER_EXTENSION_ID,
     isRichBlock: isLoaderElement,
     isVoid: isLoaderElement,
-    normalizers: [normalizeRedundantLoaderAttributes],
+    normalizeNode: normalizeRedundantLoaderAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isLoaderElement(element)) {
             return (

--- a/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
+++ b/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
@@ -13,6 +13,7 @@ export const LoaderExtension = ({
 }: LoaderParameters): Extension => ({
     id: LOADER_EXTENSION_ID,
     isRichBlock: isLoaderElement,
+    isVoid: isLoaderElement,
     normalizers: [normalizeRedundantLoaderAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isLoaderElement(element)) {
@@ -31,5 +32,4 @@ export const LoaderExtension = ({
         return undefined;
     },
     rootTypes: [LOADER_TYPE],
-    voidTypes: [LOADER_TYPE],
 });

--- a/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
+++ b/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
@@ -7,15 +7,15 @@ import type { MentionElementType } from './types';
 
 interface Options<T extends string> {
     id: Extension['id'];
-    normalizers: Extension['normalizers'];
+    type: T;
+    normalizeNode?: Extension['normalizeNode'];
     parseSerializedElement: (serialized: string) => MentionElementType | undefined;
     renderElement: Extension['renderElement'];
-    type: T;
 }
 
 export function MentionsExtension<T extends string>({
     id,
-    normalizers,
+    normalizeNode,
     parseSerializedElement,
     renderElement,
     type,
@@ -33,7 +33,7 @@ export function MentionsExtension<T extends string>({
         id,
         isInline: isMention,
         isVoid: isMention,
-        normalizers,
+        normalizeNode,
         renderElement,
     };
 }

--- a/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
+++ b/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
@@ -1,5 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
+import type { Node } from 'slate';
+import { Element } from 'slate';
 
 import type { MentionElementType } from './types';
 
@@ -18,6 +20,10 @@ export function MentionsExtension<T extends string>({
     renderElement,
     type,
 }: Options<T>): Extension {
+    function isMention(node: Node) {
+        return Element.isElementType(node, type);
+    }
+
     return {
         deserialize: {
             element: {
@@ -26,8 +32,8 @@ export function MentionsExtension<T extends string>({
         },
         id,
         inlineTypes: [type],
+        isVoid: isMention,
         normalizers,
         renderElement,
-        voidTypes: [type],
     };
 }

--- a/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
+++ b/packages/slate-editor/src/extensions/mentions/MentionsExtension.ts
@@ -31,7 +31,7 @@ export function MentionsExtension<T extends string>({
             },
         },
         id,
-        inlineTypes: [type],
+        isInline: isMention,
         isVoid: isMention,
         normalizers,
         renderElement,

--- a/packages/slate-editor/src/extensions/mentions/test-utils.tsx
+++ b/packages/slate-editor/src/extensions/mentions/test-utils.tsx
@@ -11,7 +11,6 @@ import { MentionsExtension } from './MentionsExtension';
 const PlaceholderMentionsExtension = () =>
     MentionsExtension({
         id: 'MentionsExtension',
-        normalizers: [],
         parseSerializedElement: JSON.parse,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
             if (isPlaceholderNode(element)) {

--- a/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
@@ -15,7 +15,7 @@ import {
 export const ParagraphsExtension = (): Extension => ({
     deserialize,
     id: PARAGRAPHS_EXTENSION_ID,
-    normalizers: [
+    normalizeNode: [
         normalizeOrphanText,
         normalizeRedundantParagraphAttributes,
         normalizeUnknownElement,

--- a/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
@@ -12,7 +12,7 @@ export const PlaceholderMentionsExtension = (): Extension =>
     MentionsExtension({
         id: PLACEHOLDER_MENTIONS_EXTENSION_ID,
         type: PLACEHOLDER_NODE_TYPE,
-        normalizers: [normalizeRedundantPlaceholderMentionAttributes],
+        normalizeNode: normalizeRedundantPlaceholderMentionAttributes,
         parseSerializedElement,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
             if (isPlaceholderNode(element)) {

--- a/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
@@ -11,6 +11,7 @@ import { normalizeRedundantPlaceholderMentionAttributes, parseSerializedElement 
 export const PlaceholderMentionsExtension = (): Extension =>
     MentionsExtension({
         id: PLACEHOLDER_MENTIONS_EXTENSION_ID,
+        type: PLACEHOLDER_NODE_TYPE,
         normalizers: [normalizeRedundantPlaceholderMentionAttributes],
         parseSerializedElement,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
@@ -25,5 +26,4 @@ export const PlaceholderMentionsExtension = (): Extension =>
 
             return undefined;
         },
-        type: PLACEHOLDER_NODE_TYPE,
     });

--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -15,6 +15,7 @@ export const PressContactsExtension = (): Extension => ({
         },
     },
     isRichBlock: isContactNode,
+    isVoid: isContactNode,
     normalizers: [normalizeRedundantPressContactAttributes],
     renderElement: ({ attributes, children, element }) => {
         if (isContactNode(element)) {
@@ -28,5 +29,4 @@ export const PressContactsExtension = (): Extension => ({
         return undefined;
     },
     rootTypes: [CONTACT_NODE_TYPE],
-    voidTypes: [CONTACT_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -16,7 +16,7 @@ export const PressContactsExtension = (): Extension => ({
     },
     isRichBlock: isContactNode,
     isVoid: isContactNode,
-    normalizers: [normalizeRedundantPressContactAttributes],
+    normalizeNode: normalizeRedundantPressContactAttributes,
     renderElement: ({ attributes, children, element }) => {
         if (isContactNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
+++ b/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
@@ -22,7 +22,7 @@ interface Parameters {
 export const RichFormattingExtension = ({ blocks }: Parameters): Extension => ({
     id: RICH_FORMATTING_EXTENSION_ID,
     deserialize: createDeserialize({ blocks }),
-    normalizers: [normalizeRedundantRichTextAttributes],
+    normalizeNode: normalizeRedundantRichTextAttributes,
     onKeyDown: createOnKeyDownHandler({ blocks }),
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (blocks && isRichTextElement(element)) {

--- a/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
+++ b/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
@@ -22,7 +22,6 @@ interface Parameters {
 export const RichFormattingExtension = ({ blocks }: Parameters): Extension => ({
     id: RICH_FORMATTING_EXTENSION_ID,
     deserialize: createDeserialize({ blocks }),
-    inlineTypes: [],
     normalizers: [normalizeRedundantRichTextAttributes],
     onKeyDown: createOnKeyDownHandler({ blocks }),
     renderElement: ({ attributes, children, element }: RenderElementProps) => {

--- a/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
@@ -17,6 +17,7 @@ export const StoryBookmarkExtension = (params: StoryBookmarkExtensionParameters)
         },
     },
     isRichBlock: isStoryBookmarkNode,
+    isVoid: isStoryBookmarkNode,
     normalizers: [normalizeRedundantStoryBookmarkAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isStoryBookmarkNode(element)) {
@@ -30,5 +31,4 @@ export const StoryBookmarkExtension = (params: StoryBookmarkExtensionParameters)
         return undefined;
     },
     rootTypes: [STORY_BOOKMARK_NODE_TYPE],
-    voidTypes: [STORY_BOOKMARK_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
@@ -18,7 +18,7 @@ export const StoryBookmarkExtension = (params: StoryBookmarkExtensionParameters)
     },
     isRichBlock: isStoryBookmarkNode,
     isVoid: isStoryBookmarkNode,
-    normalizers: [normalizeRedundantStoryBookmarkAttributes],
+    normalizeNode: normalizeRedundantStoryBookmarkAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isStoryBookmarkNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
@@ -18,7 +18,7 @@ export const StoryEmbedExtension = ({ render }: StoryEmbedExtensionParameters): 
     },
     isRichBlock: isStoryEmbedNode,
     isVoid: isStoryEmbedNode,
-    normalizers: [normalizeRedundantStoryEmbedAttributes],
+    normalizeNode: normalizeRedundantStoryEmbedAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isStoryEmbedNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
@@ -17,6 +17,7 @@ export const StoryEmbedExtension = ({ render }: StoryEmbedExtensionParameters): 
         },
     },
     isRichBlock: isStoryEmbedNode,
+    isVoid: isStoryEmbedNode,
     normalizers: [normalizeRedundantStoryEmbedAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isStoryEmbedNode(element)) {
@@ -32,5 +33,4 @@ export const StoryEmbedExtension = ({ render }: StoryEmbedExtensionParameters): 
         return undefined;
     },
     rootTypes: [STORY_EMBED_NODE_TYPE],
-    voidTypes: [STORY_EMBED_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
@@ -11,6 +11,7 @@ import { normalizeRedundantUserMentionAttributes, parseSerializedElement } from 
 export const UserMentionsExtension = (): Extension =>
     MentionsExtension({
         id: USER_MENTIONS_EXTENSION_ID,
+        type: MENTION_NODE_TYPE,
         normalizers: [normalizeRedundantUserMentionAttributes],
         parseSerializedElement,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
@@ -25,5 +26,4 @@ export const UserMentionsExtension = (): Extension =>
 
             return undefined;
         },
-        type: MENTION_NODE_TYPE,
     });

--- a/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
@@ -12,7 +12,7 @@ export const UserMentionsExtension = (): Extension =>
     MentionsExtension({
         id: USER_MENTIONS_EXTENSION_ID,
         type: MENTION_NODE_TYPE,
-        normalizers: [normalizeRedundantUserMentionAttributes],
+        normalizeNode: normalizeRedundantUserMentionAttributes,
         parseSerializedElement,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
             if (isMentionNode(element)) {

--- a/packages/slate-editor/src/extensions/video/VideoExtension.tsx
+++ b/packages/slate-editor/src/extensions/video/VideoExtension.tsx
@@ -17,7 +17,7 @@ export function VideoExtension(): Extension {
         },
         isRichBlock: isVideoNode,
         isVoid: isVideoNode,
-        normalizers: [normalizeRedundantVideoAttributes],
+        normalizeNode: normalizeRedundantVideoAttributes,
         renderElement: ({ attributes, children, element }) => {
             if (isVideoNode(element)) {
                 return (

--- a/packages/slate-editor/src/extensions/video/VideoExtension.tsx
+++ b/packages/slate-editor/src/extensions/video/VideoExtension.tsx
@@ -16,6 +16,7 @@ export function VideoExtension(): Extension {
             },
         },
         isRichBlock: isVideoNode,
+        isVoid: isVideoNode,
         normalizers: [normalizeRedundantVideoAttributes],
         renderElement: ({ attributes, children, element }) => {
             if (isVideoNode(element)) {
@@ -29,6 +30,5 @@ export function VideoExtension(): Extension {
             return undefined;
         },
         rootTypes: [VIDEO_NODE_TYPE],
-        voidTypes: [VIDEO_NODE_TYPE],
     };
 }

--- a/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
@@ -22,6 +22,7 @@ export const WebBookmarkExtension = ({
         },
     },
     isRichBlock: isBookmarkNode,
+    isVoid: isBookmarkNode,
     normalizers: [normalizeRedundantWebBookmarkAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isBookmarkNode(element)) {
@@ -41,5 +42,4 @@ export const WebBookmarkExtension = ({
         return undefined;
     },
     rootTypes: [BOOKMARK_NODE_TYPE],
-    voidTypes: [BOOKMARK_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
@@ -23,7 +23,7 @@ export const WebBookmarkExtension = ({
     },
     isRichBlock: isBookmarkNode,
     isVoid: isBookmarkNode,
-    normalizers: [normalizeRedundantWebBookmarkAttributes],
+    normalizeNode: [normalizeRedundantWebBookmarkAttributes],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isBookmarkNode(element)) {
             return (


### PR DESCRIPTION
- Replace `inlineTypes` and `voidTypes` array (`string[]`) properties with more abstract `isInline` and `isVoid` checker functions.
  This is one more step toward not depending on the `type` property being always present on node objects.
- Rename `normalizers` to `normalizeNode` to match [Slate API](https://docs.slatejs.org/concepts/11-normalizing#adding-constraints) 