### PR TITLE
[QRF-349] Remove unused embed props

### DIFF
--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -92,15 +92,7 @@ export interface EditorProps {
     withCoverage?: false | CoverageExtensionConfiguration;
     withCursorInView?: false | Parameters<typeof useCursorInView>[1];
     withDivider?: boolean;
-    withEmbeds?:
-        | false
-        | (EmbedExtensionConfiguration & {
-              menuOptions?: {
-                  embed?: boolean;
-                  link?: boolean;
-                  socialPost?: boolean;
-              };
-          });
+    withEmbeds?: false | EmbedExtensionConfiguration;
     withEntryPointsAroundBlocks?: boolean;
     withFloatingAddMenu?: boolean | FloatingAddMenuExtensionConfiguration;
     withGalleries?: false | GalleriesExtensionConfiguration;

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -99,7 +99,6 @@ export interface EditorProps {
                   embed?: boolean;
                   link?: boolean;
                   socialPost?: boolean;
-                  video?: boolean;
               };
           });
     withEntryPointsAroundBlocks?: boolean;


### PR DESCRIPTION
Looks like video prop is not used anymore
https://linear.app/prezly/issue/QRF-349/story-editor-embed-option-not-working