### PR TITLE
[QRF-288] Fix - Non-movable image resize handles

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/ResizableEditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/ResizableEditorBlock.tsx
@@ -101,24 +101,28 @@ export const ResizableEditorBlock = forwardRef<HTMLDivElement, Props>((props, re
                 {renderInjectionPoint(renderReadOnlyFrame ?? renderEditableFrame, props)}
                 {resizable && (
                     <div contentEditable={false}>
-                        <ResizeButton
-                            offsetParent={blockElement ?? undefined}
-                            show={props.isSelected || props.isHovered}
-                            onDrag={handleResizeEvent}
-                            onStart={handleResizingStarted}
-                            onStop={handleResizingFinished}
-                            className={classNames(styles.ResizeButton, styles.left)}
-                            position="left"
-                        />
-                        <ResizeButton
-                            offsetParent={blockElement ?? undefined}
-                            show={props.isSelected || props.isHovered}
-                            onDrag={handleResizeEvent}
-                            onStart={handleResizingStarted}
-                            onStop={handleResizingFinished}
-                            className={classNames(styles.ResizeButton, styles.right)}
-                            position="right"
-                        />
+                        {align !== 'left' && (
+                            <ResizeButton
+                                offsetParent={blockElement ?? undefined}
+                                show={props.isSelected || props.isHovered}
+                                onDrag={handleResizeEvent}
+                                onStart={handleResizingStarted}
+                                onStop={handleResizingFinished}
+                                className={classNames(styles.ResizeButton, styles.left)}
+                                position="left"
+                            />
+                        )}
+                        {align !== 'right' && (
+                            <ResizeButton
+                                offsetParent={blockElement ?? undefined}
+                                show={props.isSelected || props.isHovered}
+                                onDrag={handleResizeEvent}
+                                onStart={handleResizingStarted}
+                                onStop={handleResizingFinished}
+                                className={classNames(styles.ResizeButton, styles.right)}
+                                position="right"
+                            />
+                        )}
                     </div>
                 )}
             </>


### PR DESCRIPTION
Followup on https://github.com/prezly/slate/pull/342

Hide non-movable image resize handles for left- or right-aligned images. As using them to resize  feelss really weird, as they do not move.