### PR TITLE
[DEV-9898] Get rid of virtual reference element in Menu component

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/Menu.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/Menu.tsx
@@ -1,7 +1,6 @@
 import type { Rect } from '@popperjs/core';
 import classNames from 'classnames';
 import type { MouseEvent, ReactNode } from 'react';
-import { useCallback } from 'react';
 import React from 'react';
 import { createPortal } from 'react-dom';
 import type { Modifier } from 'react-popper';
@@ -93,31 +92,6 @@ function getModifiers(popperOptions: PopperOptionsContextType): Modifier<string>
 export function Menu({ children, className, onClick, popperOptions, reference }: Props) {
     const placement = popperOptions.placement ?? 'right-start';
 
-    const getVirtualReferenceClientRect = useCallback((): ClientRect => {
-        const container = reference.getBoundingClientRect();
-
-        const rect = {
-            top: container.top,
-            right: container.right,
-            bottom: container.bottom,
-            left: container.left,
-            x: container.x,
-            y: container.y,
-            width: container.width,
-            height: container.height,
-            toJSON() {
-                return JSON.stringify(this);
-            },
-        };
-
-        return {
-            ...rect,
-            toJSON() {
-                return rect;
-            },
-        };
-    }, [reference]);
-
     function mountPopper(content: ReactNode) {
         if (popperOptions.portalNode?.current) {
             return createPortal(content, popperOptions.portalNode.current);
@@ -128,9 +102,7 @@ export function Menu({ children, className, onClick, popperOptions, reference }:
 
     return (
         <Popper
-            referenceElement={{
-                getBoundingClientRect: getVirtualReferenceClientRect,
-            }}
+            referenceElement={reference}
             modifiers={getModifiers(popperOptions)}
             placement={placement}
             strategy="fixed"


### PR DESCRIPTION
This virtual reference element was previously used to allow the menu flipping to the left if your browser has smaller width.
However with the rework of Story Composer page and the sidebar moving to the right of the page, there's not enough space on the left so flipping does not help there (it's currently broken anyway).

Removing the virtual reference element restores the proper menu positioning.