### PR TITLE
[DEV-8914] Fix - File dropping in Chrome

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/elements/AttachmentPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/AttachmentPlaceholderElement.tsx
@@ -57,6 +57,8 @@ export function AttachmentPlaceholderElement({ children, element, ...props }: Pr
     });
 
     const handleDrop = useFunction<DragEventHandler>((event) => {
+        event.preventDefault();
+        event.stopPropagation();
         const files = Array.from(event.dataTransfer.files).map((file) =>
             uploadcare.fileFrom('object', file),
         );

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryPlaceholderElement.tsx
@@ -68,6 +68,8 @@ export function GalleryPlaceholderElement({ children, element, ...props }: Props
     });
 
     const handleDrop = useFunction<DragEventHandler>((event) => {
+        event.preventDefault();
+        event.stopPropagation();
         const images = Array.from(event.dataTransfer.files)
             .filter((file) => IMAGE_TYPES.includes(file.type))
             .map((file) => uploadcare.fileFrom('object', file));

--- a/packages/slate-editor/src/extensions/placeholders/elements/ImagePlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ImagePlaceholderElement.tsx
@@ -58,6 +58,8 @@ export function ImagePlaceholderElement({ children, element, ...props }: Props) 
     });
 
     const handleDrop = useFunction<DragEventHandler>((event) => {
+        event.preventDefault();
+        event.stopPropagation();
         const images = Array.from(event.dataTransfer.files)
             .filter((file) => IMAGE_TYPES.includes(file.type))
             .map((file) => uploadcare.fileFrom('object', file));


### PR DESCRIPTION
Previously, the file drop events have been handled on multiple levels -- in the Placeholders and on the Editor level.
Resulting in Image being pasted twice.