### PR TITLE
[MT-5219] Fix - Editor inserting empty block before cropped image

### DIFF
--- a/packages/slate-commons/src/selection/highest.test.ts
+++ b/packages/slate-commons/src/selection/highest.test.ts
@@ -6,20 +6,17 @@ describe('highest', function () {
         expect(highest([5])).toEqual([5]);
     });
 
-    it('should return top-level point value for a given point', function () {
-        expect(highest({ path: [2, 4, 5], offset: 10 })).toEqual({ path: [2], offset: 0 });
-        expect(highest({ path: [5], offset: 1 })).toEqual({ path: [5], offset: 0 });
+    it('should return top-level path value for a given point', function () {
+        expect(highest({ path: [2, 4, 5], offset: 10 })).toEqual([2]);
+        expect(highest({ path: [5], offset: 1 })).toEqual([5]);
     });
 
-    it('should return top-level range value for a given range', function () {
+    it('should return top-level focus point path for a given range', function () {
         expect(
             highest({
                 anchor: { path: [2, 4, 5], offset: 10 },
                 focus: { path: [5, 2], offset: 5 },
             }),
-        ).toEqual({
-            anchor: { path: [2], offset: 0 },
-            focus: { path: [5], offset: 0 },
-        });
+        ).toEqual([5]);
     });
 });

--- a/packages/slate-commons/src/selection/highest.ts
+++ b/packages/slate-commons/src/selection/highest.ts
@@ -2,17 +2,14 @@ import type { Location, Range } from 'slate';
 import { Path, Point } from 'slate';
 
 export function highest(selection: Path): Path;
-export function highest(selection: Point): Point;
-export function highest(selection: Range): Range;
-export function highest(selection: Location): Location {
+export function highest(selection: Point): Path;
+export function highest(selection: Range): Path;
+export function highest(selection: Location): Path {
     if (Path.isPath(selection)) {
         return selection.slice(0, 1) as Path;
     }
     if (Point.isPoint(selection)) {
-        return { path: highest(selection.path), offset: 0 };
+        return highest(selection.path);
     }
-    return {
-        anchor: highest(selection.anchor),
-        focus: highest(selection.focus),
-    };
+    return highest(selection.focus);
 }

--- a/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
+++ b/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
@@ -1,5 +1,5 @@
 import { EditorCommands } from '@prezly/slate-commons';
-import type { Editor, Element } from 'slate';
+import { type Element, Editor } from 'slate';
 import { Transforms } from 'slate';
 
 import { findLoaderPath, isLoaderElement } from '../lib';
@@ -12,15 +12,17 @@ export function replaceLoader(editor: Editor, loader: LoaderNode, element: Eleme
 
     const wasSelected = EditorCommands.isTopLevelNodeSelected(editor, loader);
 
-    Transforms.removeNodes(editor, {
-        at: loaderPath,
-        match: (node) => isLoaderElement(node) && node.id === loader.id,
-    });
+    Editor.withoutNormalizing(editor, () => {
+        Transforms.removeNodes(editor, {
+            at: loaderPath,
+            match: (node) => isLoaderElement(node) && node.id === loader.id,
+        });
 
-    Transforms.insertNodes(editor, element, {
-        at: loaderPath,
-        mode: 'highest',
-    });
+        Transforms.insertNodes(editor, element, {
+            at: loaderPath,
+            mode: 'highest',
+        });
 
-    if (wasSelected) Transforms.select(editor, loaderPath);
+        if (wasSelected) Transforms.select(editor, loaderPath);
+    });
 }


### PR DESCRIPTION
The problem was here:

https://github.com/prezly/slate/blob/550124c7101cf67446cbad2559b799a86428bc7c/packages/slate-editor/src/modules/editor/lib/images/createImageEditHandler.ts#L41-L44

It should have been inserting a new paragraph at the top-most `Path` location, but `Selection.highest()` returned a `Range` for `editor.selection`. So it was inserting a paragraph inside another block.

This glitch was compensated by the previous normalization implementation. But not anymore, after we've refactored the normalization logic.