### PR TITLE
[MT-5128] Fix - Editor selection observed slowness

### DIFF
--- a/packages/slate-editor/src/extensions/decorate-selection/components/SelectionHighlight.module.scss
+++ b/packages/slate-editor/src/extensions/decorate-selection/components/SelectionHighlight.module.scss
@@ -2,12 +2,12 @@
 
 .selection {
     border-radius: 4px;
-    box-shadow: 0px 2px 0px 1px #c7d2fe, 0px -2px 0px 1px #c7d2fe;
-    color: #3630a3;
+    box-shadow: 0px 2px 0px 1px $editor-selection-bg, 0px -2px 0px 1px $editor-selection-bg;
+    color: $editor-selection-color;
 
     &,
     &::selection,
     & *::selection {
-        background: #c7d2fe !important;
+        background: $editor-selection-bg !important;
     }
 }

--- a/packages/slate-editor/src/modules/editor/Editor.module.scss
+++ b/packages/slate-editor/src/modules/editor/Editor.module.scss
@@ -7,7 +7,8 @@
 
 .Editable {
     *::selection {
-        background: #c2e5ff;
+        background: $editor-selection-bg;
+        color: $editor-selection-color;
     }
 
     > [data-slate-block] {

--- a/packages/slate-editor/src/styles/variables.scss
+++ b/packages/slate-editor/src/styles/variables.scss
@@ -67,3 +67,6 @@ $editor-floating-button-size: 24px;
 $editor-floating-button-margin: 12px;
 $editor-block-overlay-z-index: 10;
 $editor-floating-container-z-index: $editor-block-overlay-z-index + 1;
+
+$editor-selection-bg: #c7d2fe;
+$editor-selection-color: #3630a3;


### PR DESCRIPTION
- Make native browser selection colors match the simulated rounded borders selection. This way it's harder to notice the lag.