### PR TITLE
[DEV-8970] Make PlaceholdersExtension auto-enable depending on enabled extensions

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -22,6 +22,7 @@ export const EXTENSION_ID = 'PlaceholdersExtension';
 const isPlaceholderNode = PlaceholderNode.isPlaceholderNode;
 
 export interface Parameters {
+    format?: FrameProps['format'];
     removable?: boolean;
     withAttachmentPlaceholders?: boolean;
     withContactPlaceholders?:
@@ -41,14 +42,16 @@ export interface Parameters {
               | 'onCreateCoverage'
           >;
     withEmbedPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
-    withGalleryPlaceholders?: boolean | { newsroom?: NewsroomRef };
-    withImagePlaceholders?: boolean | { withCaptions: boolean; newsroom?: NewsroomRef };
+    withGalleryPlaceholders?: boolean | { newsroom: NewsroomRef | undefined };
+    withImagePlaceholders?: boolean | { withCaptions: boolean; newsroom: NewsroomRef | undefined };
     withSocialPostPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
-    withVideoPlaceholders?: false | { fetchOembed: FetchOEmbedFn; format?: FrameProps['format'] };
+    withVideoPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
     withWebBookmarkPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
 }
 
 export function PlaceholdersExtension({
+    format = undefined,
+    removable = false,
     withAttachmentPlaceholders = false,
     withContactPlaceholders = false,
     withCoveragePlaceholders = false,
@@ -58,10 +61,7 @@ export function PlaceholdersExtension({
     withSocialPostPlaceholders = false,
     withWebBookmarkPlaceholders = false,
     withVideoPlaceholders = false,
-    ...parameters
 }: Parameters = {}): Extension {
-    const removable = parameters.removable ?? true;
-
     return {
         id: EXTENSION_ID,
         isRichBlock: PlaceholderNode.isPlaceholderNode,
@@ -89,6 +89,7 @@ export function PlaceholdersExtension({
                     <AttachmentPlaceholderElement
                         attributes={attributes}
                         element={element}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -104,6 +105,7 @@ export function PlaceholdersExtension({
                         {...withContactPlaceholders}
                         attributes={attributes}
                         element={element}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -119,6 +121,7 @@ export function PlaceholdersExtension({
                         {...withCoveragePlaceholders}
                         attributes={attributes}
                         element={element}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -131,6 +134,7 @@ export function PlaceholdersExtension({
                         attributes={attributes}
                         element={element}
                         fetchOembed={withEmbedPlaceholders.fetchOembed}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -145,6 +149,7 @@ export function PlaceholdersExtension({
                     <ImagePlaceholderElement
                         attributes={attributes}
                         element={element}
+                        format={format}
                         newsroom={newsroom}
                         withCaptions={withCaptions}
                         removable={removable}
@@ -163,6 +168,7 @@ export function PlaceholdersExtension({
                     <GalleryPlaceholderElement
                         attributes={attributes}
                         element={element}
+                        format={format}
                         newsroom={newsroom}
                         withCaptions
                         removable={removable}
@@ -180,6 +186,7 @@ export function PlaceholdersExtension({
                         attributes={attributes}
                         element={element}
                         fetchOembed={withSocialPostPlaceholders.fetchOembed}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -192,7 +199,7 @@ export function PlaceholdersExtension({
                         attributes={attributes}
                         element={element}
                         fetchOembed={withVideoPlaceholders.fetchOembed}
-                        format={withVideoPlaceholders.format}
+                        format={format}
                         removable={removable}
                     >
                         {children}
@@ -208,6 +215,7 @@ export function PlaceholdersExtension({
                         attributes={attributes}
                         element={element}
                         fetchOembed={withWebBookmarkPlaceholders.fetchOembed}
+                        format={format}
                         removable={removable}
                     >
                         {children}

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -338,16 +338,13 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
             return;
         }
         if (action === MenuAction.ADD_CONTACT) {
-            if (withPlaceholders && withPlaceholders?.withContactPlaceholders) {
-                const placeholder = insertPlaceholder(
-                    editor,
-                    { type: PlaceholderNode.Type.CONTACT },
-                    true,
-                );
-                PlaceholdersManager.trigger(placeholder);
-                EditorCommands.selectNode(editor, placeholder);
-                return;
-            }
+            const placeholder = insertPlaceholder(
+                editor,
+                { type: PlaceholderNode.Type.CONTACT },
+                true,
+            );
+            PlaceholdersManager.trigger(placeholder);
+            EditorCommands.selectNode(editor, placeholder);
             return;
         }
         if (action === MenuAction.ADD_COVERAGE) {

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -22,6 +22,7 @@ import { ListExtension } from '#extensions/list';
 import { LoaderExtension } from '#extensions/loader';
 import { createParagraph, ParagraphsExtension } from '#extensions/paragraphs';
 import { PasteSlateContentExtension } from '#extensions/paste-slate-content';
+import type { PlaceholdersExtensionParameters } from '#extensions/placeholders';
 import { PlaceholdersExtension } from '#extensions/placeholders';
 import { PressContactsExtension } from '#extensions/press-contacts';
 import { SnippetsExtension } from '#extensions/snippet';
@@ -88,36 +89,36 @@ type Parameters = {
     | 'withSnippets'
 >;
 
-export function* getEnabledExtensions({
-    availableWidth,
-    onFloatingAddMenuToggle,
-    onOperationEnd = noop,
-    onOperationStart = noop,
-    withAllowedBlocks,
-    withAttachments,
-    withAutoformat,
-    withBlockquotes,
-    withCoverage,
-    withDivider,
-    withEmbeds,
-    withFloatingAddMenu,
-    withGalleries,
-    withHeadings,
-    withImages,
-    withInlineLinks,
-    withLists,
-    withPlaceholders,
-    withPressContacts,
-    withSnippets,
-    withStoryBookmarks,
-    withStoryEmbeds,
-    withTextStyling,
-    withTables,
-    withUserMentions,
-    withVariables,
-    withVideos,
-    withWebBookmarks,
-}: Parameters): Generator<Extension> {
+export function* getEnabledExtensions(parameters: Parameters): Generator<Extension> {
+    const {
+        availableWidth,
+        onFloatingAddMenuToggle,
+        onOperationEnd = noop,
+        onOperationStart = noop,
+        withAllowedBlocks,
+        withAttachments,
+        withAutoformat,
+        withBlockquotes,
+        withCoverage,
+        withDivider,
+        withEmbeds,
+        withFloatingAddMenu,
+        withGalleries,
+        withHeadings,
+        withImages,
+        withInlineLinks,
+        withLists,
+        withPressContacts,
+        withSnippets,
+        withStoryBookmarks,
+        withStoryEmbeds,
+        withTextStyling,
+        withTables,
+        withUserMentions,
+        withVariables,
+        withVideos,
+        withWebBookmarks,
+    } = parameters;
     yield DecorateSelectionExtension();
     yield FlashNodesExtension();
     yield ParagraphsExtension();
@@ -230,8 +231,9 @@ export function* getEnabledExtensions({
         yield AutoformatExtension({ rules });
     }
 
-    if (withPlaceholders) {
-        yield PlaceholdersExtension(withPlaceholders);
+    const placeholders = buildPlaceholdersExtensionConfiguration(parameters);
+    if (placeholders) {
+        yield PlaceholdersExtension(placeholders);
     }
 
     if (withSnippets) {
@@ -263,4 +265,76 @@ export function* getEnabledExtensions({
     yield PasteSlateContentExtension({
         isPreservedBlock: (_, node) => isImageNode(node) || isQuoteNode(node),
     });
+}
+
+function buildPlaceholdersExtensionConfiguration({
+    withAttachments,
+    withCoverage,
+    withEmbeds,
+    withGalleries,
+    withImages,
+    withPlaceholders,
+    withPressContacts,
+    withVideos,
+    withWebBookmarks,
+}: Parameters): PlaceholdersExtensionParameters | false {
+    function* generate(): Generator<Partial<PlaceholdersExtensionParameters>> {
+        if (withAttachments) {
+            yield {
+                withAttachmentPlaceholders: true,
+            };
+        }
+        if (withCoverage) {
+            yield {
+                withCoveragePlaceholders: withCoverage,
+            };
+        }
+        if (withEmbeds) {
+            yield {
+                withEmbedPlaceholders: withEmbeds,
+                withSocialPostPlaceholders: withEmbeds,
+            };
+        }
+        if (withGalleries) {
+            yield {
+                withGalleryPlaceholders: {
+                    newsroom: withGalleries.mediaGalleryTab?.newsroom,
+                },
+            };
+        }
+        if (withImages) {
+            yield {
+                withImagePlaceholders: {
+                    withCaptions: Boolean(withImages.captions),
+                    newsroom: withImages.mediaGalleryTab?.newsroom,
+                },
+            };
+        }
+        if (withPressContacts) {
+            yield {
+                withContactPlaceholders: withPressContacts,
+            };
+        }
+        if (withWebBookmarks) {
+            yield {
+                withWebBookmarkPlaceholders: withWebBookmarks,
+            };
+        }
+        if (withVideos) {
+            yield {
+                withVideoPlaceholders: withVideos,
+            };
+        }
+    }
+
+    const extensions = Array.from(generate());
+
+    if (extensions.length === 0) {
+        return false;
+    }
+
+    return extensions.reduce(
+        (config, part): PlaceholdersExtensionParameters => ({ ...config, ...part }),
+        withPlaceholders,
+    );
 }

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -26,6 +26,11 @@ export function getAllExtensions() {
             withCoverage: {
                 dateFormat: 'YYYY/MM/DD',
                 fetchCoverage: createDelayedResolve(coverage),
+                getSuggestions: () => [],
+                renderEmpty: () => null,
+                renderSuggestion: () => null,
+                renderSuggestionsFooter: () => null,
+                onCreateCoverage: createDelayedResolve({ coverage }),
             },
             withDivider: true,
             withEmbeds: {
@@ -41,17 +46,13 @@ export function getAllExtensions() {
             },
             withInlineLinks: true,
             withLists: true,
-            withPlaceholders: {
-                withAttachmentPlaceholders: true,
-                withContactPlaceholders: false,
-                withEmbedPlaceholders: { fetchOembed },
-                withGalleryPlaceholders: { newsroom: undefined },
-                withImagePlaceholders: { withCaptions: true, newsroom: undefined },
-                withSocialPostPlaceholders: { fetchOembed },
-                withVideoPlaceholders: { fetchOembed },
-                withWebBookmarkPlaceholders: { fetchOembed },
+            withPlaceholders: {},
+            withPressContacts: {
+                getSuggestions: () => [],
+                renderEmpty: () => null,
+                renderSuggestion: () => null,
+                renderSuggestionsFooter: () => null,
             },
-            withPressContacts: true,
             withStoryBookmarks: {
                 loadStory: () => Promise.reject(),
                 renderInput: () => null,

--- a/packages/slate-editor/src/modules/editor/types.ts
+++ b/packages/slate-editor/src/modules/editor/types.ts
@@ -95,7 +95,10 @@ export interface EditorProps {
     withAttachments?: boolean;
     withAutoformat?: boolean | AutoformatParameters;
     withBlockquotes?: boolean;
-    withCoverage?: false | CoverageExtensionConfiguration;
+    withCoverage?:
+        | false
+        | (CoverageExtensionConfiguration &
+              PlaceholdersExtensionParameters['withCoveragePlaceholders']);
     withCursorInView?: false | Parameters<typeof useCursorInView>[1];
     withDivider?: boolean;
     withEmbeds?: false | EmbedExtensionConfiguration;
@@ -106,8 +109,8 @@ export interface EditorProps {
     withImages?: false | ImageExtensionConfiguration;
     withInlineLinks?: boolean;
     withLists?: boolean;
-    withPlaceholders?: PlaceholdersExtensionParameters;
-    withPressContacts?: boolean;
+    withPlaceholders?: Pick<PlaceholdersExtensionParameters, 'format' | 'removable'>;
+    withPressContacts?: false | PlaceholdersExtensionParameters['withContactPlaceholders'];
     withRichFormattingMenu?:
         | boolean
         | {


### PR DESCRIPTION
Individual placeholders configuration is now part of individual `withXxx` extension configuration prop. For example, Coverage placeholder params are now passed with `withCoverage` extension configuration property.