### PR TITLE
Change - Remove border toggle from Table menu 

### DIFF
--- a/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
+++ b/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
@@ -23,13 +23,6 @@ export function TableMenu({ element, onClose }: Props) {
 
             <Toolbox.Section caption="Layout">
                 <Toggle
-                    name="borders"
-                    value={Boolean(element.border)}
-                    onChange={() => TablesEditor.updateTable(editor, { border: !element.border })}
-                >
-                    With borders
-                </Toggle>
-                <Toggle
                     name="header-row"
                     value={Boolean(element.header?.some((h) => h === 'first_row'))}
                     onChange={() => TablesEditor.toggleTableHeader(editor, undefined, 'first_row')}

--- a/packages/slate-editor/src/extensions/tables/normalization.test.tsx
+++ b/packages/slate-editor/src/extensions/tables/normalization.test.tsx
@@ -1,0 +1,331 @@
+/** @jsx jsx */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { Editor, Node } from 'slate';
+
+import { jsx } from '../../jsx';
+
+import {
+    normalizeTableAttributes,
+    normalizeRowAttributes,
+    normalizeCellAttributes,
+} from './normalization';
+
+describe('normalizeTableAttributes', () => {
+    it('should always enable `border: true` on table nodes', () => {
+        const editor = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table border={true}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        editor.normalizeNode = function (entry) {
+            normalizeTableAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+
+    it('should remove empty `header: []` prop from table nodes', () => {
+        const editor = (
+            <editor>
+                <h:table border={true} header={[]}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table border={true}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        editor.normalizeNode = function (entry) {
+            normalizeTableAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+
+    it('should normalize `header` prop order and remove duplicates', () => {
+        const editor = (
+            <editor>
+                <h:table border={true} header={['first_row', 'first_row', 'first_column']}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table border={true} header={['first_column', 'first_row']}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        editor.normalizeNode = function (entry) {
+            normalizeTableAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+
+    it('should remove unknown table props', () => {
+        const editor = (
+            <editor>
+                {/* @ts-ignore */}
+                <h:table border={true} hello="world" colspan={2} className="header">
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table border={true}>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        editor.normalizeNode = function (entry) {
+            normalizeTableAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+});
+
+describe('normalizeRowAttributes', () => {
+    it('should remove unknown row props', () => {
+        const editor = (
+            <editor>
+                <h:table>
+                    {/* @ts-ignore */}
+                    <h:tr title="Hello world" colspan={2} className="header">
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        expect(Node.get(editor, [0, 0])).toMatchObject({ title: 'Hello world' });
+
+        editor.normalizeNode = function (entry) {
+            normalizeRowAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+});
+
+describe('normalizeCellAttributes', () => {
+    it('should remove default values of `colspan: 1` and `rowspan: 1` props', () => {
+        const editor = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        <h:td colspan={1} rowspan={2}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={2} rowspan={1}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={1} rowspan={1}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={2} rowspan={2}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={1}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        <h:td rowspan={2}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={2}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td colspan={2} rowspan={2}>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        editor.normalizeNode = function (entry) {
+            normalizeCellAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+
+    it('should remove unknown cell props', () => {
+        const editor = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        {/* @ts-ignore */}
+                        <h:td title="Hello world" className="header">
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:table>
+                    <h:tr>
+                        <h:td>
+                            <h:paragraph>
+                                <h:text>Hello world</h:text>
+                            </h:paragraph>
+                        </h:td>
+                    </h:tr>
+                </h:table>
+            </editor>
+        ) as unknown as Editor;
+
+        expect(Node.get(editor, [0, 0, 0])).toMatchObject({ title: 'Hello world' });
+
+        editor.normalizeNode = function (entry) {
+            normalizeCellAttributes(editor, entry);
+        };
+
+        Editor.normalize(editor, { force: true });
+
+        expect(editor.children).toEqual(expected.children);
+    });
+});

--- a/packages/slate-editor/src/extensions/tables/normalization.ts
+++ b/packages/slate-editor/src/extensions/tables/normalization.ts
@@ -9,7 +9,7 @@ import {
 } from '@prezly/slate-types';
 import { type Editor, type NodeEntry, Transforms } from 'slate';
 
-import { isEqual } from '#lodash';
+import { isEqual, uniq } from '#lodash';
 
 const ALLOWED_TABLE_ATTRIBUTES: { [key in keyof TableNode]: boolean } = {
     type: true,
@@ -41,9 +41,9 @@ export function normalizeTableAttributes(editor: Editor, [node, path]: NodeEntry
             return true;
         }
         if (node.header && node.header.length > 2) {
-            const sortedHeader = [...node.header].sort();
-            if (!isEqual(sortedHeader, node.header)) {
-                Transforms.setNodes<TableNode>(editor, { header: sortedHeader }, { at: path });
+            const normalizedHeader = uniq([...node.header].sort());
+            if (!isEqual(normalizedHeader, node.header)) {
+                Transforms.setNodes<TableNode>(editor, { header: normalizedHeader }, { at: path });
                 return true;
             }
         }

--- a/packages/slate-editor/src/extensions/tables/normalization.ts
+++ b/packages/slate-editor/src/extensions/tables/normalization.ts
@@ -32,8 +32,8 @@ const ALLOWED_CELL_ATTRIBUTES: { [key in keyof TableCellNode]: boolean } = {
 
 export function normalizeTableAttributes(editor: Editor, [node, path]: NodeEntry): boolean {
     if (isTableNode(node)) {
-        if (node.border === false) {
-            Transforms.unsetNodes<TableNode>(editor, 'border', { at: path });
+        if (!node.border) {
+            Transforms.setNodes<TableNode>(editor, { border: true }, { at: path });
             return true;
         }
         if (node.header !== undefined && node.header.length === 0) {


### PR DESCRIPTION
- Remove "border" toggle from the table menu
- Implement normalization to always add `border: true` on all TableNodes 

Extracted this part from #231, as it is a standalone change by itself