### PR TITLE
[QRF-45] Fix horizontal story bookmark provider width

### DIFF
--- a/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.module.scss
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.module.scss
@@ -56,7 +56,7 @@
 .details {
     padding: (2.5 * $spacing-base) (3 * $spacing-base);
     flex-grow: 1;
-    overflow: hidden;
+    min-width: 0;
 }
 
 .title {
@@ -105,7 +105,6 @@
     align-items: center;
     color: $grey-700;
     font-weight: 600;
-    text-overflow: ellipsis;
 
     .vertical & {
         margin-top: 13px;

--- a/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.module.scss
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.module.scss
@@ -56,6 +56,7 @@
 .details {
     padding: (2.5 * $spacing-base) (3 * $spacing-base);
     flex-grow: 1;
+    overflow: hidden;
 }
 
 .title {
@@ -104,6 +105,7 @@
     align-items: center;
     color: $grey-700;
     font-weight: 600;
+    text-overflow: ellipsis;
 
     .vertical & {
         margin-top: 13px;


### PR DESCRIPTION
https://linear.app/prezly/issue/QRF-45/story-cards-cutting-off-title
Before:
<img width="774" alt="image" src="https://user-images.githubusercontent.com/3620639/203036883-e60fd28a-70de-4623-b688-c4e4a8b068ca.png">

After:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/3620639/203036559-0f449f5d-7723-4b61-93bc-50f263da7a5d.png">

