### PR TITLE
[DEV-8694] Feature - Editor imperative API to update nodes

### DIFF
--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -24,6 +24,7 @@ import React, {
     useState,
 } from 'react';
 import type { Element } from 'slate';
+import { Transforms } from 'slate';
 import { ReactEditor, Slate } from 'slate-react';
 
 import { useFunction, useSize } from '#lib';
@@ -188,6 +189,13 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             focus: () => EditorCommands.focus(editor),
             clearSelection: () => EditorCommands.resetSelection(editor),
             insertNodes: (nodes, options) => EditorCommands.insertNodes(editor, nodes, options),
+            updateNodes: (props, options = {}) => {
+                Transforms.setNodes(
+                    editor,
+                    props,
+                    options.match ? { at: [], ...options } : options,
+                );
+            },
             isEmpty: () => EditorCommands.isEmpty(editor),
             isEqualTo: (value) => isEditorValueEqual(editor, value, editor.children as Value),
             isFocused: () => ReactEditor.isFocused(editor),

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -3,6 +3,7 @@ import type { Decorate, EditorCommands } from '@prezly/slate-commons';
 import type { Alignment } from '@prezly/slate-types';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import type { Editor, Element, Node } from 'slate';
+import type { Transforms } from 'slate';
 
 import type { AutoformatParameters } from '#extensions/autoformat';
 import type { CoverageExtensionConfiguration } from '#extensions/coverage';
@@ -28,6 +29,10 @@ export interface EditorRef {
     insertNodes: (
         nodes: Node[],
         options?: Parameters<typeof EditorCommands.insertNodes>[2],
+    ) => void;
+    updateNodes: <T extends Node>(
+        props: Partial<Omit<T, 'children' | 'text'>>,
+        options?: Parameters<typeof Transforms.setNodes<T>>[2],
     ) => void;
     isEmpty: () => boolean;
     isEqualTo: (value: Value) => void;


### PR DESCRIPTION
- Introduce one more imperative method: `updateNodes()`
  Which is a proxy to `Transforms.setNodes()`