### PR TITLE
Fix - Improve behaviour of image/gallery blocks

### DIFF
--- a/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
+++ b/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
@@ -1,16 +1,13 @@
-import { EditorCommands } from '@prezly/slate-commons';
 import { type Element, Editor } from 'slate';
 import { Transforms } from 'slate';
 
 import { findLoaderPath, isLoaderElement } from '../lib';
 import type { LoaderNode } from '../types';
 
-export function replaceLoader(editor: Editor, loader: LoaderNode, element: Element): void {
+export function replaceLoader(editor: Editor, loader: LoaderNode, element: Element, shouldFocus = true): void {
     const loaderPath = findLoaderPath(editor, loader.id);
 
     if (!loaderPath) return;
-
-    const wasSelected = EditorCommands.isTopLevelNodeSelected(editor, loader);
 
     Editor.withoutNormalizing(editor, () => {
         Transforms.removeNodes(editor, {
@@ -23,6 +20,8 @@ export function replaceLoader(editor: Editor, loader: LoaderNode, element: Eleme
             mode: 'highest',
         });
 
-        if (wasSelected) Transforms.select(editor, loaderPath);
+        if (shouldFocus) {
+            Transforms.select(editor, loaderPath);
+        }
     });
 }

--- a/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
+++ b/packages/slate-editor/src/extensions/loader/transforms/replaceLoader.ts
@@ -4,7 +4,12 @@ import { Transforms } from 'slate';
 import { findLoaderPath, isLoaderElement } from '../lib';
 import type { LoaderNode } from '../types';
 
-export function replaceLoader(editor: Editor, loader: LoaderNode, element: Element, shouldFocus = true): void {
+export function replaceLoader(
+    editor: Editor,
+    loader: LoaderNode,
+    element: Element,
+    shouldFocus = true,
+): void {
     const loaderPath = findLoaderPath(editor, loader.id);
 
     if (!loaderPath) return;

--- a/packages/slate-editor/src/modules/editor/lib/file-attachment/handleAddAttachment.ts
+++ b/packages/slate-editor/src/modules/editor/lib/file-attachment/handleAddAttachment.ts
@@ -26,7 +26,6 @@ export async function handleAddAttachment(editor: Editor) {
                 const caption: string = fileInfo[UPLOADCARE_FILE_DATA_KEY]?.caption || '';
                 return createFileAttachment(file.toPrezlyStoragePayload(), caption);
             },
-            ensureEmptyParagraphAfter: true,
             filePromise: toProgressPromise(filePromise),
             loaderContentType: LoaderContentType.ATTACHMENT,
             loaderMessage: 'Uploading Attachment',

--- a/packages/slate-editor/src/modules/editor/lib/galleries/createHandleAddGallery.ts
+++ b/packages/slate-editor/src/modules/editor/lib/galleries/createHandleAddGallery.ts
@@ -37,7 +37,6 @@ export function createHandleAddGallery(config: GalleriesExtensionConfiguration) 
                 });
                 return createGallery({ images });
             },
-            ensureEmptyParagraphAfter: true,
             filePromise: awaitUploads(filePromises).then(({ failedUploads, successfulUploads }) => {
                 failedUploads.forEach((error) => {
                     EventsEditor.dispatchEvent(editor, 'error', error);

--- a/packages/slate-editor/src/modules/editor/lib/galleries/createHandleEditGallery.ts
+++ b/packages/slate-editor/src/modules/editor/lib/galleries/createHandleEditGallery.ts
@@ -1,10 +1,9 @@
-import { EditorCommands } from '@prezly/slate-commons';
 import type { PrezlyFileInfo } from '@prezly/uploadcare';
 import { awaitUploads, UPLOADCARE_FILE_DATA_KEY, UploadcareImage } from '@prezly/uploadcare';
 import type { Editor } from 'slate';
 
 import type { GalleriesExtensionConfiguration } from '#extensions/galleries';
-import { createGallery, getCurrentGalleryNodeEntry, removeGallery } from '#extensions/galleries';
+import { createGallery, getCurrentGalleryNodeEntry } from '#extensions/galleries';
 import { LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';
 import { UploadcareEditor } from '#modules/uploadcare';
@@ -41,9 +40,6 @@ export function createHandleEditGallery(config: GalleriesExtensionConfiguration)
             return;
         }
 
-        removeGallery(editor);
-        EditorCommands.insertEmptyParagraph(editor);
-
         await insertUploadingFile<PrezlyFileInfo[]>(editor, {
             createElement: (fileInfos) => {
                 const images = fileInfos.map((fileInfo) => {
@@ -55,7 +51,6 @@ export function createHandleEditGallery(config: GalleriesExtensionConfiguration)
                 });
                 return createGallery({ ...gallery, images });
             },
-            ensureEmptyParagraphAfter: true,
             filePromise: awaitUploads(filePromises).then(({ failedUploads, successfulUploads }) => {
                 failedUploads.forEach((error) => {
                     EventsEditor.dispatchEvent(editor, 'error', error);

--- a/packages/slate-editor/src/modules/editor/lib/images/createImageAddHandler.ts
+++ b/packages/slate-editor/src/modules/editor/lib/images/createImageAddHandler.ts
@@ -36,7 +36,6 @@ export function createImageAddHandler(params: ImageExtensionConfiguration) {
                             children: [{ text: caption }],
                         });
                     },
-                    ensureEmptyParagraphAfter: true,
                     filePromise: toProgressPromise(filePromise),
                     loaderContentType: LoaderContentType.IMAGE,
                     loaderMessage: 'Uploading Image',

--- a/packages/slate-editor/src/modules/editor/lib/images/createImageEditHandler.ts
+++ b/packages/slate-editor/src/modules/editor/lib/images/createImageEditHandler.ts
@@ -1,10 +1,9 @@
-import { EditorCommands, Selection } from '@prezly/slate-commons';
 import type { PrezlyFileInfo } from '@prezly/uploadcare';
 import { toProgressPromise, UPLOADCARE_FILE_DATA_KEY, UploadcareImage } from '@prezly/uploadcare';
 import { Editor } from 'slate';
 
 import type { ImageExtensionConfiguration } from '#extensions/image';
-import { createImage, getCurrentImageNodeEntry, removeImage } from '#extensions/image';
+import { createImage, getCurrentImageNodeEntry } from '#extensions/image';
 import { LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';
 import { UploadcareEditor } from '#modules/uploadcare';
@@ -37,12 +36,6 @@ export function createImageEditHandler(params: ImageExtensionConfiguration) {
             return;
         }
 
-        removeImage(editor);
-        EditorCommands.insertEmptyParagraph(editor, {
-            at: editor.selection ? Selection.highest(editor.selection) : undefined,
-            select: true,
-        });
-
         const imageFileInfo = await insertUploadingFile<PrezlyFileInfo>(editor, {
             createElement(fileInfo) {
                 const image = UploadcareImage.createFromUploadcareWidgetPayload(fileInfo);
@@ -56,7 +49,6 @@ export function createImageEditHandler(params: ImageExtensionConfiguration) {
                     width: imageElement.width,
                 });
             },
-            ensureEmptyParagraphAfter: false,
             filePromise: toProgressPromise(filePromises[0]),
             loaderContentType: LoaderContentType.IMAGE,
             loaderMessage: 'Uploading Image',

--- a/packages/slate-editor/src/modules/editor/lib/images/createImageReplaceHandler.ts
+++ b/packages/slate-editor/src/modules/editor/lib/images/createImageReplaceHandler.ts
@@ -1,10 +1,9 @@
-import { EditorCommands, Selection } from '@prezly/slate-commons';
 import type { PrezlyFileInfo } from '@prezly/uploadcare';
 import { toProgressPromise, UPLOADCARE_FILE_DATA_KEY, UploadcareImage } from '@prezly/uploadcare';
 import type { Editor } from 'slate';
 
 import type { ImageExtensionConfiguration } from '#extensions/image';
-import { createImage, getCurrentImageNodeEntry, removeImage } from '#extensions/image';
+import { createImage, getCurrentImageNodeEntry } from '#extensions/image';
 import { LoaderContentType } from '#extensions/loader';
 import { EventsEditor } from '#modules/events';
 import { UploadcareEditor } from '#modules/uploadcare';
@@ -34,12 +33,6 @@ export function createImageReplaceHandler(params: ImageExtensionConfiguration) {
             return;
         }
 
-        removeImage(editor);
-        EditorCommands.insertEmptyParagraph(editor, {
-            at: editor.selection ? Selection.highest(editor.selection) : undefined,
-            select: true,
-        });
-
         const imageFileInfo = await insertUploadingFile<PrezlyFileInfo>(editor, {
             createElement(fileInfo) {
                 const image = UploadcareImage.createFromUploadcareWidgetPayload(fileInfo);
@@ -53,7 +46,6 @@ export function createImageReplaceHandler(params: ImageExtensionConfiguration) {
                     width: imageElement.width,
                 });
             },
-            ensureEmptyParagraphAfter: false,
             filePromise: toProgressPromise(filePromises[0]),
             loaderContentType: LoaderContentType.IMAGE,
             loaderMessage: 'Uploading Image',

--- a/packages/slate-editor/src/modules/editor/lib/insertUploadingFile.ts
+++ b/packages/slate-editor/src/modules/editor/lib/insertUploadingFile.ts
@@ -1,6 +1,6 @@
 import type { ProgressPromise } from '@prezly/progress-promise';
 import { EditorCommands } from '@prezly/slate-commons';
-import type { Editor, Element} from 'slate';
+import type { Editor, Element } from 'slate';
 import { Transforms } from 'slate';
 
 import type { LoaderContentType } from '#extensions/loader';
@@ -44,8 +44,8 @@ export async function insertUploadingFile<T>(
     if (mode === 'insert') {
         EditorCommands.insertNodes(editor, [loader], { ensureEmptyParagraphAfter: true });
     }
-    
-    if (mode ==='replace') {
+
+    if (mode === 'replace') {
         Transforms.setNodes(editor, loader);
     }
 

--- a/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withFilePasting.ts
@@ -102,12 +102,12 @@ export function withFilePasting(getExtensions: () => Extension[]) {
                             UploadcareFile.createFromUploadcareWidgetPayload(fileInfo);
                         return createFileAttachment(attachment.toPrezlyStoragePayload(), caption);
                     },
-                    ensureEmptyParagraphAfter: true,
                     filePromise: toProgressPromise(uploadcare.fileFrom('object', file)),
                     loaderContentType: isImage
                         ? LoaderContentType.IMAGE
                         : LoaderContentType.ATTACHMENT,
                     loaderMessage: isImage ? 'Uploading Image' : 'Uploading Attachment',
+                    mode: 'insert',
                 });
 
                 if (!uploadedFileInfo) {


### PR DESCRIPTION
When editing an image or a gallery, the original element is removed first, replaced by an empty paragraph, then replaced by the loader element and then replaced by the actual element.

This makes it fairly difficult to use the new `AllowedBlocks` extension because when you edit a gallery/image, for a brief moment the original element will be replaced by a paragraph. If you don't allow paragraphs, it will replace it with a custom block, which is not the desired outcome.

With these changes, when editing, the element is not removed and there's no paragraph used as an intermediary medium. Instead the element is replaced by a loader which is then replaced by the actual updated element.

There's a new `mode` option that affects whether to use replace or simply insert nodes as in some cases (e.g. `withFilePasting`) we don't want to actually replace the nodes but insert new ones.

I have tested the new behaviour and everything seems to work the same as it currently does in production.

Thanks to these changes I was also able to fix two bugs:
1. when you edited a gallery, it would place an empty paragraph above the gallery. That doesn't seem useful.
2. when you edited a gallery, it would focus the empty paragraph below it instead of keeping the focus on the gallery (that's how it works for images)

We still create a new paragraph below the element when creating it.