### PR TITLE
[MT-5184] Feature - Insert blocks above/below current block

### DIFF
--- a/packages/slate-editor/src/extensions/insert-block-hotkey/InsertBlockHotkeyExtension.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/InsertBlockHotkeyExtension.ts
@@ -6,12 +6,12 @@ import { insertBlockAbove, insertBlockBelow } from './lib';
 
 export const EXTENSION_ID = InsertBlockHotkeyExtension.name;
 
+const isModEnter = isHotkey('mod+enter');
+const isShiftModEnter = isHotkey('shift+mod+enter');
+
 interface Parameters {
     createDefaultElement: (props?: Partial<Element>) => Element;
 }
-
-const isModEnter = isHotkey('mod+enter');
-const isShiftModEnter = isHotkey('shift+mod+enter');
 
 export function InsertBlockHotkeyExtension({ createDefaultElement }: Parameters): Extension {
     return {

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/InsertBlockHotkeyExtension.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/InsertBlockHotkeyExtension.ts
@@ -1,0 +1,31 @@
+import type { Extension } from '@prezly/slate-commons';
+import { isHotkey } from 'is-hotkey';
+import type { Element } from 'slate';
+
+import { insertBlockAbove, insertBlockBelow } from './lib';
+
+export const EXTENSION_ID = InsertBlockHotkeyExtension.name;
+
+interface Parameters {
+    createDefaultElement: (props?: Partial<Element>) => Element;
+}
+
+const isModEnter = isHotkey('mod+enter');
+const isShiftModEnter = isHotkey('shift+mod+enter');
+
+export function InsertBlockHotkeyExtension({ createDefaultElement }: Parameters): Extension {
+    return {
+        id: EXTENSION_ID,
+        onKeyDown: (event, editor) => {
+            if (isShiftModEnter(event) && insertBlockAbove(editor, createDefaultElement)) {
+                event.preventDefault();
+                return;
+            }
+
+            if (isModEnter(event) && insertBlockBelow(editor, createDefaultElement)) {
+                event.preventDefault();
+                return;
+            }
+        },
+    };
+}

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/index.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/index.ts
@@ -1,0 +1,1 @@
+export { InsertBlockHotkeyExtension, EXTENSION_ID } from './InsertBlockHotkeyExtension';

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
@@ -9,11 +9,11 @@ export function insertBlockBelow(editor: Editor, createElement: () => Element): 
 }
 
 function insertBlock(editor: Editor, createElement: () => Element, offset: number): boolean {
-    if (!editor.selection) return false;
+    const path = editor.selection?.focus.path ?? [];
 
-    const [index] = editor.selection.focus.path;
+    if (path.length === 0) return false;
 
-    if (!index) return false;
+    const [index] = path;
 
     Transforms.insertNodes(editor, createElement(), { at: [index + offset] });
     Transforms.select(editor, [index + offset]);

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
@@ -1,22 +1,28 @@
 import { type Editor, type Element, Transforms } from 'slate';
 
+enum Direction {
+    // Note: the indexes here are used as index offsets. Watch out when you decide to modify them.
+    ABOVE = 0,
+    BELOW = 1,
+}
+
 export function insertBlockAbove(editor: Editor, createElement: () => Element): boolean {
-    return insertBlock(editor, createElement, 0);
+    return insertBlock(editor, createElement, Direction.ABOVE);
 }
 
 export function insertBlockBelow(editor: Editor, createElement: () => Element): boolean {
-    return insertBlock(editor, createElement, +1);
+    return insertBlock(editor, createElement, Direction.BELOW);
 }
 
-function insertBlock(editor: Editor, createElement: () => Element, offset: number): boolean {
+function insertBlock(editor: Editor, createElement: () => Element, direction: Direction): boolean {
     const path = editor.selection?.focus.path ?? [];
 
     if (path.length === 0) return false;
 
     const [index] = path;
 
-    Transforms.insertNodes(editor, createElement(), { at: [index + offset] });
-    Transforms.select(editor, [index + offset]);
+    Transforms.insertNodes(editor, createElement(), { at: [index + direction] });
+    Transforms.select(editor, [index + direction]);
 
     return true;
 }

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
@@ -1,0 +1,22 @@
+import { type Editor, type Element, Transforms } from 'slate';
+
+export function insertBlockAbove(editor: Editor, createElement: () => Element): boolean {
+    return insertBlock(editor, createElement, 0);
+}
+
+export function insertBlockBelow(editor: Editor, createElement: () => Element): boolean {
+    return insertBlock(editor, createElement, +1);
+}
+
+function insertBlock(editor: Editor, createElement: () => Element, offset: number): boolean {
+    if (!editor.selection) return false;
+
+    const [index] = editor.selection.focus.path;
+
+    if (!index) return false;
+
+    Transforms.insertNodes(editor, createElement(), { at: [index + offset] });
+    Transforms.select(editor, [index + offset]);
+
+    return true;
+}

--- a/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
+++ b/packages/slate-editor/src/extensions/insert-block-hotkey/lib.ts
@@ -1,7 +1,7 @@
 import { type Editor, type Element, Transforms } from 'slate';
 
 enum Direction {
-    // Note: the indexes here are used as index offsets. Watch out when you decide to modify them.
+    // Note: The enum values are used as index offsets. Watch out when you decide to modify them.
     ABOVE = 0,
     BELOW = 1,
 }

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -15,9 +15,10 @@ import { HeadingExtension } from '#extensions/heading';
 import { HtmlExtension } from '#extensions/html';
 import { ImageExtension } from '#extensions/image';
 import { InlineLinksExtension } from '#extensions/inline-links';
+import { InsertBlockHotkeyExtension } from '#extensions/insert-block-hotkey';
 import { ListExtension } from '#extensions/list';
 import { LoaderExtension } from '#extensions/loader';
-import {createParagraph, ParagraphsExtension} from '#extensions/paragraphs';
+import { createParagraph, ParagraphsExtension } from '#extensions/paragraphs';
 import { PlaceholderMentionsExtension } from '#extensions/placeholder-mentions';
 import { PressContactsExtension } from '#extensions/press-contacts';
 import { SoftBreakExtension } from '#extensions/soft-break';
@@ -47,7 +48,6 @@ import {
     handleRemoveImage,
 } from './lib';
 import type { EditorProps } from './types';
-import {InsertBlockHotkeyExtension} from "#extensions/insert-block-hotkey";
 
 type Parameters = {
     availableWidth: number;

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -17,7 +17,7 @@ import { ImageExtension } from '#extensions/image';
 import { InlineLinksExtension } from '#extensions/inline-links';
 import { ListExtension } from '#extensions/list';
 import { LoaderExtension } from '#extensions/loader';
-import { ParagraphsExtension } from '#extensions/paragraphs';
+import {createParagraph, ParagraphsExtension} from '#extensions/paragraphs';
 import { PlaceholderMentionsExtension } from '#extensions/placeholder-mentions';
 import { PressContactsExtension } from '#extensions/press-contacts';
 import { SoftBreakExtension } from '#extensions/soft-break';
@@ -47,6 +47,7 @@ import {
     handleRemoveImage,
 } from './lib';
 import type { EditorProps } from './types';
+import {InsertBlockHotkeyExtension} from "#extensions/insert-block-hotkey";
 
 type Parameters = {
     availableWidth: number;
@@ -108,6 +109,7 @@ export function* getEnabledExtensions({
     yield DecorateSelectionExtension();
     yield ParagraphsExtension();
     yield SoftBreakExtension();
+    yield InsertBlockHotkeyExtension({ createDefaultElement: createParagraph });
 
     if (withBlockquotes) {
         yield BlockquoteExtension();


### PR DESCRIPTION
- Implement `InsertBlockHotkeyExtension` extension to support hotkeys to insert blocks above/below current top-level block