### PR TITLE
[MT-5090][MT-5071] Fix - StoryEmbed element

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
@@ -53,8 +53,15 @@
 
 .Content {
     position: relative;
-    overflow: hidden;
     z-index: $editor-block-overlay-z-index - 1;
+
+    &.overflowHidden {
+        overflow: hidden;
+    }
+
+    &.overflowVisible {
+        overflow: visible;
+    }
 
     &.editable {
         white-space: pre-wrap;

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -40,6 +40,7 @@ export interface Props
      */
     hasError?: boolean;
     layout?: `${Layout}`;
+    overflow?: 'visible' | 'hidden';
     overlay?: OverlayMode;
     renderAboveFrame?: ((props: { isSelected: boolean }) => ReactNode) | ReactNode;
     renderBelowFrame?: ((props: { isSelected: boolean }) => ReactNode) | ReactNode;
@@ -61,6 +62,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
         extendedHitArea,
         hasError,
         layout = 'contained',
+        overflow = 'hidden',
         overlay = false,
         renderAboveFrame,
         renderBelowFrame,
@@ -147,12 +149,14 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                 />
                 <div
                     className={classNames(styles.Content, {
-                        [styles.editable]: Boolean(renderEditableFrame),
-                        [styles.selected]: isSelected,
-                        [styles.hasError]: hasError,
                         [styles.border]: border,
-                        [styles.rounded]: rounded,
+                        [styles.editable]: Boolean(renderEditableFrame),
                         [styles.fullWidth]: layout === Layout.FULL_WIDTH,
+                        [styles.hasError]: hasError,
+                        [styles.overflowHidden]: overflow === 'hidden',
+                        [styles.overflowVisible]: overflow === 'visible',
+                        [styles.rounded]: rounded,
+                        [styles.selected]: isSelected,
                     })}
                     onClick={handleFrameClick}
                 >

--- a/packages/slate-editor/src/extensions/story-embed/components/StoryEmbedElement/StoryEmbedElement.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/components/StoryEmbedElement/StoryEmbedElement.tsx
@@ -36,6 +36,7 @@ export const StoryEmbedElement: FunctionComponent<Props> = ({
             element={element}
             layout="full-width"
             overlay="always"
+            overflow="visible"
             renderMenu={undefined}
             // We have to render children or Slate will fail when trying to find the node.
             renderAboveFrame={children}

--- a/packages/slate-editor/src/extensions/story-embed/components/StoryEmbedElement/StoryEmbedElement.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/components/StoryEmbedElement/StoryEmbedElement.tsx
@@ -34,6 +34,7 @@ export const StoryEmbedElement: FunctionComponent<Props> = ({
         <EditorBlock
             {...attributes} // contains `ref`
             element={element}
+            layout="full-width"
             overlay="always"
             renderMenu={undefined}
             // We have to render children or Slate will fail when trying to find the node.

--- a/packages/slate-editor/src/extensions/story-embed/lib/createStoryEmbed.ts
+++ b/packages/slate-editor/src/extensions/story-embed/lib/createStoryEmbed.ts
@@ -18,8 +18,8 @@ function withoutExtraAttributes<T extends StoryEmbedNode>(node: T): StoryEmbedNo
 
 export function createStoryEmbed(props: RequiredProps & Partial<OptionalProps>): StoryEmbedNode {
     return withoutExtraAttributes({
-        appearance: StoryEmbedAppearance.INTRO,
-        position: StoryEmbedPosition.LEFT,
+        appearance: StoryEmbedAppearance.FULL,
+        position: StoryEmbedPosition.CENTER,
         ...props,
         children: [{ text: '' }],
         type: STORY_EMBED_NODE_TYPE, // disallowed to override type


### PR DESCRIPTION
- Make `center` / `full` default StoryEmbed settings (see MT-5090)
- Fix visual presentation of StoryEmbed nodes in the editor