### PR TITLE
[MT-5017] Fix - Use image original src as a return value from the `useImage` hook

### DIFF
--- a/packages/slate-editor/src/components/LoadingPlaceholder/ImageWithLoadingPlaceholder.tsx
+++ b/packages/slate-editor/src/components/LoadingPlaceholder/ImageWithLoadingPlaceholder.tsx
@@ -48,7 +48,7 @@ export const ImageWithLoadingPlaceholder = forwardRef<HTMLDivElement, Props>((pr
     } = props;
     const aspectRatio = imageHeight ? imageWidth / imageHeight : undefined;
     const callbacks = useLatest({ onStartLoading, onLoad });
-    const { loading, progress, url } = useImage(src);
+    const { loading, progress, loaded: isLoaded } = useImage(src);
 
     useEffect(
         function () {
@@ -59,12 +59,12 @@ export const ImageWithLoadingPlaceholder = forwardRef<HTMLDivElement, Props>((pr
                 );
                 return () => clearTimeout(timeout);
             }
-            if (url !== undefined) {
+            if (isLoaded) {
                 callbacks.current.onLoad?.();
             }
             return;
         },
-        [loading, url],
+        [loading, isLoaded],
     );
 
     return (
@@ -73,12 +73,12 @@ export const ImageWithLoadingPlaceholder = forwardRef<HTMLDivElement, Props>((pr
             className={classNames(styles.ImageWithLoadingPlaceholder, attributes.className)}
             style={{
                 aspectRatio: aspectRatio ? String(aspectRatio) : undefined,
-                backgroundImage: url ? `url("${url}")` : undefined,
+                backgroundImage: isLoaded ? `url("${src}")` : undefined,
                 ...attributes.style,
             }}
             ref={ref}
         >
-            {url && <img className={styles.Image} src={url} alt={alt} />}
+            {isLoaded && <img className={styles.Image} src={src} alt={alt} />}
 
             {loading && (
                 <LoadingPlaceholder

--- a/packages/slate-editor/src/lib/createImageProgressPromise/index.ts
+++ b/packages/slate-editor/src/lib/createImageProgressPromise/index.ts
@@ -1,1 +1,0 @@
-export { createImageProgressPromise } from './createImageProgressPromise';

--- a/packages/slate-editor/src/lib/fetchImageWithProgress/fetchImageWithReadableStream.ts
+++ b/packages/slate-editor/src/lib/fetchImageWithProgress/fetchImageWithReadableStream.ts
@@ -49,7 +49,7 @@ function createReadableStream(response: Response, onProgress: (progress: number)
 /**
  * Based on https://github.com/AnthumChris/fetch-progress-indicators/blob/3fd300c/fetch-basic/supported-browser.js
  */
-export function createFetchImageProgressPromise(src: string): ProgressPromise<string, number> {
+export function fetchImageWithReadableStream(src: string): ProgressPromise<string, number> {
     return new ProgressPromise((resolve, reject, progress) => {
         fetch(src)
             .then((response) => {

--- a/packages/slate-editor/src/lib/fetchImageWithProgress/fetchImageWithXmlHttpRequest.ts
+++ b/packages/slate-editor/src/lib/fetchImageWithProgress/fetchImageWithXmlHttpRequest.ts
@@ -3,7 +3,7 @@ import { ProgressPromise } from '@prezly/progress-promise';
 /**
  * Based on https://stackoverflow.com/a/22593907
  */
-export function createXmlHttpImageProgressPromise(src: string): ProgressPromise<string, number> {
+export function fetchImageWithXmlHttpRequest(src: string): ProgressPromise<string, number> {
     return new ProgressPromise((resolve, reject, progress) => {
         const xhr = new XMLHttpRequest();
 

--- a/packages/slate-editor/src/lib/fetchImageWithProgress/index.ts
+++ b/packages/slate-editor/src/lib/fetchImageWithProgress/index.ts
@@ -1,0 +1,1 @@
+export { fetchImageWithProgress } from './fetchImageWithProgress';

--- a/packages/slate-editor/src/lib/hooks/useImage.ts
+++ b/packages/slate-editor/src/lib/hooks/useImage.ts
@@ -4,15 +4,18 @@ import { fetchImageWithProgress } from '../fetchImageWithProgress';
 
 import { useAsyncProgress } from './useAsyncProgress';
 
+type OriginalURIOrBlobDataURI = string;
+
 interface State {
     error?: Error;
     loading: boolean;
     progress: number;
     loaded: boolean;
+    url: OriginalURIOrBlobDataURI | undefined;
 }
 
 export function useImage(src: string): State {
     const fetchImage = useCallback(() => fetchImageWithProgress(src), [src]);
     const { error, loading, progress, value } = useAsyncProgress(fetchImage);
-    return { error, loading, progress, loaded: Boolean(value) };
+    return { error, loading, progress, loaded: Boolean(value), url: value };
 }

--- a/packages/slate-editor/src/lib/hooks/useImage.ts
+++ b/packages/slate-editor/src/lib/hooks/useImage.ts
@@ -12,7 +12,7 @@ interface State {
 }
 
 export function useImage(src: string): State {
-    const getPromise = useCallback(() => createImageProgressPromise(src), [src]);
+    const getPromise = useCallback(() => createImageProgressPromise(src).then(() => src), [src]);
     const { error, loading, progress, value } = useAsyncProgress(getPromise);
     return { error, loading, progress, url: value };
 }

--- a/packages/slate-editor/src/lib/hooks/useImage.ts
+++ b/packages/slate-editor/src/lib/hooks/useImage.ts
@@ -8,11 +8,11 @@ interface State {
     error?: Error;
     loading: boolean;
     progress: number;
-    url?: string;
+    loaded: boolean;
 }
 
 export function useImage(src: string): State {
-    const getPromise = useCallback(() => fetchImageWithProgress(src).then(() => src), [src]);
+    const getPromise = useCallback(() => fetchImageWithProgress(src), [src]);
     const { error, loading, progress, value } = useAsyncProgress(getPromise);
-    return { error, loading, progress, url: value };
+    return { error, loading, progress, loaded: Boolean(value) };
 }

--- a/packages/slate-editor/src/lib/hooks/useImage.ts
+++ b/packages/slate-editor/src/lib/hooks/useImage.ts
@@ -12,7 +12,7 @@ interface State {
 }
 
 export function useImage(src: string): State {
-    const getPromise = useCallback(() => fetchImageWithProgress(src), [src]);
-    const { error, loading, progress, value } = useAsyncProgress(getPromise);
+    const fetchImage = useCallback(() => fetchImageWithProgress(src), [src]);
+    const { error, loading, progress, value } = useAsyncProgress(fetchImage);
     return { error, loading, progress, loaded: Boolean(value) };
 }

--- a/packages/slate-editor/src/lib/hooks/useImage.ts
+++ b/packages/slate-editor/src/lib/hooks/useImage.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { createImageProgressPromise } from '../createImageProgressPromise';
+import { fetchImageWithProgress } from '../fetchImageWithProgress';
 
 import { useAsyncProgress } from './useAsyncProgress';
 
@@ -12,7 +12,7 @@ interface State {
 }
 
 export function useImage(src: string): State {
-    const getPromise = useCallback(() => createImageProgressPromise(src).then(() => src), [src]);
+    const getPromise = useCallback(() => fetchImageWithProgress(src).then(() => src), [src]);
     const { error, loading, progress, value } = useAsyncProgress(getPromise);
     return { error, loading, progress, url: value };
 }

--- a/packages/slate-editor/src/lib/index.ts
+++ b/packages/slate-editor/src/lib/index.ts
@@ -1,6 +1,6 @@
 export * from './hooks';
 export { convertToHtml } from './convertToHtml';
-export { createImageProgressPromise } from './createImageProgressPromise';
+export { fetchImageWithProgress } from './fetchImageWithProgress';
 export { dataUriToFile } from './dataUriToFile';
 export { ensureChildInView } from './ensureChildInView';
 export { ensureElementInView } from './ensureElementInView';


### PR DESCRIPTION
See comments in MT-5017 for details.

- Change `useImage` return object to provide `loaded` flag, instead of the blob URL
- Rename `useImage` internal functions for clarity