### PR TITLE
Reorganize extension ID constants

### DIFF
--- a/packages/slate-editor/src/extensions/autoformat/AutoformatExtension.ts
+++ b/packages/slate-editor/src/extensions/autoformat/AutoformatExtension.ts
@@ -1,12 +1,13 @@
 import type { Extension } from '@prezly/slate-commons';
 
-import { AUTOFORMAT_EXTENSION_ID } from './constants';
 import type { AutoformatParameters } from './types';
 import { withAutoformat } from './withAutoformat';
 
+export const EXTENSION_ID = 'AutoformatExtension';
+
 export function AutoformatExtension(params: AutoformatParameters): Extension {
     return {
-        id: AUTOFORMAT_EXTENSION_ID,
+        id: EXTENSION_ID,
         withOverrides: (editor) => withAutoformat(editor, params.rules),
     };
 }

--- a/packages/slate-editor/src/extensions/autoformat/constants.ts
+++ b/packages/slate-editor/src/extensions/autoformat/constants.ts
@@ -1,1 +1,0 @@
-export const AUTOFORMAT_EXTENSION_ID = 'AutoformatExtension';

--- a/packages/slate-editor/src/extensions/autoformat/index.ts
+++ b/packages/slate-editor/src/extensions/autoformat/index.ts
@@ -1,2 +1,2 @@
-export * from './AutoformatExtension';
+export { AutoformatExtension, EXTENSION_ID } from './AutoformatExtension';
 export type { AutoformatParameters, AutoformatRule } from './types';

--- a/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
+++ b/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
@@ -4,14 +4,15 @@ import { COVERAGE_NODE_TYPE, isCoverageNode } from '@prezly/slate-types';
 import React from 'react';
 
 import { CoverageElement } from './components';
-import { COVERAGE_EXTENSION_ID } from './constants';
 import { normalizeRedundantCoverageAttributes, parseSerializedElement } from './lib';
 import type { CoverageExtensionConfiguration } from './types';
