### PR TITLE
[MT-5132] Feature - Allow tracking of [+] menu options clicks

### DIFF
--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
@@ -35,7 +35,7 @@ interface Props<Action> extends Settings {
     containerRef: RefObject<HTMLElement>;
     open: boolean;
     options: Option<Action>[];
-    onActivate: (action: Action) => void;
+    onActivate: (option: Option<Action>) => void;
     onToggle: (isShown: boolean) => void;
     showTooltipByDefault: boolean;
 }
@@ -90,7 +90,7 @@ export function FloatingAddMenu<Action>({
 
     function onSelect(option: Option<Action>) {
         menu.close();
-        onActivate(option.action);
+        onActivate(option);
     }
 
     function handleKeyDown(event: KeyboardEvent) {

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
@@ -36,7 +36,7 @@ interface Props<Action> extends Settings {
     containerRef: RefObject<HTMLElement>;
     open: boolean;
     options: Option<Action>[];
-    onActivate: (option: Option<Action>) => void;
+    onActivate: (option: Option<Action>, query: string) => void;
     onFilter?: (query: string, resultsCount: number) => void;
     onToggle: (isShown: boolean) => void;
     showTooltipByDefault: boolean;
@@ -104,7 +104,7 @@ export function FloatingAddMenu<Action>({
 
     function onSelect(option: Option<Action>) {
         menu.close();
-        onActivate(option);
+        onActivate(option, query);
     }
 
     function handleKeyDown(event: KeyboardEvent) {

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenu.tsx
@@ -8,7 +8,7 @@ import {
 import classNames from 'classnames';
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent, RefObject } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Modifier } from 'react-popper';
 import { Node, Transforms } from 'slate';
 import { useSlate } from 'slate-react';
@@ -36,6 +36,7 @@ interface Props<Action> extends Settings {
     open: boolean;
     options: Option<Action>[];
     onActivate: (option: Option<Action>) => void;
+    onFilter?: (query: string, resultsCount: number) => void;
     onToggle: (isShown: boolean) => void;
     showTooltipByDefault: boolean;
 }
@@ -55,6 +56,7 @@ export function FloatingAddMenu<Action>({
     availableWidth,
     containerRef,
     onActivate,
+    onFilter,
     onToggle,
     open,
     options,
@@ -87,6 +89,13 @@ export function FloatingAddMenu<Action>({
             resetSelectedOption();
         },
     });
+
+    useEffect(
+        function () {
+            onFilter?.(query, filteredOptions.length);
+        },
+        [query, filteredOptions.length],
+    );
 
     function onSelect(option: Option<Action>) {
         menu.close();

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
@@ -12,19 +12,19 @@ function isTriggerInput(event: KeyboardEvent) {
 
 export const EXTENSION_ID = 'FloatingAddMenuExtension';
 
-export function FloatingAddMenuExtension(toggleMenu: (open?: boolean) => void): Extension {
+export function FloatingAddMenuExtension(toggleMenu: (open: boolean) => void): Extension {
     return {
         id: EXTENSION_ID,
         onKeyDown(event, editor) {
             if (isMenuHotkey(event) && shouldShowMenuButton(editor)) {
                 event.preventDefault();
                 event.stopPropagation();
-                toggleMenu();
+                toggleMenu(true);
                 return;
             }
 
             if (isTriggerInput(event) && shouldShowMenuButton(editor)) {
-                toggleMenu();
+                toggleMenu(true);
                 return;
             }
         },

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/useMenuToggle.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/useMenuToggle.ts
@@ -29,9 +29,9 @@ export function useMenuToggle(
             }
 
             if (willOpen) {
-                params.current.callbacks.onOpen && params.current.callbacks.onOpen();
+                params.current.callbacks.onOpen?.();
             } else {
-                params.current.callbacks.onClose && params.current.callbacks.onClose();
+                params.current.callbacks.onClose?.();
             }
 
             params.current.onChange(willOpen);

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -289,7 +289,6 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         withWebBookmarks: Boolean(withWebBookmarks),
     });
 
-
     const handleMenuAction = useFunction((option: Option<MenuAction>, query: string) => {
         const { action, text, suggested } = option;
 

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -29,6 +29,7 @@ import { noop } from '#lodash';
 import { FloatingCoverageMenu, useFloatingCoverageMenu } from '#extensions/coverage';
 import { FloatingEmbedInput, useFloatingEmbedInput } from '#extensions/embed';
 import { FloatingAddMenu } from '#extensions/floating-add-menu';
+import type { Option } from '#extensions/floating-add-menu';
 import { LoaderContentType } from '#extensions/loader';
 import {
     PlaceholderMentionsDropdown,
@@ -46,6 +47,7 @@ import { FloatingWebBookmarkInput, useFloatingWebBookmarkInput } from '#extensio
 import { FloatingStoryEmbedInput, Placeholder } from '#modules/components';
 import { EditableWithExtensions } from '#modules/editable';
 import type { EditorEventMap } from '#modules/events';
+import { EventsEditor } from '#modules/events';
 import { RichFormattingMenu, toggleBlock } from '#modules/rich-formatting-menu';
 
 import styles from './Editor.module.scss';
@@ -282,7 +284,15 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             withWebBookmarks: Boolean(withWebBookmarks),
         }),
     );
-    const handleMenuAction = (action: MenuAction) => {
+
+    const handleMenuAction = (option: Option<MenuAction>) => {
+        const { action, text } = option;
+
+        EventsEditor.dispatchEvent(editor, 'add-button-menu-option-click', {
+            action,
+            title: text,
+        });
+
         if (action === MenuAction.ADD_PARAGRAPH) {
             return toggleBlock<ParagraphNode>(editor, PARAGRAPH_NODE_TYPE);
         }

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -121,7 +121,13 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
     // [+] menu
     const [isFloatingAddMenuOpen, setFloatingAddMenuOpen] = useState(false);
     const onFloatingAddMenuToggle = useCallback(
-        (shouldOpen?: boolean) => setFloatingAddMenuOpen((isOpen) => shouldOpen ?? !isOpen),
+        function (shouldOpen: boolean) {
+            setFloatingAddMenuOpen(shouldOpen);
+            EventsEditor.dispatchEvent(
+                editor,
+                shouldOpen ? 'add-button-menu-opened' : 'add-button-menu-closed',
+            );
+        },
         [setFloatingAddMenuOpen],
     );
     const getInitialValue = useFunction(() => initialValue);

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -291,7 +291,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         }),
     );
 
-    const handleMenuAction = (option: Option<MenuAction>) => {
+    const handleMenuAction = useFunction((option: Option<MenuAction>) => {
         const { action, text } = option;
 
         EventsEditor.dispatchEvent(editor, 'add-button-menu-option-click', {
@@ -381,7 +381,10 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             });
         }
         return;
-    };
+    });
+    const handleMenuFilter = useFunction((query: string, resultsCount: number) => {
+        EventsEditor.dispatchEvent(editor, 'add-button-menu-filtered', { query, resultsCount });
+    });
 
     const hasCustomPlaceholder =
         withFloatingAddMenu && (ReactEditor.isFocused(editor) || isFloatingAddMenuOpen);
@@ -452,6 +455,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
                         availableWidth={availableWidth}
                         containerRef={containerRef}
                         onActivate={handleMenuAction}
+                        onFilter={handleMenuFilter}
                         onToggle={onFloatingAddMenuToggle}
                         options={menuOptions}
                         showTooltipByDefault={EditorCommands.isEmpty(editor)}

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -290,12 +290,14 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
     });
 
 
-    const handleMenuAction = useFunction((option: Option<MenuAction>) => {
-        const { action, text } = option;
+    const handleMenuAction = useFunction((option: Option<MenuAction>, query: string) => {
+        const { action, text, suggested } = option;
 
         EventsEditor.dispatchEvent(editor, 'add-button-menu-option-click', {
             action,
             title: text,
+            suggested: typeof suggested === 'number',
+            query,
         });
         if (action === MenuAction.ADD_PARAGRAPH) {
             return toggleBlock<ParagraphNode>(editor, PARAGRAPH_NODE_TYPE);

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -50,7 +50,7 @@ import type { EditorProps } from './types';
 
 type Parameters = {
     availableWidth: number;
-    onFloatingAddMenuToggle: (show?: boolean) => void;
+    onFloatingAddMenuToggle: (show: boolean) => void;
     onOperationEnd?: () => void;
     onOperationStart?: () => void;
 } & Pick<

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -4,6 +4,8 @@ import type { PressContact, TableHeader } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 
 export type EditorEventMap = {
+    'add-button-menu-opened': never;
+    'add-button-menu-closed': never;
     'add-button-menu-option-click': {
         title: string;
         action: string;

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -13,6 +13,8 @@ export type EditorEventMap = {
     'add-button-menu-option-click': {
         title: string;
         action: string;
+        suggested: boolean;
+        query: string;
     };
     'attachment-add-clicked': never;
     'attachment-added': {

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -4,6 +4,10 @@ import type { PressContact, TableHeader } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 
 export type EditorEventMap = {
+    'add-button-menu-option-click': {
+        title: string;
+        action: string;
+    };
     'attachment-add-clicked': never;
     'attachment-added': {
         description: string;

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -6,6 +6,10 @@ import type { ReactNode } from 'react';
 export type EditorEventMap = {
     'add-button-menu-opened': never;
     'add-button-menu-closed': never;
+    'add-button-menu-filtered': {
+        query: string;
+        resultsCount: number;
+    };
     'add-button-menu-option-click': {
         title: string;
         action: string;


### PR DESCRIPTION
Trigger editor events for the following actions (so we can bind analytics tracking to them):
- `[+] menu opened`
- `[+] menu closed`
- `[+] menu filtered`
- `[+] menu option clicked`