### PR TITLE
[CARE-1064] Fix text toolbar issues with `blurOnOutsideClick`

### DIFF
--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -205,15 +205,15 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
                 clickTarget.tagName.toLowerCase() === 'textarea' ||
                 clickTarget.tagName.toLowerCase() === 'input';
 
-            // Placeholder elements get re-rendered on click, removing the original clicked element out of the DOM.
-            const isPlaceholderElement =
-                clickTarget.getAttribute('data-placeholder-format') !== null;
+            // Placeholder and some other elements (like link button in the text toolbar) get re-rendered on click, removing the original clicked element out of the DOM.
+            // In this case, we don't want to blur the editor.
+            const isRemovedFromDom = !document.contains(clickTarget);
 
             if (
                 !isWithinEditor &&
                 !isWithinMenuPortal &&
                 !isTextboxElement &&
-                !isPlaceholderElement &&
+                !isRemovedFromDom &&
                 !EditorCommands.isCursorInEmptyParagraph(editor)
             ) {
                 EditorCommands.blur(editor);


### PR DESCRIPTION
The issue with the Link button on the text toolbar was pretty much the same as with Placeholders - the original clicked element is removed from the DOM, so it fails all of the `element.contains` checks.
I updated the check to not be Placeholder-specific and check that the element is still in the DOM at the time the handler catches the event.