+
+export const EXTENSION_ID = 'CoverageExtension';
 
 export interface Parameters extends CoverageExtensionConfiguration {}
 
 export const CoverageExtension = ({ dateFormat, fetchCoverage }: Parameters): Extension => ({
-    id: COVERAGE_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [COVERAGE_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/coverage/constants.ts
+++ b/packages/slate-editor/src/extensions/coverage/constants.ts
@@ -1,1 +1,0 @@
-export const COVERAGE_EXTENSION_ID = 'CoverageExtension';

--- a/packages/slate-editor/src/extensions/coverage/index.ts
+++ b/packages/slate-editor/src/extensions/coverage/index.ts
@@ -1,5 +1,5 @@
+export { CoverageExtension, EXTENSION_ID } from './CoverageExtension';
+
 export { FloatingCoverageMenu } from './components';
-export { COVERAGE_EXTENSION_ID } from './constants';
-export { CoverageExtension } from './CoverageExtension';
 export { createCoverage, getCurrentCoverageNode, useFloatingCoverageMenu } from './lib';
 export type { CoverageExtensionConfiguration, SearchProps } from './types';

--- a/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
+++ b/packages/slate-editor/src/extensions/divider/DividerExtension.tsx
@@ -5,10 +5,12 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { DividerElement } from './components';
-import { DIVIDER_EXTENSION_ID } from './constants';
 import { createDivider, normalizeRedundantDividerAttributes, parseSerializedElement } from './lib';
 
+export const EXTENSION_ID = 'DividerExtension';
+
 export const DividerExtension = (): Extension => ({
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [DIVIDER_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
@@ -21,7 +23,6 @@ export const DividerExtension = (): Extension => ({
             },
         },
     },
-    id: DIVIDER_EXTENSION_ID,
     isVoid: isDividerNode,
     normalizeNode: normalizeRedundantDividerAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {

--- a/packages/slate-editor/src/extensions/divider/constants.ts
+++ b/packages/slate-editor/src/extensions/divider/constants.ts
@@ -1,1 +1,0 @@
-export const DIVIDER_EXTENSION_ID = 'DividerExtension';

--- a/packages/slate-editor/src/extensions/divider/index.ts
+++ b/packages/slate-editor/src/extensions/divider/index.ts
@@ -1,3 +1,3 @@
-export { DIVIDER_EXTENSION_ID } from './constants';
-export { DividerExtension } from './DividerExtension';
+export { DividerExtension, EXTENSION_ID } from './DividerExtension';
+
 export { createDivider } from './lib';

--- a/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
@@ -1,11 +1,10 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
-import { isEmbedNode } from '@prezly/slate-types';
+import { EMBED_NODE_TYPE, isEmbedNode } from '@prezly/slate-types';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { EmbedElement } from './components';
-import { EMBED_EXTENSION_ID, EMBED_TYPE } from './constants';
 import { normalizeRedundantEmbedAttributes, parseSerializedElement } from './lib';
 import type { EmbedExtensionConfiguration } from './types';
 
@@ -13,11 +12,13 @@ interface Parameters extends EmbedExtensionConfiguration {
     availableWidth: number;
 }
 
+export const EXTENSION_ID = 'EmbedExtension';
+
 export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters): Extension => ({
-    id: EMBED_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
-            [EMBED_TYPE]: createDeserializeElement(parseSerializedElement),
+            [EMBED_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         },
     },
     isRichBlock: isEmbedNode,
@@ -41,5 +42,5 @@ export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters)
 
         return undefined;
     },
-    rootTypes: [EMBED_TYPE],
+    rootTypes: [EMBED_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/embed/constants.ts
+++ b/packages/slate-editor/src/extensions/embed/constants.ts
@@ -1,3 +1,0 @@
-export const EMBED_EXTENSION_ID = 'EmbedExtension';
-
-export const EMBED_TYPE = 'embed';

--- a/packages/slate-editor/src/extensions/embed/index.ts
+++ b/packages/slate-editor/src/extensions/embed/index.ts
@@ -1,5 +1,5 @@
+export { EmbedExtension, EXTENSION_ID } from './EmbedExtension';
+
 export { FloatingEmbedInput } from './components';
-export { EMBED_EXTENSION_ID } from './constants';
-export { EmbedExtension } from './EmbedExtension';
 export { createEmbed, useFloatingEmbedInput } from './lib';
 export type { EmbedExtensionConfiguration } from './types';

--- a/packages/slate-editor/src/extensions/embed/lib/createEmbed.ts
+++ b/packages/slate-editor/src/extensions/embed/lib/createEmbed.ts
@@ -1,12 +1,11 @@
 import type { OEmbedInfo } from '@prezly/sdk';
 import type { EmbedNode } from '@prezly/slate-types';
+import { EMBED_NODE_TYPE } from '@prezly/slate-types';
 import { v4 as uuidV4 } from 'uuid';
-
-import { EMBED_TYPE } from '../constants';
 
 export function createEmbed(oembed: OEmbedInfo, url: string): EmbedNode {
     return {
-        type: EMBED_TYPE,
+        type: EMBED_NODE_TYPE,
         children: [{ text: '' }],
         oembed,
         url,

--- a/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
+++ b/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
@@ -10,7 +10,6 @@ import { EditorBlock } from '#components';
 import { noop } from '#lodash';
 
 import { FileAttachment, FileAttachmentMenu } from './components';
-import { FILE_ATTACHMENT_EXTENSION_ID } from './constants';
 import { normalizeRedundantFileAttachmentAttributes, parseSerializedElement } from './lib';
 
 export interface Parameters {
@@ -18,11 +17,13 @@ export interface Parameters {
     onRemove?: (editor: Editor, element: AttachmentNode) => void;
 }
 
+export const EXTENSION_ID = 'FileAttachmentExtension';
+
 export const FileAttachmentExtension = ({
     onEdit = noop,
     onRemove = noop,
 }: Parameters): Extension => ({
-    id: FILE_ATTACHMENT_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [ATTACHMENT_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/file-attachment/constants.ts
+++ b/packages/slate-editor/src/extensions/file-attachment/constants.ts
@@ -1,1 +1,0 @@
-export const FILE_ATTACHMENT_EXTENSION_ID = 'FileAttachmentExtension';

--- a/packages/slate-editor/src/extensions/file-attachment/index.ts
+++ b/packages/slate-editor/src/extensions/file-attachment/index.ts
@@ -1,4 +1,4 @@
-export { FILE_ATTACHMENT_EXTENSION_ID } from './constants';
-export { FileAttachmentExtension } from './FileAttachmentExtension';
+export { FileAttachmentExtension, EXTENSION_ID } from './FileAttachmentExtension';
+
 export { createFileAttachment, getCurrentFileAttachmentElement } from './lib';
 export { removeFileAttachment } from './transforms';

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
@@ -4,17 +4,17 @@ import type { KeyboardEvent } from 'react';
 
 import { isMenuHotkey, MENU_TRIGGER_CHARACTERS, shouldShowMenuButton } from './lib';
 
-const FLOATING_ADD_MENU_EXTENSION_ID = 'FloatingAddMenuExtension';
-
 function isTriggerInput(event: KeyboardEvent) {
     return MENU_TRIGGER_CHARACTERS.some((tiggerKey) =>
         isHotkey(tiggerKey, { byKey: true }, event.nativeEvent),
     );
 }
 
+export const EXTENSION_ID = 'FloatingAddMenuExtension';
+
 export function FloatingAddMenuExtension(toggleMenu: (open?: boolean) => void): Extension {
     return {
-        id: FLOATING_ADD_MENU_EXTENSION_ID,
+        id: EXTENSION_ID,
         onKeyDown(event, editor) {
             if (isMenuHotkey(event) && shouldShowMenuButton(editor)) {
                 event.preventDefault();

--- a/packages/slate-editor/src/extensions/floating-add-menu/index.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/index.ts
@@ -1,3 +1,4 @@
+export { FloatingAddMenuExtension, EXTENSION_ID } from './FloatingAddMenuExtension';
+
 export { FloatingAddMenu } from './FloatingAddMenu';
-export { FloatingAddMenuExtension } from './FloatingAddMenuExtension';
 export type { Settings, Option } from './types';

--- a/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
+++ b/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
@@ -6,7 +6,6 @@ import type { Editor } from 'slate';
 import type { RenderElementProps } from 'slate-react';
 
 import { GalleryElement } from './components';
-import { GALLERIES_EXTENSION_ID } from './constants';
 import {
     normalizeInvalidGallery,
     normalizeRedundantGalleryAttributes,
@@ -18,8 +17,10 @@ interface Parameters {
     onEdit: (editor: Editor) => void;
 }
 
+export const EXTENSION_ID = 'GalleriesExtension';
+
 export const GalleriesExtension = ({ availableWidth, onEdit }: Parameters): Extension => ({
-    id: GALLERIES_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [GALLERY_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/galleries/constants.ts
+++ b/packages/slate-editor/src/extensions/galleries/constants.ts
@@ -1,1 +1,0 @@
-export const GALLERIES_EXTENSION_ID = 'GalleriesExtension';

--- a/packages/slate-editor/src/extensions/galleries/index.ts
+++ b/packages/slate-editor/src/extensions/galleries/index.ts
@@ -1,5 +1,5 @@
-export { GALLERIES_EXTENSION_ID } from './constants';
-export { GalleriesExtension } from './GalleriesExtension';
+export { GalleriesExtension, EXTENSION_ID } from './GalleriesExtension';
+
 export { createGallery, getCurrentGalleryNodeEntry } from './lib';
 export { removeGallery } from './transforms';
 export type { GalleriesExtensionConfiguration } from './types';

--- a/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
+++ b/packages/slate-editor/src/extensions/html/HtmlExtension.tsx
@@ -5,16 +5,17 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { HtmlElement } from './components';
-import { HTML_EXTENSION_ID } from './constants';
 import { normalizeRedundantHtmlBlockAttributes, parseSerializedElement } from './lib';
 
+export const EXTENSION_ID = 'HtmlExtension';
+
 export const HtmlExtension = (): Extension => ({
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [HTML_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         },
     },
-    id: HTML_EXTENSION_ID,
     isVoid: isHtmlNode,
     normalizeNode: normalizeRedundantHtmlBlockAttributes,
     renderElement: ({ attributes, children, element }: RenderElementProps) => {

--- a/packages/slate-editor/src/extensions/html/constants.ts
+++ b/packages/slate-editor/src/extensions/html/constants.ts
@@ -1,1 +1,0 @@
-export const HTML_EXTENSION_ID = 'HtmlExtension';

--- a/packages/slate-editor/src/extensions/html/index.ts
+++ b/packages/slate-editor/src/extensions/html/index.ts
@@ -1,3 +1,3 @@
-export { HTML_EXTENSION_ID } from './constants';
-export { HtmlExtension } from './HtmlExtension';
+export { HtmlExtension, EXTENSION_ID } from './HtmlExtension';
+
 export { createHtmlBlock } from './lib';

--- a/packages/slate-editor/src/extensions/image/ImageExtension.tsx
+++ b/packages/slate-editor/src/extensions/image/ImageExtension.tsx
@@ -15,7 +15,7 @@ import { noop } from '#lodash';
 import { createParagraph } from '#extensions/paragraphs';
 
 import { ImageElement } from './components';
-import { IMAGE_CANDIDATE_TYPE, IMAGE_EXTENSION_ID } from './constants';
+import { IMAGE_CANDIDATE_NODE_TYPE } from './constants';
 import {
     createImageCandidate,
     getAncestorAnchor,
@@ -37,6 +37,8 @@ interface Parameters extends ImageExtensionConfiguration {
     onReplace?: (editor: Editor, element: ImageNode) => void;
 }
 
+export const EXTENSION_ID = 'ImageExtension';
+
 export const ImageExtension = ({
     captions,
     onCrop = noop,
@@ -47,7 +49,7 @@ export const ImageExtension = ({
     withLayoutOptions = false,
     withNewTabOption = true,
 }: Parameters): Extension => ({
-    id: IMAGE_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [IMAGE_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
@@ -155,5 +157,5 @@ export const ImageExtension = ({
 
         return undefined;
     },
-    rootTypes: [IMAGE_CANDIDATE_TYPE, IMAGE_NODE_TYPE],
+    rootTypes: [IMAGE_CANDIDATE_NODE_TYPE, IMAGE_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/image/constants.ts
+++ b/packages/slate-editor/src/extensions/image/constants.ts
@@ -1,3 +1,1 @@
-export const IMAGE_EXTENSION_ID = 'ImageExtension';
-
-export const IMAGE_CANDIDATE_TYPE = 'image-block-candidate';
+export const IMAGE_CANDIDATE_NODE_TYPE = 'image-block-candidate';

--- a/packages/slate-editor/src/extensions/image/index.ts
+++ b/packages/slate-editor/src/extensions/image/index.ts
@@ -1,5 +1,5 @@
-export { IMAGE_EXTENSION_ID } from './constants';
-export { ImageExtension } from './ImageExtension';
+export { ImageExtension, EXTENSION_ID } from './ImageExtension';
+
 export { createImage, getCurrentImageNodeEntry, isImageCandidateElement } from './lib';
 export { withoutImageCandidates } from './serialization';
 export { removeImage } from './transforms';

--- a/packages/slate-editor/src/extensions/image/jsx.ts
+++ b/packages/slate-editor/src/extensions/image/jsx.ts
@@ -7,9 +7,9 @@ import type { ReactNode } from 'react';
 import { createHyperscript, createText } from 'slate-hyperscript';
 
 import type { LoaderNode } from '#extensions/loader';
-import { LOADER_TYPE } from '#extensions/loader';
+import { LOADER_NODE_TYPE } from '#extensions/loader';
 
-import { IMAGE_CANDIDATE_TYPE } from './constants';
+import { IMAGE_CANDIDATE_NODE_TYPE } from './constants';
 
 declare global {
     namespace JSX {
@@ -42,8 +42,8 @@ declare global {
 export const jsx = createHyperscript({
     elements: {
         'h-image': { type: IMAGE_NODE_TYPE },
-        'h-image-candidate': { type: IMAGE_CANDIDATE_TYPE },
-        'h-loader': { type: LOADER_TYPE },
+        'h-image-candidate': { type: IMAGE_CANDIDATE_NODE_TYPE },
+        'h-loader': { type: LOADER_NODE_TYPE },
         'h-p': { type: PARAGRAPH_NODE_TYPE },
     },
     creators: {

--- a/packages/slate-editor/src/extensions/image/lib/createImageCandidate.ts
+++ b/packages/slate-editor/src/extensions/image/lib/createImageCandidate.ts
@@ -1,4 +1,4 @@
-import { IMAGE_CANDIDATE_TYPE } from '../constants';
+import { IMAGE_CANDIDATE_NODE_TYPE } from '../constants';
 import type { ImageCandidateNode } from '../types';
 
 export function createImageCandidate(src: string, href = ''): ImageCandidateNode {
@@ -6,6 +6,6 @@ export function createImageCandidate(src: string, href = ''): ImageCandidateNode
         children: [{ text: '' }],
         href,
         src,
-        type: IMAGE_CANDIDATE_TYPE,
+        type: IMAGE_CANDIDATE_NODE_TYPE,
     };
 }

--- a/packages/slate-editor/src/extensions/image/lib/isImageCandidateElement.ts
+++ b/packages/slate-editor/src/extensions/image/lib/isImageCandidateElement.ts
@@ -1,8 +1,8 @@
 import { isElementNode } from '@prezly/slate-types';
 
-import { IMAGE_CANDIDATE_TYPE } from '../constants';
+import { IMAGE_CANDIDATE_NODE_TYPE } from '../constants';
 import type { ImageCandidateNode } from '../types';
 
 export function isImageCandidateElement(node: unknown): node is ImageCandidateNode {
-    return isElementNode<ImageCandidateNode>(node, IMAGE_CANDIDATE_TYPE);
+    return isElementNode<ImageCandidateNode>(node, IMAGE_CANDIDATE_NODE_TYPE);
 }

--- a/packages/slate-editor/src/extensions/image/types.ts
+++ b/packages/slate-editor/src/extensions/image/types.ts
@@ -2,7 +2,7 @@ import type { NewsroomRef } from '@prezly/sdk';
 import type { ElementNode } from '@prezly/slate-types';
 import type { Text } from 'slate';
 
-import type { IMAGE_CANDIDATE_TYPE } from './constants';
+import type { IMAGE_CANDIDATE_NODE_TYPE } from './constants';
 
 /**
  * Image Candidate Element is just an ephemeral node which exists inbetween deserialization
@@ -11,7 +11,7 @@ import type { IMAGE_CANDIDATE_TYPE } from './constants';
  * and normalization (which is responsible for converting these nodes into actual images).
  */
 export interface ImageCandidateNode extends ElementNode {
-    type: typeof IMAGE_CANDIDATE_TYPE;
+    type: typeof IMAGE_CANDIDATE_NODE_TYPE;
     children: Text[];
     /** empty string if no URL */
     href: string;

--- a/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
+++ b/packages/slate-editor/src/extensions/inline-links/InlineLinksExtension.tsx
@@ -14,8 +14,10 @@ import {
     parseSerializedLinkElement,
 } from './lib';
 
+export const EXTENSION_ID = 'InlineLinksExtension';
+
 export const InlineLinksExtension = (): Extension => ({
-    id: 'InlineLinksExtension',
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [LINK_NODE_TYPE]: createDeserializeElement(parseSerializedLinkElement),

--- a/packages/slate-editor/src/extensions/inline-links/index.ts
+++ b/packages/slate-editor/src/extensions/inline-links/index.ts
@@ -1,2 +1,3 @@
-export { InlineLinksExtension } from './InlineLinksExtension';
+export { InlineLinksExtension, EXTENSION_ID } from './InlineLinksExtension';
+
 export { unwrapLink, wrapInLink } from './lib';

--- a/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
+++ b/packages/slate-editor/src/extensions/loader/LoaderExtension.tsx
@@ -3,15 +3,17 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { LoaderElement } from './components';
-import { LOADER_EXTENSION_ID, LOADER_TYPE } from './constants';
+import { LOADER_NODE_TYPE } from './constants';
 import { isLoaderElement, normalizeRedundantLoaderAttributes } from './lib';
 import type { LoaderParameters } from './types';
+
+export const EXTENSION_ID = 'LoaderExtension';
 
 export const LoaderExtension = ({
     onOperationEnd,
     onOperationStart,
 }: LoaderParameters): Extension => ({
-    id: LOADER_EXTENSION_ID,
+    id: EXTENSION_ID,
     isRichBlock: isLoaderElement,
     isVoid: isLoaderElement,
     normalizeNode: normalizeRedundantLoaderAttributes,
@@ -31,5 +33,5 @@ export const LoaderExtension = ({
 
         return undefined;
     },
-    rootTypes: [LOADER_TYPE],
+    rootTypes: [LOADER_NODE_TYPE],
 });

--- a/packages/slate-editor/src/extensions/loader/constants.ts
+++ b/packages/slate-editor/src/extensions/loader/constants.ts
@@ -1,3 +1,1 @@
-export const LOADER_EXTENSION_ID = 'LoaderExtension';
-
-export const LOADER_TYPE = 'loader';
+export const LOADER_NODE_TYPE = 'loader';

--- a/packages/slate-editor/src/extensions/loader/index.ts
+++ b/packages/slate-editor/src/extensions/loader/index.ts
@@ -1,6 +1,7 @@
-export { LOADER_EXTENSION_ID, LOADER_TYPE } from './constants';
+export { LoaderExtension, EXTENSION_ID } from './LoaderExtension';
+
+export { LOADER_NODE_TYPE } from './constants';
 export { createLoader, findLoaderPath, isLoaderElement, loaderPromiseManager } from './lib';
-export { LoaderExtension } from './LoaderExtension';
 export { withoutLoaders } from './serialization';
 export { removeLoader, replaceLoader } from './transforms';
 export type { LoaderNode } from './types';

--- a/packages/slate-editor/src/extensions/loader/jsx.ts
+++ b/packages/slate-editor/src/extensions/loader/jsx.ts
@@ -4,7 +4,7 @@ import { PARAGRAPH_NODE_TYPE } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 import { createHyperscript, createText } from 'slate-hyperscript';
 
-import { LOADER_TYPE } from './constants';
+import { LOADER_NODE_TYPE } from './constants';
 import type { LoaderNode } from './types';
 
 declare global {
@@ -25,7 +25,7 @@ declare global {
 
 export const jsx = createHyperscript({
     elements: {
-        'h-loader': { type: LOADER_TYPE },
+        'h-loader': { type: LOADER_NODE_TYPE },
         'h-p': { type: PARAGRAPH_NODE_TYPE },
     },
     creators: {

--- a/packages/slate-editor/src/extensions/loader/lib/createLoader.ts
+++ b/packages/slate-editor/src/extensions/loader/lib/createLoader.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidV4 } from 'uuid';
 
-import { LOADER_TYPE } from '../constants';
+import { LOADER_NODE_TYPE } from '../constants';
 import type { LoaderContentType, LoaderNode } from '../types';
 
 interface Parameters {
@@ -15,6 +15,6 @@ export function createLoader({ contentType, id = uuidV4(), message }: Parameters
         contentType,
         id,
         message,
-        type: LOADER_TYPE,
+        type: LOADER_NODE_TYPE,
     };
 }

--- a/packages/slate-editor/src/extensions/loader/lib/isLoaderElement.ts
+++ b/packages/slate-editor/src/extensions/loader/lib/isLoaderElement.ts
@@ -1,9 +1,9 @@
 import { isElementNode } from '@prezly/slate-types';
 import type { Node } from 'slate';
 
-import { LOADER_TYPE } from '../constants';
+import { LOADER_NODE_TYPE } from '../constants';
 import type { LoaderNode } from '../types';
 
 export function isLoaderElement(node: Node): node is LoaderNode {
-    return isElementNode<LoaderNode>(node, LOADER_TYPE);
+    return isElementNode<LoaderNode>(node, LOADER_NODE_TYPE);
 }

--- a/packages/slate-editor/src/extensions/loader/types.ts
+++ b/packages/slate-editor/src/extensions/loader/types.ts
@@ -1,6 +1,6 @@
 import type { ElementNode } from '@prezly/slate-types';
 
-import type { LOADER_TYPE } from './constants';
+import type { LOADER_NODE_TYPE } from './constants';
 
 export enum LoaderContentType {
     ATTACHMENT = 'attachment',
@@ -14,7 +14,7 @@ export enum LoaderContentType {
 }
 
 export interface LoaderNode extends ElementNode {
-    type: typeof LOADER_TYPE;
+    type: typeof LOADER_NODE_TYPE;
     contentType: LoaderContentType;
     id: string;
     message: string;

--- a/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { ParagraphElement } from './components';
-import { PARAGRAPHS_EXTENSION_ID } from './constants';
 import { deserialize } from './deserialize';
 import {
     normalizeOrphanText,
@@ -12,9 +11,11 @@ import {
     normalizeUnknownElement,
 } from './lib';
 
+export const EXTENSION_ID = 'ParagraphsExtension';
+
 export const ParagraphsExtension = (): Extension => ({
+    id: EXTENSION_ID,
     deserialize,
-    id: PARAGRAPHS_EXTENSION_ID,
     normalizeNode: [
         normalizeOrphanText,
         normalizeRedundantParagraphAttributes,

--- a/packages/slate-editor/src/extensions/paragraphs/constants.ts
+++ b/packages/slate-editor/src/extensions/paragraphs/constants.ts
@@ -1,1 +1,0 @@
-export const PARAGRAPHS_EXTENSION_ID = 'ParagraphsExtension';

--- a/packages/slate-editor/src/extensions/paragraphs/index.ts
+++ b/packages/slate-editor/src/extensions/paragraphs/index.ts
@@ -1,4 +1,4 @@
+export { ParagraphsExtension, EXTENSION_ID } from './ParagraphsExtension';
+
 export { ParagraphElement } from './components';
-export { PARAGRAPHS_EXTENSION_ID } from './constants';
 export { createParagraph } from './lib';
-export { ParagraphsExtension } from './ParagraphsExtension';

--- a/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
@@ -5,12 +5,13 @@ import type { RenderElementProps } from 'slate-react';
 
 import { MentionElement, MentionsExtension } from '#extensions/mentions';
 
-import { PLACEHOLDER_MENTIONS_EXTENSION_ID } from './constants';
 import { normalizeRedundantPlaceholderMentionAttributes, parseSerializedElement } from './lib';
+
+export const EXTENSION_ID = 'PlaceholderMentionsExtension';
 
 export const PlaceholderMentionsExtension = (): Extension =>
     MentionsExtension({
-        id: PLACEHOLDER_MENTIONS_EXTENSION_ID,
+        id: EXTENSION_ID,
         type: PLACEHOLDER_NODE_TYPE,
         normalizeNode: normalizeRedundantPlaceholderMentionAttributes,
         parseSerializedElement,

--- a/packages/slate-editor/src/extensions/placeholder-mentions/constants.ts
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/constants.ts
@@ -1,1 +1,0 @@
-export const PLACEHOLDER_MENTIONS_EXTENSION_ID = 'PlaceholderMentionsExtension';

--- a/packages/slate-editor/src/extensions/placeholder-mentions/index.ts
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/index.ts
@@ -1,5 +1,5 @@
+export { PlaceholderMentionsExtension, EXTENSION_ID } from './PlaceholderMentionsExtension';
+
 export { PlaceholderMentionsDropdown } from './components';
-export { PLACEHOLDER_MENTIONS_EXTENSION_ID } from './constants';
-export { PlaceholderMentionsExtension } from './PlaceholderMentionsExtension';
 export type { Placeholder, PlaceholderMentionsExtensionParameters } from './types';
 export { usePlaceholderMentions } from './usePlaceholderMentions';

--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -4,11 +4,12 @@ import { CONTACT_NODE_TYPE, isContactNode } from '@prezly/slate-types';
 import React from 'react';
 
 import { PressContactElement } from './components';
-import { PRESS_CONTACTS_EXTENSION_ID } from './constants';
 import { normalizeRedundantPressContactAttributes, parseSerializedElement } from './lib';
 
+export const EXTENSION_ID = 'PressContactExtension';
+
 export const PressContactsExtension = (): Extension => ({
-    id: PRESS_CONTACTS_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [CONTACT_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/press-contacts/constants.ts
+++ b/packages/slate-editor/src/extensions/press-contacts/constants.ts
@@ -1,1 +1,0 @@
-export const PRESS_CONTACTS_EXTENSION_ID = 'PressContactExtension';

--- a/packages/slate-editor/src/extensions/press-contacts/index.ts
+++ b/packages/slate-editor/src/extensions/press-contacts/index.ts
@@ -1,5 +1,5 @@
+export { PressContactsExtension, EXTENSION_ID } from './PressContactsExtension';
+
 export { JobDescription, FloatingPressContactsMenu } from './components';
-export { PRESS_CONTACTS_EXTENSION_ID } from './constants';
 export { createPressContact, useFloatingPressContactsMenu } from './lib';
-export { PressContactsExtension } from './PressContactsExtension';
 export type { PressContactsExtensionParameters, SearchProps } from './types';

--- a/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
+++ b/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
@@ -9,7 +9,6 @@ import type { RenderElementProps } from 'slate-react';
 import { flow, identity } from '#lodash';
 
 import { RichTextElement, Text } from './components';
-import { RICH_FORMATTING_EXTENSION_ID } from './constants';
 import { createDeserialize } from './createDeserialize';
 import {
     isRichTextElement,
@@ -24,8 +23,10 @@ interface Parameters {
     blocks: boolean;
 }
 
+export const EXTENSION_ID = 'RichFormattingExtension';
+
 export const RichFormattingExtension = ({ blocks }: Parameters): Extension => ({
-    id: RICH_FORMATTING_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: createDeserialize({ blocks }),
     normalizeNode: normalizeRedundantRichTextAttributes,
     onKeyDown: (event: KeyboardEvent, editor: Editor) => {

--- a/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
+++ b/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
@@ -1,6 +1,5 @@
 import type { Extension, WithOverrides } from '@prezly/slate-commons';
 import { onKeyDown as onKeyboardDoListsFormatting } from '@prezly/slate-lists';
-import { PARAGRAPH_NODE_TYPE } from '@prezly/slate-types';
 import type { KeyboardEvent } from 'react';
 import React from 'react';
 import type { Editor } from 'slate';
@@ -51,7 +50,6 @@ export const RichFormattingExtension = ({ blocks }: Parameters): Extension => ({
     },
     renderLeaf: Text,
     rootTypes: [
-        PARAGRAPH_NODE_TYPE,
         ElementType.BLOCK_QUOTE,
         ElementType.HEADING_ONE,
         ElementType.HEADING_TWO,

--- a/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
+++ b/packages/slate-editor/src/extensions/rich-formatting/RichFormattingExtension.tsx
@@ -49,11 +49,7 @@ export const RichFormattingExtension = ({ blocks }: Parameters): Extension => ({
         return undefined;
     },
     renderLeaf: Text,
-    rootTypes: [
-        ElementType.BLOCK_QUOTE,
-        ElementType.HEADING_ONE,
-        ElementType.HEADING_TWO,
-    ],
+    rootTypes: [ElementType.BLOCK_QUOTE, ElementType.HEADING_ONE, ElementType.HEADING_TWO],
     withOverrides(editor) {
         const overrides: WithOverrides[] = [
             withResetFormattingOnBreak,

--- a/packages/slate-editor/src/extensions/rich-formatting/constants.ts
+++ b/packages/slate-editor/src/extensions/rich-formatting/constants.ts
@@ -1,1 +1,0 @@
-export const RICH_FORMATTING_EXTENSION_ID = 'RichFormattingExtension';

--- a/packages/slate-editor/src/extensions/rich-formatting/index.ts
+++ b/packages/slate-editor/src/extensions/rich-formatting/index.ts
@@ -1,6 +1,6 @@
+export { RichFormattingExtension, EXTENSION_ID } from './RichFormattingExtension';
+
 export { RichTextElement, Text } from './components';
-export { RICH_FORMATTING_EXTENSION_ID } from './constants';
 export { isRichTextBlockElement, isRichTextElement, toggleBlock } from './lib';
-export { RichFormattingExtension } from './RichFormattingExtension';
 export type { RichFormattingExtensionParameters, RichTextElementType } from './types';
 export { ElementType, MarkType } from './types';

--- a/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
@@ -5,12 +5,13 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { StoryBookmarkElement } from './components';
-import { STORY_BOOKMARK_EXTENSION_ID } from './constants';
 import { normalizeRedundantStoryBookmarkAttributes, parseSerializedElement } from './lib';
 import type { StoryBookmarkExtensionParameters } from './types';
 
+export const EXTENSION_ID = 'StoryBookmarkExtension';
+
 export const StoryBookmarkExtension = (params: StoryBookmarkExtensionParameters): Extension => ({
-    id: STORY_BOOKMARK_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [STORY_BOOKMARK_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/story-bookmark/constants.ts
+++ b/packages/slate-editor/src/extensions/story-bookmark/constants.ts
@@ -1,1 +1,0 @@
-export const STORY_BOOKMARK_EXTENSION_ID = 'StoryBookmarkExtension';

--- a/packages/slate-editor/src/extensions/story-bookmark/index.ts
+++ b/packages/slate-editor/src/extensions/story-bookmark/index.ts
@@ -1,3 +1,3 @@
-export * from './StoryBookmarkExtension';
+export { StoryBookmarkExtension, EXTENSION_ID } from './StoryBookmarkExtension';
 export * from './lib/useFloatingStoryBookmarkInput';
 export * from './types';

--- a/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
@@ -5,12 +5,13 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { StoryEmbedElement } from './components';
-import { STORY_EMBED_EXTENSION_ID } from './constants';
 import { normalizeRedundantStoryEmbedAttributes, parseSerializedElement } from './lib';
 import type { StoryEmbedExtensionParameters } from './types';
 
+export const EXTENSION_ID = 'StoryEmbedExtension';
+
 export const StoryEmbedExtension = ({ render }: StoryEmbedExtensionParameters): Extension => ({
-    id: STORY_EMBED_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [STORY_EMBED_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/story-embed/constants.ts
+++ b/packages/slate-editor/src/extensions/story-embed/constants.ts
@@ -1,1 +1,0 @@
-export const STORY_EMBED_EXTENSION_ID = 'StoryEmbedExtension';

--- a/packages/slate-editor/src/extensions/story-embed/index.ts
+++ b/packages/slate-editor/src/extensions/story-embed/index.ts
@@ -1,4 +1,3 @@
-export { STORY_EMBED_EXTENSION_ID } from './constants';
-export { StoryEmbedExtension } from './StoryEmbedExtension';
+export { StoryEmbedExtension, EXTENSION_ID } from './StoryEmbedExtension';
 export { createStoryEmbed, useFloatingStoryEmbedInput } from './lib';
 export type { StoryEmbedExtensionParameters } from './types';

--- a/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/user-mentions/UserMentionsExtension.tsx
@@ -5,12 +5,13 @@ import type { RenderElementProps } from 'slate-react';
 
 import { MentionElement, MentionsExtension } from '#extensions/mentions';
 
-import { USER_MENTIONS_EXTENSION_ID } from './constants';
 import { normalizeRedundantUserMentionAttributes, parseSerializedElement } from './lib';
+
+export const EXTENSION_ID = 'UserMentionsExtension';
 
 export const UserMentionsExtension = (): Extension =>
     MentionsExtension({
-        id: USER_MENTIONS_EXTENSION_ID,
+        id: EXTENSION_ID,
         type: MENTION_NODE_TYPE,
         normalizeNode: normalizeRedundantUserMentionAttributes,
         parseSerializedElement,

--- a/packages/slate-editor/src/extensions/user-mentions/constants.ts
+++ b/packages/slate-editor/src/extensions/user-mentions/constants.ts
@@ -1,1 +1,0 @@
-export const USER_MENTIONS_EXTENSION_ID = 'UserMentionsExtension';

--- a/packages/slate-editor/src/extensions/user-mentions/index.ts
+++ b/packages/slate-editor/src/extensions/user-mentions/index.ts
@@ -1,5 +1,5 @@
+export { UserMentionsExtension, EXTENSION_ID } from './UserMentionsExtension';
+
 export { UserMentionsDropdown } from './components';
-export { USER_MENTIONS_EXTENSION_ID } from './constants';
 export type { User, UserMentionsExtensionParameters } from './types';
-export { UserMentionsExtension } from './UserMentionsExtension';
 export { useUserMentions } from './useUserMentions';

--- a/packages/slate-editor/src/extensions/video/VideoExtension.tsx
+++ b/packages/slate-editor/src/extensions/video/VideoExtension.tsx
@@ -4,12 +4,13 @@ import { isVideoNode, VIDEO_NODE_TYPE } from '@prezly/slate-types';
 import React from 'react';
 
 import { VideoElement } from './components';
-import { VIDEO_EXTENSION_ID } from './constants';
 import { normalizeRedundantVideoAttributes, parseSerializedElement } from './lib';
+
+export const EXTENSION_ID = 'VideoExtension';
 
 export function VideoExtension(): Extension {
     return {
-        id: VIDEO_EXTENSION_ID,
+        id: EXTENSION_ID,
         deserialize: {
             element: {
                 [VIDEO_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/video/constants.ts
+++ b/packages/slate-editor/src/extensions/video/constants.ts
@@ -1,1 +1,0 @@
-export const VIDEO_EXTENSION_ID = 'VideoExtension';

--- a/packages/slate-editor/src/extensions/video/index.ts
+++ b/packages/slate-editor/src/extensions/video/index.ts
@@ -1,5 +1,5 @@
-export { VIDEO_EXTENSION_ID } from './constants';
+export { VideoExtension, EXTENSION_ID } from './VideoExtension';
+
 export { FloatingVideoInput } from './components';
-export { VideoExtension } from './VideoExtension';
 export { createVideoBookmark, useFloatingVideoInput } from './lib';
 export type { VideoExtensionParameters } from './types';

--- a/packages/slate-editor/src/extensions/void/VoidExtension.tsx
+++ b/packages/slate-editor/src/extensions/void/VoidExtension.tsx
@@ -7,11 +7,11 @@ import { isDeletingEvent } from '#lib';
 
 import { createParagraph } from '#extensions/paragraphs';
 
-import { VOID_EXTENSION_ID } from './constants';
+export const EXTENSION_ID = 'VoidExtension';
 
 export function VoidExtension(): Extension {
     return {
-        id: VOID_EXTENSION_ID,
+        id: EXTENSION_ID,
         onKeyDown: (event, editor) => {
             const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
 

--- a/packages/slate-editor/src/extensions/void/constants.ts
+++ b/packages/slate-editor/src/extensions/void/constants.ts
@@ -1,1 +1,0 @@
-export const VOID_EXTENSION_ID = 'VoidExtension';

--- a/packages/slate-editor/src/extensions/void/index.ts
+++ b/packages/slate-editor/src/extensions/void/index.ts
@@ -1,2 +1,1 @@
-export * from './constants';
-export * from './VoidExtension';
+export { VoidExtension, EXTENSION_ID } from './VoidExtension';

--- a/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
@@ -5,17 +5,18 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { WebBookmarkElement } from './components';
-import { WEB_BOOKMARK_EXTENSION_ID } from './constants';
 import { normalizeRedundantWebBookmarkAttributes, parseSerializedElement } from './lib';
 
 interface WebBookmarkExtensionParameters {
     withNewTabOption?: boolean;
 }
 
+export const EXTENSION_ID = 'WebBookmarkExtension';
+
 export const WebBookmarkExtension = ({
     withNewTabOption = true,
 }: WebBookmarkExtensionParameters): Extension => ({
-    id: WEB_BOOKMARK_EXTENSION_ID,
+    id: EXTENSION_ID,
     deserialize: {
         element: {
             [BOOKMARK_NODE_TYPE]: createDeserializeElement(parseSerializedElement),

--- a/packages/slate-editor/src/extensions/web-bookmark/constants.ts
+++ b/packages/slate-editor/src/extensions/web-bookmark/constants.ts
@@ -1,1 +1,0 @@
-export const WEB_BOOKMARK_EXTENSION_ID = 'WebBookmarkExtension';

--- a/packages/slate-editor/src/extensions/web-bookmark/index.ts
+++ b/packages/slate-editor/src/extensions/web-bookmark/index.ts
@@ -1,5 +1,5 @@
-export { WEB_BOOKMARK_EXTENSION_ID } from './constants';
+export { WebBookmarkExtension, EXTENSION_ID } from './WebBookmarkExtension';
+
 export { FloatingWebBookmarkInput } from './components';
-export { WebBookmarkExtension } from './WebBookmarkExtension';
 export { createWebBookmark, useFloatingWebBookmarkInput } from './lib';
 export type { WebBookmarkExtensionParameters } from './types';

--- a/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
@@ -16,7 +16,7 @@ import {
     createFileAttachment,
     EXTENSION_ID as FILE_ATTACHMENT_EXTENSION_ID,
 } from '#extensions/file-attachment';
-import { createImage, EXTENSION_ID } from '#extensions/image';
+import { createImage, EXTENSION_ID as IMAGE_EXTENSION_ID } from '#extensions/image';
 import { EXTENSION_ID as LOADER_EXTENSION_ID, LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';
 
@@ -37,7 +37,7 @@ function canPasteFiles(extensions: Extension[], data: DataTransfer): boolean {
         return false;
     }
 
-    const isImageExtensionEnabled = extensions.some(({ id }) => id === EXTENSION_ID);
+    const isImageExtensionEnabled = extensions.some(({ id }) => id === IMAGE_EXTENSION_ID);
     const isFileAttachmentExtensionEnabled = extensions.some(
         ({ id }) => id === FILE_ATTACHMENT_EXTENSION_ID,
     );
@@ -64,7 +64,7 @@ export function withFilePasting(getExtensions: () => Extension[]) {
             }
 
             const files = Array.from(data.files);
-            const isImageExtensionEnabled = extensions.some(({ id }) => id === EXTENSION_ID);
+            const isImageExtensionEnabled = extensions.some(({ id }) => id === IMAGE_EXTENSION_ID);
             const isFileAttachmentExtensionEnabled = extensions.some(
                 ({ id }) => id === FILE_ATTACHMENT_EXTENSION_ID,
             );

--- a/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
@@ -12,7 +12,10 @@ import {
 import uploadcare from '@prezly/uploadcare-widget';
 import type { Editor } from 'slate';
 
-import { createFileAttachment, EXTENSION_ID as FILE_ATTACHMENT_EXTENSION_ID } from '#extensions/file-attachment';
+import {
+    createFileAttachment,
+    EXTENSION_ID as FILE_ATTACHMENT_EXTENSION_ID,
+} from '#extensions/file-attachment';
 import { createImage, EXTENSION_ID } from '#extensions/image';
 import { EXTENSION_ID as LOADER_EXTENSION_ID, LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';

--- a/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
@@ -12,9 +12,9 @@ import {
 import uploadcare from '@prezly/uploadcare-widget';
 import type { Editor } from 'slate';
 
-import { createFileAttachment, FILE_ATTACHMENT_EXTENSION_ID } from '#extensions/file-attachment';
-import { createImage, IMAGE_EXTENSION_ID } from '#extensions/image';
-import { LOADER_EXTENSION_ID, LoaderContentType } from '#extensions/loader';
+import { createFileAttachment, EXTENSION_ID as FILE_ATTACHMENT_EXTENSION_ID } from '#extensions/file-attachment';
+import { createImage, EXTENSION_ID } from '#extensions/image';
+import { EXTENSION_ID as LOADER_EXTENSION_ID, LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';
 
 import { insertUploadingFile } from '../lib';
@@ -34,7 +34,7 @@ function canPasteFiles(extensions: Extension[], data: DataTransfer): boolean {
         return false;
     }
 
-    const isImageExtensionEnabled = extensions.some(({ id }) => id === IMAGE_EXTENSION_ID);
+    const isImageExtensionEnabled = extensions.some(({ id }) => id === EXTENSION_ID);
     const isFileAttachmentExtensionEnabled = extensions.some(
         ({ id }) => id === FILE_ATTACHMENT_EXTENSION_ID,
     );
@@ -61,7 +61,7 @@ export function withFilePasting(getExtensions: () => Extension[]) {
             }
 
             const files = Array.from(data.files);
-            const isImageExtensionEnabled = extensions.some(({ id }) => id === IMAGE_EXTENSION_ID);
+            const isImageExtensionEnabled = extensions.some(({ id }) => id === EXTENSION_ID);
             const isFileAttachmentExtensionEnabled = extensions.some(
                 ({ id }) => id === FILE_ATTACHMENT_EXTENSION_ID,
             );


### PR DESCRIPTION
- They now live next to the extension definition
- They are always exported as `EXTENSION_ID`. It's up
  to the consumer code to resolve naming collisions
- Drop empty-now `constants.ts` files