### PR TITLE
[DEV-6123] Allow optional Shift when detecting trigger character in FloatingAddMenu

### DIFF
--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
@@ -5,8 +5,8 @@ import type { KeyboardEvent } from 'react';
 import { isMenuHotkey, MENU_TRIGGER_CHARACTERS, shouldShowMenuButton } from './lib';
 
 function isTriggerInput(event: KeyboardEvent) {
-    return MENU_TRIGGER_CHARACTERS.some((tiggerKey) =>
-        isHotkey(tiggerKey, { byKey: true }, event.nativeEvent),
+    return MENU_TRIGGER_CHARACTERS.some((triggerKey) =>
+        isHotkey(`shift?+${triggerKey}`, { byKey: true })(event),
     );
 }
 

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
@@ -1,10 +1,9 @@
 import type { Extension } from '@prezly/slate-commons';
-import { isHotkey } from 'is-hotkey';
-import type { KeyboardEvent } from 'react';
+import { isHotkey, type KeyboardEventLike } from 'is-hotkey';
 
 import { isMenuHotkey, MENU_TRIGGER_CHARACTERS, shouldShowMenuButton } from './lib';
 
-function isTriggerInput(event: KeyboardEvent) {
+function isTriggerInput(event: KeyboardEventLike) {
     return MENU_TRIGGER_CHARACTERS.some((triggerKey) =>
         isHotkey(`shift?+${triggerKey}`, { byKey: true })(event),
     );

--- a/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
+++ b/packages/slate-editor/src/extensions/floating-add-menu/FloatingAddMenuExtension.tsx
@@ -1,13 +1,9 @@
 import type { Extension } from '@prezly/slate-commons';
-import { isHotkey, type KeyboardEventLike } from 'is-hotkey';
+import { isHotkey } from 'is-hotkey';
 
-import { isMenuHotkey, MENU_TRIGGER_CHARACTERS, shouldShowMenuButton } from './lib';
+import { isMenuHotkey, MENU_TRIGGER_CHARACTER, shouldShowMenuButton } from './lib';
 
-function isTriggerInput(event: KeyboardEventLike) {
-    return MENU_TRIGGER_CHARACTERS.some((triggerKey) =>
-        isHotkey(`shift?+${triggerKey}`, { byKey: true })(event),
-    );
-}
+const isTriggerHotkey = isHotkey(`shift?+${MENU_TRIGGER_CHARACTER}`, { byKey: true });
 
 export const EXTENSION_ID = 'FloatingAddMenuExtension';
 
@@ -26,7 +22,7 @@ export function FloatingAddMenuExtension({ onOpen }: Parameters): Extension {
                 return;
             }
 
-            if (isTriggerInput(event) && shouldShowMenuButton(editor)) {
+            if (isTriggerHotkey(event) && shouldShowMenuButton(editor)) {
                 onOpen('input');
                 return;
             }

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/index.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/index.ts
@@ -1,6 +1,6 @@
 export { groupOptions } from './groupOptions';
 export { isComponent } from './isComponent';
-export { isMenuHotkey, MENU_TRIGGER_CHARACTERS } from './isMenuHotkey';
+export { isMenuHotkey, MENU_TRIGGER_CHARACTER } from './isMenuHotkey';
 export { prependSuggestions } from './prependSuggestions';
 export { shouldShowMenuButton } from './shouldShowMenuButton';
 export { sortBetaOptionsLast } from './sortBetaOptionsLast';

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/isMenuHotkey.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/isMenuHotkey.ts
@@ -1,10 +1,5 @@
-import type { KeyboardEventLike } from 'is-hotkey';
 import { isHotkey } from 'is-hotkey';
 
-export const MENU_TRIGGER_CHARACTERS = ['/', '/']; // Those are two different chars. KeyCode in order 191 and 111
+export const MENU_TRIGGER_CHARACTER = '/';
 
-export function isMenuHotkey(event: KeyboardEventLike) {
-    return MENU_TRIGGER_CHARACTERS.some((triggerChar) =>
-        isHotkey(`mod+${triggerChar}`, { byKey: true })(event),
-    );
-}
+export const isMenuHotkey = isHotkey(`mod+${MENU_TRIGGER_CHARACTER}`, { byKey: true });

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
@@ -3,7 +3,7 @@ import { isHeadingNode, isParagraphNode } from '@prezly/slate-types';
 import type { Editor } from 'slate';
 import { Node, Range } from 'slate';
 
-import { MENU_TRIGGER_CHARACTERS } from './isMenuHotkey';
+import { MENU_TRIGGER_CHARACTER } from './isMenuHotkey';
 
 export function shouldShowMenuButton(editor: Editor): boolean {
     if (!editor.selection || Range.isExpanded(editor.selection)) {
@@ -26,6 +26,6 @@ export function shouldShowMenuButton(editor: Editor): boolean {
 
     const text = Node.string(currentNode);
     return (
-        text.trim() === '' || MENU_TRIGGER_CHARACTERS.some((triggerChar) => triggerChar === text)
+        text.trim() === '' || text === MENU_TRIGGER_CHARACTER
     );
 }

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
@@ -25,7 +25,5 @@ export function shouldShowMenuButton(editor: Editor): boolean {
     }
 
     const text = Node.string(currentNode);
-    return (
-        text.trim() === '' || text === MENU_TRIGGER_CHARACTER
-    );
+    return text.trim() === '' || text === MENU_TRIGGER_CHARACTER;
 }

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { MENU_TRIGGER_CHARACTERS } from './isMenuHotkey';
+import { MENU_TRIGGER_CHARACTER } from './isMenuHotkey';
 
 interface Option {
     group: string;
@@ -11,7 +11,7 @@ interface Option {
 
 export function useKeyboardFiltering<T extends Option>(input: string, options: T[]): [string, T[]] {
     const query = (
-        MENU_TRIGGER_CHARACTERS.some((triggerChar) => triggerChar === input[0])
+        MENU_TRIGGER_CHARACTER === input[0]
             ? input.substring(1)
             : input
     ).toLowerCase();

--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/useKeyboardFiltering.ts
@@ -10,11 +10,7 @@ interface Option {
 }
 
 export function useKeyboardFiltering<T extends Option>(input: string, options: T[]): [string, T[]] {
-    const query = (
-        MENU_TRIGGER_CHARACTER === input[0]
-            ? input.substring(1)
-            : input
-    ).toLowerCase();
+    const query = (MENU_TRIGGER_CHARACTER === input[0] ? input.substring(1) : input).toLowerCase();
 
     const filteredOptions = useMemo(
         function () {


### PR DESCRIPTION
Some non-English keyboard layouts have to use Shift with a different key to produce the `/` trigger character. The code checking this event was too strict and did not allow the Shift key.