### PR TITLE
[MT-5004] Fix - Inter-blocks spacing

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
@@ -5,14 +5,9 @@
     position: relative;
 
     &.extendedHitArea {
-        $area-vertical-expansion: $spacing-3; // x2 if counted in both directions: up & down
-
-        margin-top: $editor-block-spacing-vertical - $area-vertical-expansion;
-        margin-bottom: $editor-block-spacing-vertical - $area-vertical-expansion;
-
-        > .frame > .content {
-            padding-top: $area-vertical-expansion;
-            padding-bottom: $area-vertical-expansion;
+        > .Frame > .Content {
+            padding-top: $spacing-3;
+            padding-bottom: $spacing-3;
         }
     }
 
@@ -20,7 +15,7 @@
         caret-color: transparent;
     }
 
-    &.void > .frame {
+    &.void > .Frame {
         /**
          * Selection in Slate 0.50+ does not work as expected if a void block is selectable.
          * It could lead to an error when Slate is resolving the node which crashes the editor.

--- a/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
+++ b/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
@@ -4,7 +4,7 @@
 .Caption {
     height: 0;
     margin: 0 auto;
-    padding: 12px 0 0;
+    padding: $spacing-2 0 0;
     color: #767676;
     font-style: italic;
     font-size: $font-size-small;

--- a/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
+++ b/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
@@ -1,12 +1,7 @@
 @import "styles/helpers";
 @import "styles/variables";
 
-.image {
-    display: block;
-    width: 100%;
-}
-
-.caption {
+.Caption {
     height: 0;
     margin: 0 auto;
     padding: 12px 0 0;
@@ -16,9 +11,20 @@
     word-break: break-word;
 
     // if caption is empty, we want to display it outside-of-the-flow to not take vertical space.
-    &.floating {
+    &.empty {
         position: absolute;
         width: 100%;
+    }
+
+    &.withPlaceholder {
+        &::before {
+            content: attr(data-placeholder);
+            position: absolute;
+            pointer-events: none;
+            left: 0;
+            right: 0;
+            opacity: 0.3;
+        }
     }
 
     &.visible {

--- a/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
+++ b/packages/slate-editor/src/extensions/image/components/ImageElement.module.scss
@@ -23,7 +23,7 @@
             pointer-events: none;
             left: 0;
             right: 0;
-            opacity: 0.3;
+            opacity: 0.5;
         }
     }
 

--- a/packages/slate-editor/src/extensions/image/components/ImageElement.tsx
+++ b/packages/slate-editor/src/extensions/image/components/ImageElement.tsx
@@ -50,6 +50,7 @@ export function ImageElement({
     const isSupportingCaptions = !isVoid;
     const isCaptionEmpty = EditorCommands.isNodeEmpty(editor, element, true);
     const isCaptionVisible = isSupportingCaptions && (isSelected || !isCaptionEmpty);
+    const isCaptionPlaceholderVisible = isSupportingCaptions && isCaptionEmpty && isSelected;
 
     const handleResize = useCallback(
         function (width: ImageNode['width']) {
@@ -146,13 +147,15 @@ export function ImageElement({
         >
             {isSupportingCaptions ? (
                 <div
-                    className={classNames(styles.caption, {
-                        [styles.floating]: isCaptionEmpty,
+                    className={classNames(styles.Caption, {
+                        [styles.empty]: isCaptionEmpty,
+                        [styles.withPlaceholder]: isCaptionPlaceholderVisible,
                         [styles.visible]: isCaptionVisible,
                         [styles.alignLeft]: align === Alignment.LEFT,
                         [styles.alignCenter]: align === Alignment.CENTER,
                         [styles.alignRight]: align === Alignment.RIGHT,
                     })}
+                    data-placeholder="Image caption"
                 >
                     {children}
                 </div>

--- a/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.module.scss
+++ b/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.module.scss
@@ -1,7 +1,6 @@
 @import "styles/variables";
 
 .ParagraphElement {
-    margin: $spacing-2 0;
     color: $editor-text-color;
     font-weight: 500;
     font-size: $editor-paragraph-font-size;

--- a/packages/slate-editor/src/extensions/rich-formatting/components/Headings/HeadingElement.module.scss
+++ b/packages/slate-editor/src/extensions/rich-formatting/components/Headings/HeadingElement.module.scss
@@ -5,15 +5,11 @@
     font-weight: bold;
 
     &.headingOne {
-        margin-top: $editor-block-spacing-vertical;
-        margin-bottom: $spacing-3;
         font-size: $editor-heading-one-font-size;
         line-height: $editor-heading-one-line-height;
     }
 
     &.headingTwo {
-        margin-top: $spacing-3;
-        margin-bottom: $spacing-3;
         font-size: $editor-heading-two-font-size;
         line-height: $editor-heading-two-line-height;
     }

--- a/packages/slate-editor/src/extensions/rich-formatting/components/Lists/ListElement.module.scss
+++ b/packages/slate-editor/src/extensions/rich-formatting/components/Lists/ListElement.module.scss
@@ -1,7 +1,6 @@
 @import "styles/variables";
 
 .ListElement {
-    margin: $spacing-2 0;
     padding: 0;
     padding-left: $spacing-4;
     color: $editor-text-color;

--- a/packages/slate-editor/src/modules/editor/Editor.module.scss
+++ b/packages/slate-editor/src/modules/editor/Editor.module.scss
@@ -11,8 +11,6 @@
     }
 
     > [data-slate-block] {
-        margin: $editor-block-spacing-vertical 0;
-
         &:first-child {
             margin-top: 0;
         }
@@ -20,5 +18,23 @@
         &:last-child {
             margin-bottom: 0;
         }
+    }
+
+    > [data-slate-block="rich"] {
+        margin: $spacing-6 0;
+    }
+
+    > [data-slate-block="regular"] {
+        margin: $spacing-2 0;
+    }
+
+    > [data-slate-type="heading-one"],
+    > [data-slate-type="heading-two"] {
+        margin-top: $spacing-4;
+    }
+
+    > [data-slate-type="divider"] {
+        /** Compensating .extendedHitArea visual expansion */
+        margin: $spacing-3 0;
     }
 }

--- a/packages/slate-editor/src/styles/variables.scss
+++ b/packages/slate-editor/src/styles/variables.scss
@@ -55,7 +55,7 @@ $toolbar-dark-theme-hover-bg: rgba(#fff, 0.12);
 $toolbar-dark-theme-focus-outline: $indigo-200;
 
 $editor-block-focus-color: $yellow-300;
-$editor-block-spacing-vertical: 44px;
+$editor-block-spacing-vertical: $spacing-6;
 $editor-heading-one-font-size: 28px;
 $editor-heading-one-line-height: 34px;
 $editor-heading-two-font-size: 22px;


### PR DESCRIPTION
- Rework spacing between blocks
  Elements themselves are no longer responsible for outer spacing.
  It's now set up centralized in the `Editable` element stylesheet (according to the Editor design specs)

- Improve image caption UX: it now has caption prompt visible, when the image block is selected