### PR TITLE
[QRF-119] Forbid '/' in file names

### DIFF
--- a/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
+++ b/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
@@ -16,7 +16,7 @@ export async function handleEditAttachment(editor: Editor, element: Partial<Atta
     }
 
     const newElement = mapFilename({ ...currentFileAttachment, ...element }, (filename) =>
-        filename.replaceAll('/', ':'),
+        filename.replaceAll('/', '_'),
     );
 
     Transforms.setNodes<AttachmentNode>(editor, newElement, {

--- a/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
+++ b/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
@@ -15,16 +15,18 @@ export async function handleEditAttachment(editor: Editor, element: Partial<Atta
         return;
     }
 
-    Transforms.setNodes<AttachmentNode>(editor, element, {
+    const newElement = { ...currentFileAttachment, ...element };
+
+    newElement.file.filename = newElement.file.filename.replaceAll('/', ':');
+
+    Transforms.setNodes<AttachmentNode>(editor, newElement, {
         match: isAttachmentNode,
     });
 
-    const { description, file } = { ...currentFileAttachment, ...element };
-
     EventsEditor.dispatchEvent(editor, 'attachment-edited', {
-        description: description,
-        mimeType: file.mime_type,
-        size: file.size,
-        uuid: file.uuid,
+        description: newElement.description,
+        mimeType: newElement.file.mime_type,
+        size: newElement.file.size,
+        uuid: newElement.file.uuid,
     });
 }

--- a/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
+++ b/packages/slate-editor/src/modules/editor/lib/file-attachment/handleEditAttachment.ts
@@ -15,9 +15,9 @@ export async function handleEditAttachment(editor: Editor, element: Partial<Atta
         return;
     }
 
-    const newElement = { ...currentFileAttachment, ...element };
-
-    newElement.file.filename = newElement.file.filename.replaceAll('/', ':');
+    const newElement = mapFilename({ ...currentFileAttachment, ...element }, (filename) =>
+        filename.replaceAll('/', ':'),
+    );
 
     Transforms.setNodes<AttachmentNode>(editor, newElement, {
         match: isAttachmentNode,
@@ -29,4 +29,8 @@ export async function handleEditAttachment(editor: Editor, element: Partial<Atta
         size: newElement.file.size,
         uuid: newElement.file.uuid,
     });
+}
+
+function mapFilename(element: AttachmentNode, map: (filename: string) => string): AttachmentNode {
+    return { ...element, file: { ...element.file, filename: map(element.file.filename) } };
 }


### PR DESCRIPTION
https://linear.app/prezly/issue/QRF-119/unable-to-load-attached-pdf-in-campaign-email