### PR TITLE
[MT-5203] Make the filtered results appear in a relevant order

### DIFF
--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { MENU_TRIGGER_CHARACTERS } from './isMenuHotkey';
 
 interface Option {
+    group: string;
     text: string;
     description?: string;
 }
@@ -27,5 +28,22 @@ export function useKeyboardFiltering<T extends Option>(input: string, options: T
 function filter<T extends Option>(options: T[], query: string): T[] {
     if (!query) return options;
 
-    return options.filter(({ text }) => text.toLowerCase().includes(query.toLowerCase()));
+    const lowercaseQuery = query.toLowerCase().trimStart();
+
+    const relevanceOrderedOptions = [
+        ...options.filter(({ text }) => ` ${text.toLowerCase()}`.includes(` ${lowercaseQuery}`)),
+        ...options.filter(({ text }) => text.toLowerCase().includes(lowercaseQuery)),
+    ];
+
+    return keepGroups(deduplicate(relevanceOrderedOptions));
+}
+
+function deduplicate<T>(items: T[]): T[] {
+    return items.filter((item, index, self) => self.indexOf(item) === index);
+}
+
+function keepGroups<T extends Option>(options: T[]): T[] {
+    const groups = deduplicate(options.map((option) => option.group));
+
+    return groups.flatMap((group) => options.filter((option) => option.group === group));
 }


### PR DESCRIPTION
Putting the "beginning of word" matches first.

Filtering for `vid` will now put `Video` before `Divider`.

![Screenshot from 2022-07-22 16-18-27](https://user-images.githubusercontent.com/370680/180447594-3276c56f-df1a-4572-8ea1-55b1a899f3e6.png)
