### PR TITLE
[QRF-439] Add option to lose focus when clicking outside of the editor

### DIFF
--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -85,7 +85,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         decorate,
         id,
         initialValue,
-        loseFocusOnOutsideClick = true,
+        loseFocusOnOutsideClick = false,
         onIsOperationPendingChange,
         onKeyDown = noop,
         placeholder,

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -85,7 +85,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         decorate,
         id,
         initialValue,
-        loseFocusOnOutsideClick = false,
+        blurOnOutsideClick = false,
         onIsOperationPendingChange,
         onKeyDown = noop,
         placeholder,
@@ -212,14 +212,14 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             }
         }
 
-        if (loseFocusOnOutsideClick) {
+        if (blurOnOutsideClick) {
             document.addEventListener('click', handleOutsideClick);
         }
 
         return () => {
             document.removeEventListener('click', handleOutsideClick);
         };
-    }, [loseFocusOnOutsideClick, editor, popperMenuOptions]);
+    }, [blurOnOutsideClick, editor, popperMenuOptions]);
 
     useCursorInView(editor, withCursorInView || false);
 

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -85,6 +85,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         decorate,
         id,
         initialValue,
+        loseFocusOnOutsideClick = true,
         onIsOperationPendingChange,
         onKeyDown = noop,
         placeholder,
@@ -190,6 +191,35 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             EditorCommands.focus(editor);
         }
     }, [autoFocus, editor]);
+
+    useEffect(() => {
+        function handleOutsideClick(event: MouseEvent) {
+            const clickTarget = event.target as HTMLElement | null;
+
+            if (!clickTarget) {
+                return;
+            }
+
+            function isTargetWithin(container: HTMLElement | null | undefined) {
+                return container && (container === clickTarget || container.contains(clickTarget));
+            }
+
+            const isWithinMenuPortal = isTargetWithin(popperMenuOptions.portalNode?.current);
+            const isWithinEditor = isTargetWithin(containerRef.current);
+
+            if (!isWithinEditor && !isWithinMenuPortal) {
+                EditorCommands.blur(editor);
+            }
+        }
+
+        if (loseFocusOnOutsideClick) {
+            document.addEventListener('click', handleOutsideClick);
+        }
+
+        return () => {
+            document.removeEventListener('click', handleOutsideClick);
+        };
+    }, [loseFocusOnOutsideClick, editor, popperMenuOptions]);
 
     useCursorInView(editor, withCursorInView || false);
 

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -74,6 +74,10 @@ export interface EditorProps {
     decorate?: Decorate;
     id?: string;
     initialValue: Value;
+    /**
+     * When set to true, the editor will lose focus state when a click happens outside of the editor
+     */
+    loseFocusOnOutsideClick?: boolean;
     onChange: (value: Value) => void;
     onIsOperationPendingChange?: (isOperationPending: boolean) => void;
     onKeyDown?: (event: KeyboardEvent) => void;

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -77,7 +77,7 @@ export interface EditorProps {
     /**
      * When set to true, the editor will lose focus state when a click happens outside of the editor
      */
-    loseFocusOnOutsideClick?: boolean;
+    blurOnOutsideClick?: boolean;
     onChange: (value: Value) => void;
     onIsOperationPendingChange?: (isOperationPending: boolean) => void;
     onKeyDown?: (event: KeyboardEvent) => void;


### PR DESCRIPTION
A side-effect of this change was that closing the menu via the X button also loses focus to the block.

In [QRF-441](https://linear.app/prezly/issue/QRF-441/media-galleries-edit-aside-component-focus-behaviour-is-wrong) we agreed that X button can stay with the current behavior.

Here's what it looks like in this PR:

https://user-images.githubusercontent.com/1641218/207571909-f846f8ad-a597-4e7c-bcbb-f6fa2c6a20c8.mov

