### PR TITLE
Ignore `blurOnOutsideClick` events on textbox elements

### DIFF
--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -206,8 +206,11 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
 
             const isWithinMenuPortal = isTargetWithin(popperMenuOptions.portalNode?.current);
             const isWithinEditor = isTargetWithin(containerRef.current);
+            const isTextboxElement =
+                clickTarget.tagName.toLowerCase() === 'textarea' ||
+                clickTarget.tagName.toLowerCase() === 'input';
 
-            if (!isWithinEditor && !isWithinMenuPortal) {
+            if (!isWithinEditor && !isWithinMenuPortal && !isTextboxElement) {
                 EditorCommands.blur(editor);
             }
         }

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -75,7 +75,8 @@ export interface EditorProps {
     id?: string;
     initialValue: Value;
     /**
-     * When set to true, the editor will lose focus state when a click happens outside of the editor
+     * When set to `true`, the editor will lose focus state when a click happens outside of the editor.
+     * NOTE: Due to how blur logic works in slate, click events happening on textbox elements (textarea, input) are ignored to prevent issues with their focus.
      */
     blurOnOutsideClick?: boolean;
     onChange: (value: Value) => void;


### PR DESCRIPTION
This is a follow-up for #361. It turned out that while clicking anywhere outside of the story composer worked perfectly, clicking on any textbox element (e.g. Title and Subtitle textareas) would result in those elements losing focus as well. With this workaround, and additional logic on the app side, everything now works as intended. I've added extra info in the typedoc to warn about the new behavior.