### PR TITLE
[CARE-439] Fix Placeholders not working with `blurOnOutsideClick`

### DIFF
--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -199,11 +199,22 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
 
             const isWithinMenuPortal = isTargetWithin(popperMenuOptions.portalNode?.current);
             const isWithinEditor = isTargetWithin(containerRef.current);
+
+            // Due to how blur logic works in slate, click events happening on textbox elements (textarea, input) are ignored to prevent issues with their own focus.
             const isTextboxElement =
                 clickTarget.tagName.toLowerCase() === 'textarea' ||
                 clickTarget.tagName.toLowerCase() === 'input';
 
-            if (!isWithinEditor && !isWithinMenuPortal && !isTextboxElement) {
+            // Placeholder elements get re-rendered on click, removing the original clicked element out of the DOM.
+            const isPlaceholderElement =
+                clickTarget.getAttribute('data-placeholder-format') !== null;
+
+            if (
+                !isWithinEditor &&
+                !isWithinMenuPortal &&
+                !isTextboxElement &&
+                !isPlaceholderElement
+            ) {
                 EditorCommands.blur(editor);
             }
         }

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -213,7 +213,8 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
                 !isWithinEditor &&
                 !isWithinMenuPortal &&
                 !isTextboxElement &&
-                !isPlaceholderElement
+                !isPlaceholderElement &&
+                !EditorCommands.isCursorInEmptyParagraph(editor)
             ) {
                 EditorCommands.blur(editor);
             }


### PR DESCRIPTION
Another follow up for #361.

This one fixes the issue with Placeholder blocks not working with `blurOnOutsideClick` active, as well as resolving issue with FloatingAddMenu unwanted disappearing in some cases.