### PR TITLE
Dev - Fix "Go to definition" functionality

### DIFF
--- a/packages/slate-commons/tsconfig.build.json
+++ b/packages/slate-commons/tsconfig.build.json
@@ -2,7 +2,9 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "es6",
-        "target": "es6"
+        "target": "es6",
+        "rootDir": "./src",
+        "paths": {}
     },
     "exclude": ["node_modules", "**/*.test.*", "**/jsx.ts", "**/test-utils.ts"],
 }

--- a/packages/slate-commons/tsconfig.json
+++ b/packages/slate-commons/tsconfig.json
@@ -4,7 +4,11 @@
         "noEmit": false,
         "emitDeclarationOnly": true,
         "declarationDir": "./build/types",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "baseUrl": ".",
+        "paths": {
+            "@prezly/slate-types": ["../slate-types/src"]
+        }
     },
     "include": ["./src"],
     "exclude": ["node_modules"],

--- a/packages/slate-editor/src/lib/hooks/react-use.ts
+++ b/packages/slate-editor/src/lib/hooks/react-use.ts
@@ -27,30 +27,15 @@ function unwrap<T>(module: T | { __esModule: boolean; default: T }): T {
     return module;
 }
 
-const useAsyncFn = unwrap(_useAsyncFn);
-const useDebounce = unwrap(_useDebounce);
-const useEffectOnce = unwrap(_useEffectOnce);
-const useLatest = unwrap(_useLatest);
-const useMount = unwrap(_useMount);
-const useMountedState = unwrap(_useMountedState);
-const usePrevious = unwrap(_usePrevious);
-const useRafLoop = unwrap(_useRafLoop);
-const useSize = unwrap(_useSize);
-const useUnmount = unwrap(_useUnmount);
-const useUpdate = unwrap(_useUpdate);
-const useUpdateEffect = unwrap(_useUpdateEffect);
-
-export {
-    useAsyncFn,
-    useDebounce,
-    useEffectOnce,
-    useLatest,
-    useMount,
-    useMountedState,
-    usePrevious,
-    useRafLoop,
-    useSize,
-    useUnmount,
-    useUpdate,
-    useUpdateEffect,
-};
+export const useAsyncFn = unwrap(_useAsyncFn);
+export const useDebounce = unwrap(_useDebounce);
+export const useEffectOnce = unwrap(_useEffectOnce);
+export const useLatest = unwrap(_useLatest);
+export const useMount = unwrap(_useMount);
+export const useMountedState = unwrap(_useMountedState);
+export const usePrevious = unwrap(_usePrevious);
+export const useRafLoop = unwrap(_useRafLoop);
+export const useSize = unwrap(_useSize);
+export const useUnmount = unwrap(_useUnmount);
+export const useUpdate = unwrap(_useUpdate);
+export const useUpdateEffect = unwrap(_useUpdateEffect);

--- a/packages/slate-editor/tsconfig.build.json
+++ b/packages/slate-editor/tsconfig.build.json
@@ -3,7 +3,15 @@
     "compilerOptions": {
         "module": "ES6",
         "target": "ES6",
-        "rootDirs": ["./src", "./.css-modules"]
+        "rootDirs": ["./src", "./.css-modules"],
+        "paths": {
+            "#components": ["src/components"],
+            "#extensions/*": ["src/extensions/*"],
+            "#icons": ["src/icons"],
+            "#lib/type-utils": ["src/lib/type-utils"],
+            "#lib": ["src/lib"],
+            "#modules/*": ["src/modules/*"]
+        }
     },
     "exclude": ["node_modules", "**/*.test.*", "**/jsx.ts", "**/test-utils.ts"],
 }

--- a/packages/slate-editor/tsconfig.json
+++ b/packages/slate-editor/tsconfig.json
@@ -2,14 +2,18 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "rootDirs": ["./src", "./.css-modules"],
-        "baseUrl": "./src",
+        "baseUrl": "./",
         "paths": {
-            "#components": ["components"],
-            "#extensions/*": ["extensions/*"],
-            "#icons": ["icons"],
-            "#lib/type-utils": ["lib/type-utils"],
-            "#lib": ["lib"],
-            "#modules/*": ["modules/*"]
+            "@prezly/slate-types": ["../slate-types/src"],
+            "@prezly/slate-commons": ["../slate-commons/src"],
+            "@prezly/slate-lists": ["../slate-lists/src"],
+            "@prezly/slate-tables": ["../slate-tables/src"],
+            "#components": ["src/components"],
+            "#extensions/*": ["src/extensions/*"],
+            "#icons": ["src/icons"],
+            "#lib/type-utils": ["src/lib/type-utils"],
+            "#lib": ["src/lib"],
+            "#modules/*": ["src/modules/*"]
         },
         "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./src/@types"]
     },

--- a/packages/slate-tables/tsconfig.build.json
+++ b/packages/slate-tables/tsconfig.build.json
@@ -2,7 +2,9 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "es6",
-        "target": "es6"
+        "target": "es6",
+        "rootDir": "./src",
+        "paths": {}
     },
     "exclude": ["node_modules", "**/*.test.*", "**/jsx.ts"]
 }

--- a/packages/slate-tables/tsconfig.json
+++ b/packages/slate-tables/tsconfig.json
@@ -4,7 +4,10 @@
         "noEmit": false,
         "emitDeclarationOnly": true,
         "declarationDir": "./build/types",
-        "rootDir": "./src",
+        "baseUrl": ".",
+        "paths": {
+            "@prezly/slate-commons": ["../slate-commons/src"]
+        }
     },
     "include": ["./src"],
     "exclude": ["node_modules"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
+        "rootDir": "./packages",
         /**
          * I have to disable lib check as `react-use` codebase is incompatible with the latest Typescript.
          * And the library author doesn't seem to be spending time on accepting PRs.


### PR DESCRIPTION
I had this recurring problem, where after clicking on a Typescript interface from a sibling package, my IDE was opening the target file from `node_modules`, not from a sibling `packages` folder.

These configuration changes fix that.