### PR TITLE
[MT-5150] Fix calls to possibly undefined TablesEditor methods

### DIFF
--- a/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
+++ b/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
@@ -15,6 +15,10 @@ interface Props {
 export function TableMenu({ element, onClose }: Props) {
     const editor = useSlateStatic();
 
+    if (!TablesEditor.isTablesEditor(editor)) {
+        return null;
+    }
+
     return (
         <Toolbox.Panel>
             <Toolbox.Header withCloseButton onCloseClick={onClose}>

--- a/packages/slate-editor/src/index.ts
+++ b/packages/slate-editor/src/index.ts
@@ -1,5 +1,4 @@
 import type { ListsEditor } from '@prezly/slate-lists';
-import type { TablesEditor } from '@prezly/slate-tables';
 import type { ElementNode, TextNode } from '@prezly/slate-types';
 import type { BaseEditor } from 'slate';
 import type { HistoryEditor } from 'slate-history';
@@ -23,12 +22,7 @@ import type { RichBlocksAwareEditor } from './modules/editor';
 
 declare module 'slate' {
     interface CustomTypes {
-        Editor: BaseEditor &
-            ReactEditor &
-            HistoryEditor &
-            ListsEditor &
-            RichBlocksAwareEditor &
-            TablesEditor;
+        Editor: BaseEditor & ReactEditor & HistoryEditor & ListsEditor & RichBlocksAwareEditor;
         Element: ElementNode;
         Text: TextNode;
     }

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/display-name */
 import { Events } from '@prezly/events';
 import { EditorCommands } from '@prezly/slate-commons';
+import { TablesEditor } from '@prezly/slate-tables';
 import type { HeadingNode, ParagraphNode, QuoteNode } from '@prezly/slate-types';
 import {
     Alignment,
@@ -306,7 +307,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             return insertDivider(editor);
         }
         if (action === MenuAction.ADD_TABLE) {
-            return insertTable(editor);
+            return TablesEditor.isTablesEditor(editor) && insertTable(editor);
         }
         if (action === MenuAction.ADD_EMBED) {
             return openFloatingEmbedInput('Add embed', {

--- a/packages/slate-editor/src/modules/editor/lib/table/insertTable.ts
+++ b/packages/slate-editor/src/modules/editor/lib/table/insertTable.ts
@@ -1,9 +1,8 @@
 import { EditorCommands } from '@prezly/slate-commons';
 import { TablesEditor } from '@prezly/slate-tables';
-import type { Editor } from 'slate';
-import { Transforms } from 'slate';
+import { type Editor, Transforms } from 'slate';
 
-export function insertTable(editor: Editor) {
+export function insertTable(editor: Editor & TablesEditor) {
     const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) || [];
 
     if (!currentNode) {

--- a/packages/slate-editor/src/modules/nodes-hierarchy/hierarchySchema.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/hierarchySchema.ts
@@ -98,7 +98,10 @@ export const hierarchySchema: NodesHierarchySchema = {
     [TEXT_NODE_TYPE]: [
         disallowMark(
             'bold',
-            isDescendantOf((_, path, editor) => TablesEditor.isHeaderCell(editor, path)),
+            isDescendantOf(
+                (_, path, editor) =>
+                    TablesEditor.isTablesEditor(editor) && TablesEditor.isHeaderCell(editor, path),
+            ),
         ),
     ],
     [VIDEO_NODE_TYPE]: [allowChildren(isEmptyTextNode, liftNodeNoSplit)],

--- a/packages/slate-editor/src/modules/rich-formatting-menu/RichFormattingMenu.tsx
+++ b/packages/slate-editor/src/modules/rich-formatting-menu/RichFormattingMenu.tsx
@@ -194,6 +194,9 @@ export function RichFormattingMenu({
         return null;
     }
 
+    const isInsideTable = TablesEditor.isTablesEditor(editor) && TablesEditor.isInTable(editor);
+    const isInsideTableHeader = isInsideTable && TablesEditor.isHeaderCell(editor);
+
     return (
         <TextSelectionPortalV2
             containerElement={containerElement}
@@ -226,12 +229,10 @@ export function RichFormattingMenu({
                     onFormatting={handleFormattingChange}
                     onLink={handleLinkButtonClick}
                     // features
-                    withBoldFormat={
-                        TablesEditor.isInTable(editor) ? !TablesEditor.isHeaderCell(editor) : true
-                    }
+                    withBoldFormat={!isInsideTableHeader}
                     withAlignment={withAlignment}
-                    withBlockquotes={withBlockquotes && !TablesEditor.isInTable(editor)}
-                    withHeadings={withHeadings && !TablesEditor.isInTable(editor)}
+                    withBlockquotes={withBlockquotes && !isInsideTable}
+                    withHeadings={withHeadings && !isInsideTable}
                     withInlineLinks={withInlineLinks}
                     withLists={withLists}
                     withParagraphs={withParagraphs}

--- a/packages/slate-tables/src/withTables.ts
+++ b/packages/slate-tables/src/withTables.ts
@@ -2,8 +2,8 @@ import type { Editor } from 'slate';
 
 import type { TablesEditor, TablesSchema } from './TablesEditor';
 
-export function withTables<T extends TablesEditor>(editor: TablesEditor, schema: TablesSchema) {
+export function withTables<T extends Editor>(editor: T, schema: TablesSchema) {
     return Object.assign(editor, {
         ...schema,
-    }) as T & Editor;
+    }) as T & TablesEditor;
 }


### PR DESCRIPTION
It's because `withTables()` is applied conditionally depending on an incoming property. It's not universally available.