### PR TITLE
[CARE-785] Fix `TypeError: Invalid URL` errors in Web Bookmarks

### DIFF
--- a/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/WebBookmarkExtension.tsx
@@ -8,7 +8,11 @@ import type { RenderElementProps } from 'slate-react';
 import { composeElementDeserializer } from '#modules/html-deserialization';
 
 import { WebBookmarkElement } from './components';
-import { normalizeRedundantWebBookmarkAttributes, parseSerializedElement } from './lib';
+import {
+    normalizeRedundantWebBookmarkAttributes,
+    normalizeUrlAttribute,
+    parseSerializedElement,
+} from './lib';
 
 interface WebBookmarkExtensionParameters {
     withNewTabOption?: boolean;
@@ -40,7 +44,7 @@ export const WebBookmarkExtension = ({
     },
     isRichBlock: isBookmarkNode,
     isVoid: isBookmarkNode,
-    normalizeNode: [normalizeRedundantWebBookmarkAttributes],
+    normalizeNode: [normalizeRedundantWebBookmarkAttributes, normalizeUrlAttribute],
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isBookmarkNode(element)) {
             return (

--- a/packages/slate-editor/src/extensions/web-bookmark/lib/index.ts
+++ b/packages/slate-editor/src/extensions/web-bookmark/lib/index.ts
@@ -1,3 +1,3 @@
 export { createWebBookmark } from './createWebBookmark';
-export { normalizeRedundantWebBookmarkAttributes } from './normalizeRedundantWebBookmarkAttributes';
+export { normalizeRedundantWebBookmarkAttributes, normalizeUrlAttribute } from './normalizations';
 export { parseSerializedElement } from './parseSerializedElement';

--- a/packages/slate-editor/src/extensions/web-bookmark/lib/normalizations.ts
+++ b/packages/slate-editor/src/extensions/web-bookmark/lib/normalizations.ts
@@ -1,7 +1,9 @@
 import { EditorCommands } from '@prezly/slate-commons';
-import type { BookmarkNode } from '@prezly/slate-types';
+import { type BookmarkNode, normalizeUrl } from '@prezly/slate-types';
 import { isBookmarkNode } from '@prezly/slate-types';
+import { isEqual } from 'lodash-es';
 import type { Editor, NodeEntry } from 'slate';
+import { Transforms } from 'slate';
 
 const shape: Record<keyof BookmarkNode, true> = {
     type: true,
@@ -25,4 +27,17 @@ export function normalizeRedundantWebBookmarkAttributes(
     }
 
     return EditorCommands.normalizeRedundantAttributes(editor, [node, path], ALLOWED_ATTRIBUTES);
+}
+
+export function normalizeUrlAttribute(editor: Editor, [node, path]: NodeEntry): boolean {
+    if (!isBookmarkNode(node)) {
+        return false;
+    }
+
+    if (isEqual(node.url, normalizeUrl(node.url))) {
+        return false;
+    }
+
+    Transforms.setNodes<BookmarkNode>(editor, { url: normalizeUrl(node.url) }, { at: path });
+    return true;
 }

--- a/packages/slate-types/src/lib/index.ts
+++ b/packages/slate-types/src/lib/index.ts
@@ -1,1 +1,2 @@
 export { type AlignableNode, isAlignableElement } from './isAlignableElement';
+export { normalizeUrl } from './normalizeUrl';

--- a/packages/slate-types/src/lib/normalizeUrl.ts
+++ b/packages/slate-types/src/lib/normalizeUrl.ts
@@ -1,0 +1,11 @@
+export function normalizeUrl(url: string): string {
+    if (!url || url.includes('://')) {
+        return url;
+    }
+
+    if (url.startsWith('//')) {
+        return `http:${url}`;
+    }
+
+    return `http://${url}`;
+}

--- a/packages/slate-types/src/sdk/ContactInfo.ts
+++ b/packages/slate-types/src/sdk/ContactInfo.ts
@@ -1,3 +1,5 @@
+import { normalizeUrl } from '../lib';
+
 export interface ContactInfo {
     avatar_url: string | null;
     name: string;
@@ -39,19 +41,9 @@ export namespace ContactInfo {
             mobile: value.mobile ?? '',
             phone: value.phone ?? '',
             email: value.email ?? '',
-            website: withHttp(value.website ?? ''),
+            website: normalizeUrl(value.website ?? ''),
             facebook: value.facebook ?? '',
             twitter: value.twitter ?? '',
         };
     }
-}
-
-function withHttp(url: string): string {
-    if (!url || url.includes('://')) {
-        return url;
-    }
-    if (url.startsWith('//')) {
-        return `http:${url}`;
-    }
-    return `http://${url}`;
 }


### PR DESCRIPTION
As suggested by Lukas, I've ported the ContactNode normalization logic to `web-bookmarks` extension.
Due to issues with linking packages on the main app repo, I couldn't test it properly. I'll see if I can find a way to test it some other way.