### PR TITLE
[DEV-9876] Change `ContactNode` model to `reference?: uuid`

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/elements/InlineContactPlaceholderElement/InlineContactPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/InlineContactPlaceholderElement/InlineContactPlaceholderElement.tsx
@@ -53,7 +53,7 @@ export function InlineContactPlaceholderElement({
     });
 
     const handleSubmit = useFunction((contact: ContactInfo) => {
-        replacePlaceholder(editor, element, createContactNode({ contact, reference: null }));
+        replacePlaceholder(editor, element, createContactNode({ contact }));
     });
 
     usePlaceholderManagement(element.type, element.uuid, {

--- a/packages/slate-types/src/nodes/ContactNode.ts
+++ b/packages/slate-types/src/nodes/ContactNode.ts
@@ -10,7 +10,7 @@ export const CONTACT_NODE_TYPE = 'contact';
 export interface ContactNode extends ElementNode {
     type: typeof CONTACT_NODE_TYPE;
     uuid: string;
-    reference: NewsroomContact['uuid'] | null;
+    reference?: NewsroomContact['uuid'];
     contact: ContactInfo;
 }
 


### PR DESCRIPTION
This is because a node property cannot be null.

See https://github.com/ianstormtaylor/slate/issues/4836