### PR TITLE
[DEV-9877] Implement smart content-aware comparisons for other block types

### DIFF
--- a/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
+++ b/packages/slate-editor/src/extensions/coverage/CoverageExtension.tsx
@@ -20,6 +20,17 @@ export const CoverageExtension = ({ dateFormat, fetchCoverage }: Parameters): Ex
             [COVERAGE_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
     },
+    isElementEqual: (node, another) => {
+        if (isCoverageNode(node) && isCoverageNode(another)) {
+            return (
+                node.coverage.id === another.coverage.id &&
+                node.layout === another.layout &&
+                node.new_tab === another.new_tab &&
+                node.show_thumbnail === another.show_thumbnail
+            );
+        }
+        return undefined;
+    },
     isRichBlock: isCoverageNode,
     isVoid: isCoverageNode,
     normalizeNode: normalizeRedundantCoverageAttributes,

--- a/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
@@ -1,6 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
 import { EMBED_NODE_TYPE, isEmbedNode } from '@prezly/slate-types';
+import { isEqual } from 'lodash-es';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
@@ -22,6 +23,12 @@ export const EmbedExtension = ({ availableWidth, showAsScreenshot }: Parameters)
         element: composeElementDeserializer({
             [EMBED_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
+    },
+    isElementEqual: (node, another) => {
+        if (isEmbedNode(node) && isEmbedNode(another)) {
+            return node.url === another.url && isEqual(node.oembed, another.oembed);
+        }
+        return undefined;
     },
     isRichBlock: isEmbedNode,
     isVoid: isEmbedNode,

--- a/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
+++ b/packages/slate-editor/src/extensions/file-attachment/FileAttachmentExtension.tsx
@@ -2,7 +2,7 @@ import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
 import type { AttachmentNode } from '@prezly/slate-types';
 import { ATTACHMENT_NODE_TYPE, isAttachmentNode } from '@prezly/slate-types';
-import { noop } from 'lodash-es';
+import { isEqual, noop } from 'lodash-es';
 import React from 'react';
 import type { Editor } from 'slate';
 import type { RenderElementProps } from 'slate-react';
@@ -30,6 +30,13 @@ export const FileAttachmentExtension = ({
         element: composeElementDeserializer({
             [ATTACHMENT_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
+    },
+    isElementEqual: (node, another) => {
+        if (isAttachmentNode(node) && isAttachmentNode(another)) {
+            // Compare ignoring `uuid`
+            return node.description === another.description && isEqual(node.file, another.file);
+        }
+        return undefined;
     },
     isRichBlock: isAttachmentNode,
     isVoid: isAttachmentNode,

--- a/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
+++ b/packages/slate-editor/src/extensions/galleries/GalleriesExtension.tsx
@@ -1,6 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
 import { GALLERY_NODE_TYPE, isGalleryNode } from '@prezly/slate-types';
+import { isEqual } from 'lodash-es';
 import React from 'react';
 import type { Editor } from 'slate';
 import type { RenderElementProps } from 'slate-react';
@@ -32,6 +33,17 @@ export const GalleriesExtension = ({
         element: composeElementDeserializer({
             [GALLERY_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
+    },
+    isElementEqual: (node, another) => {
+        if (isGalleryNode(node) && isGalleryNode(another)) {
+            return (
+                node.layout === another.layout &&
+                node.padding === another.padding &&
+                node.thumbnail_size === another.thumbnail_size &&
+                isEqual(node.images, another.images)
+            );
+        }
+        return undefined;
     },
     isRichBlock: isGalleryNode,
     isVoid: isGalleryNode,

--- a/packages/slate-editor/src/extensions/image/ImageExtension.tsx
+++ b/packages/slate-editor/src/extensions/image/ImageExtension.tsx
@@ -3,7 +3,7 @@ import { createDeserializeElement, EditorCommands, withoutNodes } from '@prezly/
 import type { ImageNode } from '@prezly/slate-types';
 import { IMAGE_NODE_TYPE, isImageNode } from '@prezly/slate-types';
 import { isHotkey } from 'is-hotkey';
-import { noop } from 'lodash-es';
+import { isEqual, noop } from 'lodash-es';
 import type { KeyboardEvent } from 'react';
 import React from 'react';
 import type { NodeEntry, Node, Editor } from 'slate';
@@ -64,6 +64,19 @@ export const ImageExtension = ({
                 return createImageCandidate(imageElement.src);
             },
         }),
+    },
+    isElementEqual: (node, another) => {
+        if (isImageNode(node) && isImageNode(another)) {
+            return (
+                node.href === another.href &&
+                node.layout === another.layout &&
+                node.align === another.align &&
+                node.new_tab === another.new_tab &&
+                node.width === another.width &&
+                isEqual(node.file, another.file)
+            );
+        }
+        return undefined;
     },
     isRichBlock: isImageNode,
     isVoid: (node) => {

--- a/packages/slate-editor/src/extensions/inline-contacts/InlineContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/inline-contacts/InlineContactsExtension.tsx
@@ -26,11 +26,12 @@ export function InlineContactsExtension(): Extension {
         },
         isElementEqual(element, another) {
             if (isContactNode(element) && isContactNode(another)) {
-                // Compare ContactNodes ignoring `uuid`
-                return (
-                    isEqual(element.contact, another.contact) &&
-                    element.reference === another.reference
-                );
+                // If these are contact references, then ContactInfo object is irrelevant
+                if (element.reference || another.reference) {
+                    return element.reference === another.reference;
+                }
+                // Otherwise, compare ContactInfo ignoring node `uuid` and `reference`
+                return isEqual(element.contact, another.contact);
             }
             return undefined;
         },

--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -24,10 +24,12 @@ export const PressContactsExtension = (): Extension => ({
     },
     isElementEqual(element, another) {
         if (isContactNode(element) && isContactNode(another)) {
-            // Compare ContactNodes ignoring node `uuid`
-            return (
-                isEqual(element.contact, another.contact) && element.reference === another.reference
-            );
+            // If these are contact references, then ContactInfo object is irrelevant
+            if (element.reference || another.reference) {
+                return element.reference === another.reference;
+            }
+            // Otherwise, compare ContactInfo ignoring node `uuid` and `reference`
+            return isEqual(element.contact, another.contact);
         }
         return undefined;
     },

--- a/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/StoryBookmarkExtension.tsx
@@ -19,6 +19,17 @@ export const StoryBookmarkExtension = (params: StoryBookmarkExtensionParameters)
             [STORY_BOOKMARK_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
     },
+    isElementEqual: (node, another) => {
+        if (isStoryBookmarkNode(node) && isStoryBookmarkNode(another)) {
+            return (
+                node.story.uuid === another.story.uuid &&
+                node.show_thumbnail === another.show_thumbnail &&
+                node.new_tab === another.new_tab &&
+                node.layout === another.layout
+            );
+        }
+        return undefined;
+    },
     isRichBlock: isStoryBookmarkNode,
     isVoid: isStoryBookmarkNode,
     normalizeNode: normalizeRedundantStoryBookmarkAttributes,

--- a/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/story-embed/StoryEmbedExtension.tsx
@@ -19,6 +19,16 @@ export const StoryEmbedExtension = ({ render }: StoryEmbedExtensionParameters): 
             [STORY_EMBED_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
     },
+    isElementEqual: (node, another) => {
+        if (isStoryEmbedNode(node) && isStoryEmbedNode(another)) {
+            return (
+                node.story.uuid === another.story.uuid &&
+                node.appearance === another.appearance &&
+                node.position === another.position
+            );
+        }
+        return undefined;
+    },
     isRichBlock: isStoryEmbedNode,
     isVoid: isStoryEmbedNode,
     normalizeNode: normalizeRedundantStoryEmbedAttributes,

--- a/packages/slate-editor/src/extensions/video/VideoExtension.tsx
+++ b/packages/slate-editor/src/extensions/video/VideoExtension.tsx
@@ -1,6 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
 import { isVideoNode, VIDEO_NODE_TYPE } from '@prezly/slate-types';
+import { isEqual } from 'lodash-es';
 import React from 'react';
 
 import { composeElementDeserializer } from '#modules/html-deserialization';
@@ -18,6 +19,12 @@ export function VideoExtension({ mode = 'thumbnail' }: VideoExtensionParameters)
             element: composeElementDeserializer({
                 [VIDEO_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
             }),
+        },
+        isElementEqual: (node, another) => {
+            if (isVideoNode(node) && isVideoNode(another)) {
+                return node.url === another.url && isEqual(node.oembed, another.oembed);
+            }
+            return undefined;
         },
         isRichBlock: isVideoNode,
         isVoid: isVideoNode,

--- a/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
@@ -1,6 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
 import { BOOKMARK_NODE_TYPE, isBookmarkNode } from '@prezly/slate-types';
+import { isEqual } from 'lodash-es';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
@@ -23,6 +24,19 @@ export const WebBookmarkExtension = ({
         element: composeElementDeserializer({
             [BOOKMARK_NODE_TYPE]: createDeserializeElement(parseSerializedElement),
         }),
+    },
+    isElementEqual: (node, another) => {
+        if (isBookmarkNode(node) && isBookmarkNode(another)) {
+            // Compare ignoring `uuid` and `children`
+            return (
+                node.url === another.url &&
+                node.show_thumbnail === another.show_thumbnail &&
+                node.layout === another.layout &&
+                node.new_tab === another.new_tab &&
+                isEqual(node.oembed, another.oembed)
+            );
+        }
+        return undefined;
     },
     isRichBlock: isBookmarkNode,
     isVoid: isBookmarkNode,

--- a/packages/slate-types/src/nodes/StoryBookmarkNode.ts
+++ b/packages/slate-types/src/nodes/StoryBookmarkNode.ts
@@ -11,10 +11,10 @@ export enum StoryBookmarkLayout {
 
 export interface StoryBookmarkNode extends ElementNode {
     type: typeof STORY_BOOKMARK_NODE_TYPE;
+    uuid: string;
     story: {
         uuid: string;
     };
-    uuid: string;
     show_thumbnail: boolean;
     new_tab: boolean;
     layout: StoryBookmarkLayout;


### PR DESCRIPTION
Related to #375 

- `AttachmentNode`
- `BookmarkNode`
- `CoverageNode`
- `EmbedNode`
- `ImageNode`
- `GalleryNode`
- `StoryBookmarkNode`
- `StoryEmbedNode`
- `VideoNode`
