### PR TITLE
[DEV-8696] Feature - Editor Imperative API to insert nodes programmatically

### DIFF
--- a/packages/slate-editor/src/extensions/press-contacts/components/FloatingPressContactsMenu.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/components/FloatingPressContactsMenu.tsx
@@ -18,7 +18,6 @@ interface Props {
     availableWidth: number;
     containerRef: RefObject<HTMLDivElement>;
     events: Events<EditorEventMap>;
-    newsroomSettingsUrl: string;
     renderSearch: (searchProps: SearchProps) => ReactNode;
     onClose: () => void;
     onRootClose: () => void;
@@ -32,7 +31,6 @@ function trackSearchUsed(editor: Editor) {
 export function FloatingPressContactsMenu({
     availableWidth,
     containerRef,
-    newsroomSettingsUrl,
     renderSearch,
     onClose,
     onRootClose,
@@ -60,7 +58,6 @@ export function FloatingPressContactsMenu({
             <FloatingContainer.Button className={styles.closeButton} onClick={onClose} open />
 
             {renderSearch({
-                newsroomSettingsUrl,
                 onChange: handleInputChange,
                 onSubmit,
             })}

--- a/packages/slate-editor/src/extensions/press-contacts/components/FloatingPressContactsMenu.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/components/FloatingPressContactsMenu.tsx
@@ -59,6 +59,7 @@ export function FloatingPressContactsMenu({
 
             {renderSearch({
                 onChange: handleInputChange,
+                onClose,
                 onSubmit,
             })}
         </FloatingContainer.Container>

--- a/packages/slate-editor/src/extensions/press-contacts/components/PressContactElement.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/components/PressContactElement.tsx
@@ -58,7 +58,11 @@ export function PressContactElement({ attributes, children, element }: Props) {
 export function JobDescription(props: { className?: string; contact: PressContact }) {
     const { description, company } = props.contact;
     // If there is not text to show, render an empty <div> to keep height consistent.
-    const text = [description, company].filter(Boolean).join(', ') || <>&nbsp;</>;
+    const text = [description, company].filter(Boolean).join(', ').trim();
+
+    if (!text) {
+        return null;
+    }
 
     return <div className={classNames(styles.jobDescription, props.className)}>{text}</div>;
 }

--- a/packages/slate-editor/src/extensions/press-contacts/types.ts
+++ b/packages/slate-editor/src/extensions/press-contacts/types.ts
@@ -7,5 +7,6 @@ export interface PressContactsExtensionParameters {
 
 export interface SearchProps {
     onChange: (query: string) => void;
+    onClose: () => void;
     onSubmit: (contact: PressContact) => void;
 }

--- a/packages/slate-editor/src/extensions/press-contacts/types.ts
+++ b/packages/slate-editor/src/extensions/press-contacts/types.ts
@@ -2,12 +2,10 @@ import type { PressContact } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 
 export interface PressContactsExtensionParameters {
-    newsroomSettingsUrl: string;
     renderSearch: (searchProps: SearchProps) => ReactNode;
 }
 
 export interface SearchProps {
-    newsroomSettingsUrl: string;
     onChange: (query: string) => void;
     onSubmit: (contact: PressContact) => void;
 }

--- a/packages/slate-editor/src/index.ts
+++ b/packages/slate-editor/src/index.ts
@@ -13,6 +13,7 @@ export { type SearchProps as CoverageSearchProps, createCoverage } from './exten
 export { createEmbed } from './extensions/embed';
 export {
     type SearchProps as PressContactsSearchProps,
+    createPressContact,
     JobDescription,
 } from './extensions/press-contacts';
 export type { User } from './extensions/user-mentions';

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -585,7 +585,6 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
                         availableWidth={availableWidth}
                         containerRef={containerRef}
                         events={events}
-                        newsroomSettingsUrl={withPressContacts.newsroomSettingsUrl}
                         onClose={closeFloatingPressContactsMenu}
                         onRootClose={rootCloseFloatingPressContactsMenu}
                         onSubmit={submitFloatingPressContactsMenu}

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -23,7 +23,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import { type Element, Transforms } from 'slate';
+import type { Element } from 'slate';
 import { ReactEditor, Slate } from 'slate-react';
 
 import { useFunction, useSize } from '#lib';
@@ -187,7 +187,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             events,
             focus: () => EditorCommands.focus(editor),
             clearSelection: () => EditorCommands.resetSelection(editor),
-            insertNodes: (nodes) => Transforms.insertNodes(editor, nodes),
+            insertNodes: (nodes, options) => EditorCommands.insertNodes(editor, nodes, options),
             isEmpty: () => EditorCommands.isEmpty(editor),
             isEqualTo: (value) => isEditorValueEqual(editor, value, editor.children as Value),
             isFocused: () => ReactEditor.isFocused(editor),

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -2,8 +2,10 @@
 import { Events } from '@prezly/events';
 import { EditorCommands } from '@prezly/slate-commons';
 import { TablesEditor } from '@prezly/slate-tables';
-import type { HeadingNode, ParagraphNode, QuoteNode } from '@prezly/slate-types';
 import {
+    type HeadingNode,
+    type ParagraphNode,
+    type QuoteNode,
     Alignment,
     HEADING_1_NODE_TYPE,
     HEADING_2_NODE_TYPE,
@@ -21,7 +23,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import type { Element } from 'slate';
+import { type Element, Transforms } from 'slate';
 import { ReactEditor, Slate } from 'slate-react';
 
 import { useFunction, useSize } from '#lib';
@@ -185,6 +187,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             events,
             focus: () => EditorCommands.focus(editor),
             clearSelection: () => EditorCommands.resetSelection(editor),
+            insertNodes: (nodes) => Transforms.insertNodes(editor, nodes),
             isEmpty: () => EditorCommands.isEmpty(editor),
             isEqualTo: (value) => isEditorValueEqual(editor, value, editor.children as Value),
             isFocused: () => ReactEditor.isFocused(editor),

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -51,7 +51,6 @@ export function getAllExtensions() {
                 ],
             },
             withPressContacts: {
-                newsroomSettingsUrl: '',
                 renderSearch: () => null,
             },
             withStoryBookmarks: {

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -2,7 +2,7 @@ import type { Events } from '@prezly/events';
 import type { Decorate } from '@prezly/slate-commons';
 import type { Alignment } from '@prezly/slate-types';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
-import type { Editor, Element } from 'slate';
+import type { Editor, Element, Node } from 'slate';
 
 import type { AutoformatParameters } from '#extensions/autoformat';
 import type { CoverageExtensionConfiguration } from '#extensions/coverage';
@@ -25,6 +25,7 @@ export interface EditorRef {
     events: Events<EditorEventMap>;
     focus: () => void;
     clearSelection: () => void;
+    insertNodes: (nodes: Node[]) => void;
     isEmpty: () => boolean;
     isEqualTo: (value: Value) => void;
     isFocused: () => boolean;

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -1,6 +1,5 @@
 import type { Events } from '@prezly/events';
-import type { Decorate } from '@prezly/slate-commons';
-import type { EditorCommands } from '@prezly/slate-commons';
+import type { Decorate, EditorCommands } from '@prezly/slate-commons';
 import type { Alignment } from '@prezly/slate-types';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import type { Editor, Element, Node } from 'slate';

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -1,5 +1,6 @@
 import type { Events } from '@prezly/events';
 import type { Decorate } from '@prezly/slate-commons';
+import type { EditorCommands } from '@prezly/slate-commons';
 import type { Alignment } from '@prezly/slate-types';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import type { Editor, Element, Node } from 'slate';
@@ -25,7 +26,10 @@ export interface EditorRef {
     events: Events<EditorEventMap>;
     focus: () => void;
     clearSelection: () => void;
-    insertNodes: (nodes: Node[]) => void;
+    insertNodes: (
+        nodes: Node[],
+        options?: Parameters<typeof EditorCommands.insertNodes>[2],
+    ) => void;
     isEmpty: () => boolean;
     isEqualTo: (value: Value) => void;
     isFocused: () => boolean;


### PR DESCRIPTION
- Provide an additional imperative API method: `insertNodes()`
- Tweak ContactNode card rendering: do not render description block if it's empty
- Drop `newsroomSettingsUrl` prop from all components
- Additionally pass `onClose` to `renderSearch`