### PR TITLE
[QRF-288] Tweak Image resize handles behavior to feel more natural

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/ResizableEditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/ResizableEditorBlock.tsx
@@ -62,7 +62,8 @@ export const ResizableEditorBlock = forwardRef<HTMLDivElement, Props>((props, re
         function (_event: DraggableEvent, { deltaX }: DraggableData, placement: 'left' | 'right') {
             setPixelWidth(function (currentPixelWidth) {
                 const delta = placement === 'left' ? -deltaX : deltaX;
-                const nextPixelWidth = Size(currentPixelWidth + delta, Unit.PIXELS);
+                const multiplier = align === 'center' ? 2 : 1;
+                const nextPixelWidth = Size(currentPixelWidth + delta * multiplier, Unit.PIXELS);
 
                 return toPixels(
                     constrainSize(
@@ -72,7 +73,7 @@ export const ResizableEditorBlock = forwardRef<HTMLDivElement, Props>((props, re
                 ).value;
             });
         },
-        [containerWidth, constrainSize],
+        [align, containerWidth, constrainSize],
     );
     const handleResizingStarted = useCallback(() => setResizing(true), [setResizing]);
     const handleResizingFinished = useCallback(


### PR DESCRIPTION
Followup on #342 

I've noticed that with the current implementation the resizing felt unnatural.
The reason is that by moving mouse by e.g. 10px, the image _width_ is reduced by 10px, but the dragged handle only shifts by 5px, which creates a dissonance between what user does and what happens on the screen.

Modifying the width by doubling the delta helps. 