### PR TITLE
Fix - List elements `ref` support

### DIFF
--- a/packages/slate-editor/src/extensions/list/components/ListElement.tsx
+++ b/packages/slate-editor/src/extensions/list/components/ListElement.tsx
@@ -1,40 +1,49 @@
 import type { ListNode } from '@prezly/slate-types';
 import { Alignment, BULLETED_LIST_NODE_TYPE, NUMBERED_LIST_NODE_TYPE } from '@prezly/slate-types';
 import classNames from 'classnames';
-import type { HTMLAttributes } from 'react';
-import React from 'react';
+import type { HTMLAttributes, Ref } from 'react';
+import React, { forwardRef } from 'react';
 
 import styles from './ListElement.module.scss';
 
-interface Props extends HTMLAttributes<HTMLOListElement> {
+interface Props extends HTMLAttributes<HTMLUListElement | HTMLOListElement> {
     element: ListNode;
 }
 
-export function ListElement({ children, className, element, ...props }: Props) {
-    const List = element.type === BULLETED_LIST_NODE_TYPE ? 'ul' : 'ol';
+export const ListElement = forwardRef<HTMLUListElement | HTMLOListElement, Props>(
+    ({ children, className: customClassName, element, ...props }: Props, ref) => {
+        const className = classNames(customClassName, styles.ListElement, {
+            [styles.bulleted]: element.type === BULLETED_LIST_NODE_TYPE,
+            [styles.numbered]: element.type === NUMBERED_LIST_NODE_TYPE,
+            /*
+             * `inherit` is a fourth mode to inherit alignment from above.
+             * It is needed, as "inherit" presentation will have better (i.e. matching
+             * expectations) placement of the list bullets outside the text flow.
+             *
+             * Where for specified alignment it's treated as an override comparing
+             * to the document default alignment, and we have to put list bullets/numbers
+             * inside list items, which looks reasonable for centered and "opposite" alignments.
+             */
+            [styles.alignInherit]: element.align === undefined,
+            [styles.alignLeft]: element.align === Alignment.LEFT,
+            [styles.alignCenter]: element.align === Alignment.CENTER,
+            [styles.alignRight]: element.align === Alignment.RIGHT,
+        });
 
-    return (
-        <List
-            {...props}
-            className={classNames(className, styles.ListElement, {
-                [styles.bulleted]: element.type === BULLETED_LIST_NODE_TYPE,
-                [styles.numbered]: element.type === NUMBERED_LIST_NODE_TYPE,
-                /*
-                 * `inherit` is a fourth mode to inherit alignment from above.
-                 * It is needed, as "inherit" presentation will have better (i.e. matching
-                 * expectations) placement of the list bullets outside the text flow.
-                 *
-                 * Where for specified alignment it's treated as an override comparing
-                 * to the document default alignment, and we have to put list bullets/numbers
-                 * inside list items, which looks reasonable for centered and "opposite" alignments.
-                 */
-                [styles.alignInherit]: element.align === undefined,
-                [styles.alignLeft]: element.align === Alignment.LEFT,
-                [styles.alignCenter]: element.align === Alignment.CENTER,
-                [styles.alignRight]: element.align === Alignment.RIGHT,
-            })}
-        >
-            {children}
-        </List>
-    );
-}
+        if (element.type === BULLETED_LIST_NODE_TYPE) {
+            return (
+                <ul {...props} className={className} ref={ref as Ref<HTMLUListElement>}>
+                    {children}
+                </ul>
+            );
+        }
+
+        return (
+            <ol {...props} className={className} ref={ref as Ref<HTMLOListElement>}>
+                {children}
+            </ol>
+        );
+    },
+);
+
+ListElement.displayName = 'ListElement';

--- a/packages/slate-editor/src/extensions/list/components/ListItemElement.tsx
+++ b/packages/slate-editor/src/extensions/list/components/ListItemElement.tsx
@@ -1,7 +1,7 @@
 import type { ListItemNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import styles from './ListItemElement.module.scss';
 
@@ -9,10 +9,14 @@ interface Props extends HTMLAttributes<HTMLLIElement> {
     element: ListItemNode;
 }
 
-export function ListItemElement({ children, className, ...props }: Props) {
-    return (
-        <li {...props} className={classNames(styles.ListItemElement, className)}>
-            {children}
-        </li>
-    );
-}
+export const ListItemElement = forwardRef<HTMLLIElement, Props>(
+    ({ children, className, ...props }, ref) => {
+        return (
+            <li {...props} className={classNames(styles.ListItemElement, className)} ref={ref}>
+                {children}
+            </li>
+        );
+    },
+);
+
+ListItemElement.displayName = 'ListItemElement';

--- a/packages/slate-editor/src/extensions/list/components/ListItemTextElement.tsx
+++ b/packages/slate-editor/src/extensions/list/components/ListItemTextElement.tsx
@@ -12,7 +12,11 @@ interface Props extends HTMLAttributes<HTMLSpanElement> {
 export const ListItemTextElement = forwardRef<HTMLSpanElement, Props>(
     ({ children, className, ...props }, ref) => {
         return (
-            <span {...props} className={classNames(styles.ListItemTextElement, className)} ref={ref}>
+            <span
+                {...props}
+                className={classNames(styles.ListItemTextElement, className)}
+                ref={ref}
+            >
                 {children}
             </span>
         );

--- a/packages/slate-editor/src/extensions/list/components/ListItemTextElement.tsx
+++ b/packages/slate-editor/src/extensions/list/components/ListItemTextElement.tsx
@@ -1,18 +1,22 @@
 import type { ListItemTextNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import styles from './ListItemTextElement.module.scss';
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
+interface Props extends HTMLAttributes<HTMLSpanElement> {
     element: ListItemTextNode;
 }
 
-export function ListItemTextElement({ children, className, ...props }: Props) {
-    return (
-        <span {...props} className={classNames(styles.ListItemTextElement, className)}>
-            {children}
-        </span>
-    );
-}
+export const ListItemTextElement = forwardRef<HTMLSpanElement, Props>(
+    ({ children, className, ...props }, ref) => {
+        return (
+            <span {...props} className={classNames(styles.ListItemTextElement, className)} ref={ref}>
+                {children}
+            </span>
+        );
+    },
+);
+
+ListItemTextElement.displayName = 'ListItemTextElement';


### PR DESCRIPTION
Bring back `ref` support to ListExtension elements

Refs are required by Slate in order to locate document nodes by their DOM elements. Without refs, it's likely to generate `Cannot resolve a DOM point from Slate point: {...}` errors when clicking on list nodes.

This is a regression introduced in #206 