### PR TITLE
[DEV-8850] Minimal forward-compatibility with `variable` node types

### DIFF
--- a/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/PlaceholderMentionsExtension.tsx
@@ -5,7 +5,11 @@ import type { RenderElementProps } from 'slate-react';
 
 import { MentionElement, MentionsExtension } from '#extensions/mentions';
 
-import { normalizeRedundantPlaceholderMentionAttributes, parseSerializedElement } from './lib';
+import {
+    convertVariableNodesToPlaceholders,
+    parseSerializedElement,
+    normalizeRedundantPlaceholderMentionAttributes,
+} from './lib';
 
 export const EXTENSION_ID = 'PlaceholderMentionsExtension';
 
@@ -13,7 +17,10 @@ export const PlaceholderMentionsExtension = (): Extension =>
     MentionsExtension({
         id: EXTENSION_ID,
         type: PLACEHOLDER_NODE_TYPE,
-        normalizeNode: normalizeRedundantPlaceholderMentionAttributes,
+        normalizeNode: [
+            convertVariableNodesToPlaceholders,
+            normalizeRedundantPlaceholderMentionAttributes,
+        ],
         parseSerializedElement,
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
             if (isPlaceholderNode(element)) {

--- a/packages/slate-editor/src/extensions/placeholder-mentions/jsx.ts
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/jsx.ts
@@ -7,12 +7,9 @@ import { createHyperscript, createText } from 'slate-hyperscript';
 declare global {
     namespace JSX {
         interface IntrinsicElements {
-            'h-p': {
+            [name: string]: {
                 children?: ReactNode;
-            };
-            'h-placeholder-mention': {
-                children?: ReactNode;
-                key: string;
+                [prop: string]: any;
             };
         }
     }
@@ -20,10 +17,11 @@ declare global {
 
 export const jsx = createHyperscript({
     elements: {
-        'h-p': { type: PARAGRAPH_NODE_TYPE },
-        'h-placeholder-mention': { type: PLACEHOLDER_NODE_TYPE },
+        'h:paragraph': { type: PARAGRAPH_NODE_TYPE },
+        'h:placeholder': { type: PLACEHOLDER_NODE_TYPE },
+        'h:variable': { type: 'variable' },
     },
     creators: {
-        'h-text': createText,
+        'h:text': createText,
     },
 });

--- a/packages/slate-editor/src/extensions/placeholder-mentions/lib/convertVariableNodesToPlaceholders.ts
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/lib/convertVariableNodesToPlaceholders.ts
@@ -1,0 +1,16 @@
+import { isElementNode, PLACEHOLDER_NODE_TYPE } from '@prezly/slate-types';
+import { type Editor, type NodeEntry, Transforms } from 'slate';
+
+/**
+ * @deprecated
+ */
+const VARIABLE_NODE_TYPE = 'variable';
+
+export function convertVariableNodesToPlaceholders(editor: Editor, [node, path]: NodeEntry) {
+    if (isElementNode(node, VARIABLE_NODE_TYPE)) {
+        Transforms.setNodes(editor, { type: PLACEHOLDER_NODE_TYPE }, { at: path });
+        return true;
+    }
+
+    return false;
+}

--- a/packages/slate-editor/src/extensions/placeholder-mentions/lib/index.ts
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/lib/index.ts
@@ -1,3 +1,4 @@
+export { convertVariableNodesToPlaceholders } from './convertVariableNodesToPlaceholders';
 export { createPlaceholderMention } from './createPlaceholderMention';
 export { normalizeRedundantPlaceholderMentionAttributes } from './normalizeRedundantPlaceholderMentionAttributes';
 export { parseSerializedElement } from './parseSerializedElement';

--- a/packages/slate-editor/src/extensions/placeholder-mentions/normalization.test.tsx
+++ b/packages/slate-editor/src/extensions/placeholder-mentions/normalization.test.tsx
@@ -1,0 +1,104 @@
+/** @jsx jsx */
+
+import type { NodeEntry } from 'slate';
+import { Editor } from 'slate';
+
+import { jsx } from './jsx';
+import {
+    convertVariableNodesToPlaceholders,
+    normalizeRedundantPlaceholderMentionAttributes,
+} from './lib';
+
+const normalizations = [
+    convertVariableNodesToPlaceholders,
+    normalizeRedundantPlaceholderMentionAttributes,
+];
+
+function normalizeNode(editor: Editor, entry: NodeEntry) {
+    for (const normalization of normalizations) {
+        if (normalization(editor, entry)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+describe('PlaceholderMentionsExtension', () => {
+    describe('convertVariableNodesToPlaceholders', () => {
+        it('should convert future `variable` nodes to `placeholder` nodes', () => {
+            const editor = (
+                <editor>
+                    <h:paragraph>
+                        <h:text>Hello, </h:text>
+                        <h:variable key="contact.firstname">
+                            <h:text>%contact.firstname%</h:text>
+                        </h:variable>
+                        <h:variable key="contact.lastname">
+                            <h:text>%contact.lastname%</h:text>
+                        </h:variable>
+                        <h:text>!</h:text>
+                    </h:paragraph>
+                </editor>
+            ) as unknown as Editor;
+
+            const expected = (
+                <editor>
+                    <h:paragraph>
+                        <h:text>Hello, </h:text>
+                        <h:placeholder key="contact.firstname">
+                            <h:text>%contact.firstname%</h:text>
+                        </h:placeholder>
+                        <h:placeholder key="contact.lastname">
+                            <h:text>%contact.lastname%</h:text>
+                        </h:placeholder>
+                        <h:text>!</h:text>
+                    </h:paragraph>
+                </editor>
+            ) as unknown as Editor;
+
+            editor.normalizeNode = function (entry) {
+                normalizeNode(editor, entry);
+            };
+
+            Editor.normalize(editor, { force: true });
+
+            expect(editor.children).toEqual(expected.children);
+        });
+    });
+
+    describe('removeUnknownPlaceholderMentionAttributes', () => {
+        it('should remove unsupported placeholder node attributes', () => {
+            const editor = (
+                <editor>
+                    <h:paragraph>
+                        <h:text>Hello, </h:text>
+                        <h:placeholder key="contact.firstname" bold={true} style="green">
+                            <h:text>%contact.firstname%</h:text>
+                        </h:placeholder>
+                        <h:text>!</h:text>
+                    </h:paragraph>
+                </editor>
+            ) as unknown as Editor;
+
+            const expected = (
+                <editor>
+                    <h:paragraph>
+                        <h:text>Hello, </h:text>
+                        <h:placeholder key="contact.firstname">
+                            <h:text>%contact.firstname%</h:text>
+                        </h:placeholder>
+                        <h:text>!</h:text>
+                    </h:paragraph>
+                </editor>
+            ) as unknown as Editor;
+
+            editor.normalizeNode = function (entry) {
+                normalizeNode(editor, entry);
+            };
+
+            Editor.normalize(editor, { force: true });
+
+            expect(editor.children).toEqual(expected.children);
+        });
+    });
+});


### PR DESCRIPTION
A pre-deployment patch to properly roll out #298 

Just making sure the editor won't crash if it opens a document with `variable` type used in a Node.

With this change, `variable` node type will be automatically converted back to `placeholder`. Not ideal, but better than crashing the editor.