### PR TITLE
[QRF-151] Allow block auto-format only in paragraphs

### DIFF
--- a/packages/slate-editor/src/extensions/autoformat/withAutoformat.ts
+++ b/packages/slate-editor/src/extensions/autoformat/withAutoformat.ts
@@ -1,4 +1,5 @@
 import { EditorCommands } from '@prezly/slate-commons';
+import { isParagraphNode } from '@prezly/slate-types';
 import type { Editor } from 'slate';
 
 import { autoformatBlock, autoformatMark, autoformatText } from './transforms';
@@ -28,6 +29,12 @@ export function withAutoformat<T extends Editor>(editor: T, rules: AutoformatRul
             if (query && !query(editor, { ...rule, text })) continue;
 
             if (editor.selection) {
+                const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
+
+                if (mode === 'block' && !isParagraphNode(currentNode)) {
+                    return;
+                }
+
                 const formatter = autoformatters[mode];
 
                 const formatResult = formatter?.(editor, {

--- a/packages/slate-editor/src/extensions/autoformat/withAutoformat.ts
+++ b/packages/slate-editor/src/extensions/autoformat/withAutoformat.ts
@@ -32,7 +32,7 @@ export function withAutoformat<T extends Editor>(editor: T, rules: AutoformatRul
                 const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
 
                 if (mode === 'block' && !isParagraphNode(currentNode)) {
-                    return;
+                    continue;
                 }
 
                 const formatter = autoformatters[mode];


### PR DESCRIPTION
https://linear.app/prezly/issue/QRF-151/editor-fails-using-in-unordered-lists