### PR TITLE
[MT-5180] Fix - UX for copying/cutting/pasting tables

### DIFF
--- a/packages/slate-commons/src/commands/findLeafLocation.ts
+++ b/packages/slate-commons/src/commands/findLeafLocation.ts
@@ -5,7 +5,7 @@ import { findLeafPath } from './findLeafPath';
 import { findLeafPoint } from './findLeafPoint';
 import { findLeafRange } from './findLeafRange';
 
-export function findLeafLocation(editor: Editor, location: Location): Location | null {
+export function findLeafLocation(editor: Editor, location: Location): Location | undefined {
     if (Path.isPath(location)) {
         return findLeafPath(editor, location);
     }

--- a/packages/slate-commons/src/commands/findLeafPath.ts
+++ b/packages/slate-commons/src/commands/findLeafPath.ts
@@ -4,9 +4,9 @@ import { Node, Text } from 'slate';
 
 export type Edge = 'highest' | 'lowest';
 
-export function findLeafPath(editor: Editor, path: Path, edge: Edge = 'highest'): Path | null {
+export function findLeafPath(editor: Editor, path: Path, edge: Edge = 'highest'): Path | undefined {
     if (!Node.has(editor, path)) {
-        return null;
+        return undefined;
     }
 
     const node = Node.get(editor, path);

--- a/packages/slate-commons/src/commands/findLeafPoint.ts
+++ b/packages/slate-commons/src/commands/findLeafPoint.ts
@@ -3,11 +3,11 @@ import { Editor, Path, Point } from 'slate';
 import type { Edge } from './findLeafPath';
 import { findLeafPath } from './findLeafPath';
 
-export function findLeafPoint(editor: Editor, point: Point, edge: Edge = 'highest'): Point | null {
+export function findLeafPoint(editor: Editor, point: Point, edge: Edge = 'highest'): Point | undefined {
     const path = findLeafPath(editor, point.path, edge);
 
     if (!path) {
-        return null;
+        return undefined;
     }
 
     const [, end] = Editor.edges(editor, path);
@@ -22,8 +22,5 @@ export function findLeafPoint(editor: Editor, point: Point, edge: Edge = 'highes
 
     const offset = Math.min(point.offset, end.offset);
 
-    return {
-        offset,
-        path,
-    };
+    return { offset, path };
 }

--- a/packages/slate-commons/src/commands/findLeafPoint.ts
+++ b/packages/slate-commons/src/commands/findLeafPoint.ts
@@ -3,7 +3,11 @@ import { Editor, Path, Point } from 'slate';
 import type { Edge } from './findLeafPath';
 import { findLeafPath } from './findLeafPath';
 
-export function findLeafPoint(editor: Editor, point: Point, edge: Edge = 'highest'): Point | undefined {
+export function findLeafPoint(
+    editor: Editor,
+    point: Point,
+    edge: Edge = 'highest',
+): Point | undefined {
     const path = findLeafPath(editor, point.path, edge);
 
     if (!path) {

--- a/packages/slate-commons/src/commands/findLeafRange.ts
+++ b/packages/slate-commons/src/commands/findLeafRange.ts
@@ -2,14 +2,14 @@ import type { Editor, Range } from 'slate';
 
 import { findLeafPoint } from './findLeafPoint';
 
-export function findLeafRange(editor: Editor, range: Range): Range | null {
+export function findLeafRange(editor: Editor, range: Range): Range | undefined {
     const anchor = findLeafPoint(editor, range.anchor);
     const focus = findLeafPoint(editor, range.focus);
 
     if (!anchor || !focus) {
         // If any leaf point is missing, we have no way of reasonably guessing it to
         // form a valid range.
-        return null;
+        return undefined;
     }
 
     return { anchor, focus };

--- a/packages/slate-editor/src/extensions/paste-slate-content/PasteSlateContentExtension.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/PasteSlateContentExtension.ts
@@ -2,7 +2,7 @@ import type { Extension } from '@prezly/slate-commons';
 
 import { withSlatePasting } from './lib';
 
-export const EXTENSION_ID = PasteSlateContentExtension.name;
+export const EXTENSION_ID = 'PasteSlateContentExtension';
 
 export function PasteSlateContentExtension(): Extension {
     return {

--- a/packages/slate-editor/src/extensions/paste-slate-content/PasteSlateContentExtension.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/PasteSlateContentExtension.ts
@@ -2,7 +2,7 @@ import type { Extension } from '@prezly/slate-commons';
 
 import { withSlatePasting } from './lib';
 
-export const EXTENSION_ID = 'PasteSlateContentExtension';
+export const EXTENSION_ID = PasteSlateContentExtension.name;
 
 export function PasteSlateContentExtension(): Extension {
     return {

--- a/packages/slate-editor/src/extensions/paste-slate-content/lib/isFragment.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/lib/isFragment.ts
@@ -1,4 +1,4 @@
-import { Node} from 'slate';
+import { Node } from 'slate';
 
 export type Fragment = Node[];
 

--- a/packages/slate-editor/src/extensions/paste-slate-content/lib/isFragment.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/lib/isFragment.ts
@@ -1,101 +1,9 @@
-import type {
-    AttachmentNode,
-    ContactNode,
-    CoverageNode,
-    DividerNode,
-    DocumentNode,
-    EmbedNode,
-    GalleryNode,
-    HeadingNode,
-    ImageNode,
-    LinkNode,
-    ListNode,
-    ListItemNode,
-    ListItemTextNode,
-    MentionNode,
-    ParagraphNode,
-    PlaceholderNode,
-    QuoteNode,
-    TextNode,
-} from '@prezly/slate-types';
-import {
-    isAttachmentNode,
-    isContactNode,
-    isCoverageNode,
-    isDividerNode,
-    isDocumentNode,
-    isEmbedNode,
-    isGalleryNode,
-    isHeadingNode,
-    isImageNode,
-    isLinkNode,
-    isListNode,
-    isListItemNode,
-    isListItemTextNode,
-    isMentionNode,
-    isParagraphNode,
-    isPlaceholderNode,
-    isQuoteNode,
-} from '@prezly/slate-types';
-import { Element, Node, Text } from 'slate';
+import { Node} from 'slate';
 
-const validators = [
-    isAttachmentNode,
-    isContactNode,
-    isCoverageNode,
-    isDividerNode,
-    isDocumentNode,
-    isEmbedNode,
-    isGalleryNode,
-    isHeadingNode,
-    isImageNode,
-    isLinkNode,
-    isListNode,
-    isListItemNode,
-    isListItemTextNode,
-    isMentionNode,
-    isParagraphNode,
-    isPlaceholderNode,
-    isQuoteNode,
-    Text.isText,
-];
-
-type KnownNode =
-    | AttachmentNode
-    | ContactNode
-    | CoverageNode
-    | DividerNode
-    | DocumentNode
-    | EmbedNode
-    | GalleryNode
-    | HeadingNode
-    | ImageNode
-    | LinkNode
-    | ListNode
-    | ListItemNode
-    | ListItemTextNode
-    | MentionNode
-    | ParagraphNode
-    | PlaceholderNode
-    | QuoteNode
-    | TextNode;
-
-export type Fragment = KnownNode[];
-
-function isKnownNode(node: unknown): node is KnownNode {
-    return validators.some((validator) => {
-        const isKnown = validator(node);
-
-        if (Element.isElement(node)) {
-            return isKnown && isFragment(node.children);
-        }
-
-        return isKnown;
-    });
-}
+export type Fragment = Node[];
 
 /**
- * Checks recurively whether all nodes in the fragment (Node[]) are "known" nodes.
+ * Checks recursively whether all members of the fragment are Nodes.
  * It does not validate schema/hierarchy.
  */
 export function isFragment(value: unknown): value is Fragment {
@@ -103,5 +11,5 @@ export function isFragment(value: unknown): value is Fragment {
         return false;
     }
 
-    return value.length > 0 && value.every(isKnownNode);
+    return value.length > 0 && value.every(Node.isNode);
 }

--- a/packages/slate-editor/src/extensions/tables/TablesExtension.tsx
+++ b/packages/slate-editor/src/extensions/tables/TablesExtension.tsx
@@ -16,9 +16,9 @@ import {
 } from '@prezly/slate-types';
 import { flow } from 'lodash-es';
 import React from 'react';
+import type { Element } from 'slate';
 import type { RenderElementProps } from 'slate-react';
 
-import { createParagraph } from '#extensions/paragraphs';
 import { composeElementDeserializer } from '#modules/html-deserialization';
 
 import { TableElement, TableRowElement, TableCellElement } from './components';
@@ -32,7 +32,11 @@ import { onClipboardHotkey } from './onKeyDown';
 
 export const EXTENSION_ID = TablesExtension.name;
 
-export function TablesExtension(): Extension {
+interface Parameters {
+    createDefaultElement: (props?: Partial<Element>) => Element;
+}
+
+export function TablesExtension({ createDefaultElement }: Parameters): Extension {
     return {
         id: EXTENSION_ID,
         normalizeNode: [normalizeTableAttributes, normalizeRowAttributes, normalizeCellAttributes],
@@ -65,7 +69,7 @@ export function TablesExtension(): Extension {
         onKeyDown: (event, editor) => {
             if (TablesEditor.isTablesEditor(editor)) {
                 onKeyDown(event, editor);
-                onClipboardHotkey(event, editor);
+                onClipboardHotkey(event, editor, createDefaultElement);
             }
         },
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
@@ -97,7 +101,7 @@ export function TablesExtension(): Extension {
         },
         withOverrides: (editor) => {
             const tablesEditor = withTables(editor, {
-                createContentNode: createParagraph,
+                createContentNode: createDefaultElement,
                 createTableNode: ({ children, ...props }) =>
                     createTableNode({
                         ...props,

--- a/packages/slate-editor/src/extensions/tables/TablesExtension.tsx
+++ b/packages/slate-editor/src/extensions/tables/TablesExtension.tsx
@@ -28,6 +28,7 @@ import {
     normalizeRowAttributes,
     normalizeTableAttributes,
 } from './normalization';
+import { onClipboardHotkey } from './onKeyDown';
 
 export const EXTENSION_ID = TablesExtension.name;
 
@@ -64,6 +65,7 @@ export function TablesExtension(): Extension {
         onKeyDown: (event, editor) => {
             if (TablesEditor.isTablesEditor(editor)) {
                 onKeyDown(event, editor);
+                onClipboardHotkey(event, editor);
             }
         },
         renderElement: ({ attributes, children, element }: RenderElementProps) => {

--- a/packages/slate-editor/src/extensions/tables/onKeyDown.ts
+++ b/packages/slate-editor/src/extensions/tables/onKeyDown.ts
@@ -1,12 +1,12 @@
 import { TablesEditor } from '@prezly/slate-tables';
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import { Editor, Range, Transforms } from 'slate';
+import { type Element, Editor, Range, Transforms } from 'slate';
 
 const isClipboardCopy = isHotkey(['mod+c', 'ctrl+insert']);
 const isClipboardCut = isHotkey(['mod+x', 'shift+delete']);
 
-export function onClipboardHotkey(event: KeyboardEvent<Element>, editor: Editor & TablesEditor) {
+export function onClipboardHotkey(event: KeyboardEvent, editor: Editor & TablesEditor, createDefaultElement: () => Element) {
     const selection = editor.selection;
 
     if (!selection || Range.isExpanded(selection)) return;
@@ -35,7 +35,7 @@ export function onClipboardHotkey(event: KeyboardEvent<Element>, editor: Editor 
             const ref = Editor.pathRef(editor, path);
 
             if (document.execCommand('cut')) {
-                Transforms.insertNodes(editor, editor.createContentNode(), { at: path }); // FIXME: editor.createContentNode()
+                Transforms.insertNodes(editor, createDefaultElement(), { at: path });
                 if (ref.current) {
                     Transforms.removeNodes(editor, { at: ref.current });
                 }

--- a/packages/slate-editor/src/extensions/tables/onKeyDown.ts
+++ b/packages/slate-editor/src/extensions/tables/onKeyDown.ts
@@ -1,0 +1,48 @@
+import { TablesEditor } from '@prezly/slate-tables';
+import { isHotkey } from 'is-hotkey';
+import type { KeyboardEvent } from 'react';
+import { Editor, Range, Transforms } from 'slate';
+
+const isClipboardCopy = isHotkey(['mod+c', 'ctrl+insert']);
+const isClipboardCut = isHotkey(['mod+x', 'shift+delete']);
+
+export function onClipboardHotkey(event: KeyboardEvent<Element>, editor: Editor & TablesEditor) {
+    const selection = editor.selection;
+
+    if (!selection || Range.isExpanded(selection)) return;
+
+    if (isClipboardCopy(event)) {
+        const entry = TablesEditor.findParentTable(editor, selection);
+        if (!entry) {
+            return;
+        }
+        const [, path] = entry;
+
+        Transforms.select(editor, path); // Select the table
+
+        document.execCommand('copy');
+    }
+
+    if (isClipboardCut(event)) {
+        const entry = TablesEditor.findParentTable(editor, selection);
+        if (!entry) {
+            return;
+        }
+        const [, path] = entry;
+
+        Editor.withoutNormalizing(editor, () => {
+            Transforms.select(editor, path); // Select the table
+            const ref = Editor.pathRef(editor, path);
+
+            if (document.execCommand('cut')) {
+                Transforms.insertNodes(editor, editor.createContentNode(), { at: path }); // FIXME: editor.createContentNode()
+                if (ref.current) {
+                    Transforms.removeNodes(editor, { at: ref.current });
+                }
+                Transforms.select(editor, path);
+            }
+
+            ref.unref();
+        });
+    }
+}

--- a/packages/slate-editor/src/extensions/tables/onKeyDown.ts
+++ b/packages/slate-editor/src/extensions/tables/onKeyDown.ts
@@ -6,7 +6,11 @@ import { type Element, Editor, Range, Transforms } from 'slate';
 const isClipboardCopy = isHotkey(['mod+c', 'ctrl+insert']);
 const isClipboardCut = isHotkey(['mod+x', 'shift+delete']);
 
-export function onClipboardHotkey(event: KeyboardEvent, editor: Editor & TablesEditor, createDefaultElement: () => Element) {
+export function onClipboardHotkey(
+    event: KeyboardEvent,
+    editor: Editor & TablesEditor,
+    createDefaultElement: () => Element,
+) {
     const selection = editor.selection;
 
     if (!selection || Range.isExpanded(selection)) return;

--- a/packages/slate-editor/src/jsx.ts
+++ b/packages/slate-editor/src/jsx.ts
@@ -122,7 +122,7 @@ const extensions = [
     HeadingExtension(),
     InlineLinksExtension(),
     ListExtension(),
-    TablesExtension(),
+    TablesExtension({ createDefaultElement: createParagraph }),
 ];
 
 const creators: Record<keyof HElements, HyperscriptCreators[string]> = {

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -18,6 +18,7 @@ import { InsertBlockHotkeyExtension } from '#extensions/insert-block-hotkey';
 import { ListExtension } from '#extensions/list';
 import { LoaderExtension } from '#extensions/loader';
 import { createParagraph, ParagraphsExtension } from '#extensions/paragraphs';
+import { PasteSlateContentExtension } from '#extensions/paste-slate-content';
 import { PlaceholderMentionsExtension } from '#extensions/placeholder-mentions';
 import { PressContactsExtension } from '#extensions/press-contacts';
 import { SoftBreakExtension } from '#extensions/soft-break';
@@ -226,4 +227,6 @@ export function* getEnabledExtensions({
     yield VoidExtension();
 
     yield HtmlExtension();
+
+    yield PasteSlateContentExtension();
 }

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -210,7 +210,7 @@ export function* getEnabledExtensions({
     }
 
     if (withTables) {
-        yield TablesExtension();
+        yield TablesExtension({ createDefaultElement: createParagraph });
     }
 
     if (withStoryEmbeds) {

--- a/packages/slate-tables/src/TablesEditor.ts
+++ b/packages/slate-tables/src/TablesEditor.ts
@@ -23,6 +23,7 @@ export namespace TablesEditor {
     export const removeRow = TableCommands.removeRow;
     export const removeTable = TableCommands.removeTable;
 
+    export const findParentTable = TableQueries.findParentTable;
     export const isHeaderCell = TableQueries.isHeaderCell;
     export const isInTable = TableQueries.isInTable;
 

--- a/packages/slate-tables/src/TablesEditor.ts
+++ b/packages/slate-tables/src/TablesEditor.ts
@@ -23,6 +23,7 @@ export namespace TablesEditor {
     export const removeRow = TableCommands.removeRow;
     export const removeTable = TableCommands.removeTable;
 
+    export const findParentCell = TableQueries.findParentCell;
     export const findParentTable = TableQueries.findParentTable;
     export const isHeaderCell = TableQueries.isHeaderCell;
     export const isInTable = TableQueries.isInTable;

--- a/packages/slate-tables/src/core/onKeyDown.ts
+++ b/packages/slate-tables/src/core/onKeyDown.ts
@@ -1,9 +1,7 @@
 import { EditorCommands } from '@prezly/slate-commons';
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { Location, BasePoint } from 'slate';
-import { Editor, Path } from 'slate';
-import { Transforms } from 'slate';
+import { type Location, type Point, Editor, Path, Transforms } from 'slate';
 
 import { TablesEditor } from '../TablesEditor';
 
@@ -14,7 +12,7 @@ export function onKeyDown(event: KeyboardEvent<Element>, editor: TablesEditor) {
         return;
     }
 
-    let locationToSelect: Location | undefined | null = null;
+    let locationToSelect: Location | undefined = undefined;
 
     if (isHotkey('up', event)) {
         locationToSelect = onUpPress(editor);
@@ -36,7 +34,7 @@ export function onKeyDown(event: KeyboardEvent<Element>, editor: TablesEditor) {
     }
 }
 
-function onUpPress(editor: TablesEditor): BasePoint | null | undefined {
+function onUpPress(editor: TablesEditor): Point | undefined {
     if (!editor.selection) {
         return undefined;
     }
@@ -75,7 +73,7 @@ function onUpPress(editor: TablesEditor): BasePoint | null | undefined {
     return undefined;
 }
 
-function onDownPress(editor: TablesEditor): BasePoint | null | undefined {
+function onDownPress(editor: TablesEditor): Point | undefined {
     if (!editor.selection) {
         return undefined;
     }
@@ -114,7 +112,7 @@ function onDownPress(editor: TablesEditor): BasePoint | null | undefined {
     return undefined;
 }
 
-function onTabPress(editor: TablesEditor): Location | null | undefined {
+function onTabPress(editor: TablesEditor): Location | undefined {
     if (!editor.selection) {
         return undefined;
     }

--- a/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
+++ b/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
@@ -1,6 +1,6 @@
-import { type NodeEntry, type Range, Node, Path } from 'slate';
+import { type Range, Node, Path } from 'slate';
 
-import { findParentCell } from '../queries';
+import { findParentCell, findParentTable } from '../queries';
 import type { TablesEditor } from '../TablesEditor';
 
 export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): T {
@@ -8,9 +8,9 @@ export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): 
 
     editor.getFragment = () => {
         if (editor.selection) {
-            const cellEntry = findParentCell(editor, editor.selection);
+            const cellEntry = findParentCell(editor);
 
-            if (cellEntry && isRangeInsideCell(editor.selection, cellEntry)) {
+            if (cellEntry && isRangeInside(editor.selection, cellEntry[1])) {
                 const [cell, cellPath] = cellEntry;
                 const { focus, anchor } = editor.selection;
 
@@ -25,6 +25,12 @@ export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): 
                     },
                 });
             }
+
+            const tableEntry = findParentTable(editor);
+
+            if (tableEntry && isRangeInside(editor.selection, tableEntry[1])) {
+                return [tableEntry[0]];
+            }
         }
 
         return getFragment();
@@ -33,9 +39,6 @@ export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): 
     return editor;
 }
 
-function isRangeInsideCell(selection: Range, [, cellPath]: NodeEntry<Node>) {
-    return (
-        Path.isCommon(cellPath, selection.anchor.path) &&
-        Path.isCommon(cellPath, selection.focus.path)
-    );
+function isRangeInside(selection: Range, path: Path) {
+    return Path.isCommon(path, selection.anchor.path) && Path.isCommon(path, selection.focus.path);
 }

--- a/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
+++ b/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
@@ -1,6 +1,6 @@
-import type { Location, NodeEntry, Range } from 'slate';
-import { Editor, Node, Path } from 'slate';
+import { type NodeEntry, type Range, Node, Path } from 'slate';
 
+import { findParentCell } from '../queries';
 import type { TablesEditor } from '../TablesEditor';
 
 export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): T {
@@ -38,14 +38,4 @@ function isRangeInsideCell(selection: Range, [, cellPath]: NodeEntry<Node>) {
         Path.isCommon(cellPath, selection.anchor.path) &&
         Path.isCommon(cellPath, selection.focus.path)
     );
-}
-
-function findParentCell(editor: TablesEditor, at: Location) {
-    for (const entry of Editor.levels(editor, { at })) {
-        if (editor.isTableCellNode(entry[0])) {
-            return entry;
-        }
-    }
-
-    return undefined;
 }

--- a/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
+++ b/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
@@ -12,19 +12,18 @@ export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): 
 
             if (cellEntry && isRangeInsideCell(editor.selection, cellEntry)) {
                 const [cell, cellPath] = cellEntry;
+                const { focus, anchor } = editor.selection;
 
-                const rangeRelativeToCell: Range = {
+                return Node.fragment(cell, {
                     anchor: {
-                        offset: editor.selection.anchor.offset,
-                        path: Path.relative(editor.selection.anchor.path, cellPath),
+                        offset: anchor.offset,
+                        path: Path.relative(anchor.path, cellPath),
                     },
                     focus: {
-                        offset: editor.selection.focus.offset,
-                        path: Path.relative(editor.selection.focus.path, cellPath),
+                        offset: focus.offset,
+                        path: Path.relative(focus.path, cellPath),
                     },
-                };
-
-                return Node.fragment(cell, rangeRelativeToCell);
+                });
             }
         }
 

--- a/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
+++ b/packages/slate-tables/src/core/withTablesCopyPasteBehavior.ts
@@ -1,6 +1,6 @@
 import { type Range, Node, Path } from 'slate';
 
-import { findParentCell, findParentTable } from '../queries';
+import { findParentCell } from '../queries';
 import type { TablesEditor } from '../TablesEditor';
 
 export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): T {
@@ -24,12 +24,6 @@ export function withTablesCopyPasteBehavior<T extends TablesEditor>(editor: T): 
                         path: Path.relative(focus.path, cellPath),
                     },
                 });
-            }
-
-            const tableEntry = findParentTable(editor);
-
-            if (tableEntry && isRangeInside(editor.selection, tableEntry[1])) {
-                return [tableEntry[0]];
             }
         }
 

--- a/packages/slate-tables/src/queries/findParentCell.ts
+++ b/packages/slate-tables/src/queries/findParentCell.ts
@@ -1,17 +1,15 @@
 import { type Location, type NodeEntry, type Selection, Editor } from 'slate';
 
-import type { TableNode } from '../nodes';
+import type { TableCellNode } from '../nodes';
 import type { TablesEditor } from '../TablesEditor';
 
-export function findParentTable<T extends TableNode>(
+export function findParentCell<T extends TableCellNode>(
     editor: TablesEditor,
     location: Location | Selection = editor.selection,
 ): NodeEntry<T> | undefined {
-    if (!location) {
-        return undefined;
-    }
+    if (!location) return undefined;
     for (const entry of Editor.levels(editor, { at: location })) {
-        if (editor.isTableNode(entry[0])) {
+        if (editor.isTableCellNode(entry[0])) {
             return entry as NodeEntry<T>;
         }
     }

--- a/packages/slate-tables/src/queries/findParentTable.ts
+++ b/packages/slate-tables/src/queries/findParentTable.ts
@@ -1,0 +1,21 @@
+import type { Location, NodeEntry } from 'slate';
+import { Editor } from 'slate';
+
+import type { TableNode } from '../nodes';
+import type { TablesEditor } from '../TablesEditor';
+
+export function findParentTable<T extends TableNode>(
+    editor: TablesEditor,
+    location: Location | null = editor.selection,
+): NodeEntry<T> | undefined {
+    if (!location) {
+        return undefined;
+    }
+    for (const entry of Editor.levels(editor, { at: location })) {
+        if (editor.isTableNode(entry[0])) {
+            return entry as NodeEntry<T>;
+        }
+    }
+
+    return undefined;
+}

--- a/packages/slate-tables/src/queries/index.ts
+++ b/packages/slate-tables/src/queries/index.ts
@@ -1,2 +1,3 @@
-export * from './isHeaderCell';
-export * from './isInTable';
+export { findParentTable } from './findParentTable';
+export { isHeaderCell } from './isHeaderCell';
+export { isInTable } from './isInTable';

--- a/packages/slate-tables/src/queries/index.ts
+++ b/packages/slate-tables/src/queries/index.ts
@@ -1,3 +1,4 @@
+export { findParentCell } from './findParentCell';
 export { findParentTable } from './findParentTable';
 export { isHeaderCell } from './isHeaderCell';
 export { isInTable } from './isInTable';


### PR DESCRIPTION
- Re-enable forgotten extension of `PasteSlateContent` (see #210) (improves pasting for tables)
- Changes to copy/cut/paste behaviour:
  - ~Copy the full table if multiple cells are selected~ (see [the discussion](https://github.com/prezly/slate/pull/257#discussion_r927127028))
  - Copy/cut the full table if selection is collapsed and the cursor is inside table cell
- Unbind `TablesExtension` from `ParagraphsExtension` -- it's no longer dependent on it directly