### PR TITLE
Export createPlaceholder function

### DIFF
--- a/packages/slate-editor/src/index.ts
+++ b/packages/slate-editor/src/index.ts
@@ -11,7 +11,7 @@ export { EditableWithExtensions } from './modules/editable';
 
 export { type SearchProps as CoverageSearchProps, createCoverage } from './extensions/coverage';
 export { createEmbed } from './extensions/embed';
-export { type PlaceholdersExtensionParameters, PlaceholderNode } from './extensions/placeholders';
+export { type PlaceholdersExtensionParameters, createPlaceholder, PlaceholderNode } from './extensions/placeholders';
 export {
     type SearchProps as PressContactsSearchProps,
     createPressContact,

--- a/packages/slate-editor/src/index.ts
+++ b/packages/slate-editor/src/index.ts
@@ -11,7 +11,11 @@ export { EditableWithExtensions } from './modules/editable';
 
 export { type SearchProps as CoverageSearchProps, createCoverage } from './extensions/coverage';
 export { createEmbed } from './extensions/embed';
-export { type PlaceholdersExtensionParameters, createPlaceholder, PlaceholderNode } from './extensions/placeholders';
+export {
+    type PlaceholdersExtensionParameters,
+    createPlaceholder,
+    PlaceholderNode,
+} from './extensions/placeholders';
 export {
     type SearchProps as PressContactsSearchProps,
     createPressContact,


### PR DESCRIPTION
Export `createPlaceholder` function so we can create an empty editor value with placeholder prefilled, [see example here](https://github.com/prezly/prezly/blob/023cb4a08f6403900eb3f7c44b62d364926d3b56/apps/backend/resources/javascripts/modules/editors/lib/createEditorValueWithGalleryPlaceholderAsString.ts).