### PR TITLE
[CARE-1091] Upgrade Slate packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
                 "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
                 "react-bootstrap": "=0.32.4",
                 "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-                "slate": "^0.82.1",
-                "slate-history": "^0.66.0",
-                "slate-react": "^0.82.1"
+                "slate": "^0.91.4",
+                "slate-history": "^0.86.0",
+                "slate-react": "^0.91.7"
             },
             "devDependencies": {
                 "@babel/cli": "^7.17.10",
@@ -3015,6 +3015,11 @@
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
         },
         "node_modules/@lerna/add": {
             "version": "3.21.0",
@@ -27048,9 +27053,9 @@
             }
         },
         "node_modules/slate": {
-            "version": "0.82.1",
-            "resolved": "https://registry.npmjs.org/slate/-/slate-0.82.1.tgz",
-            "integrity": "sha512-3mdRdq7U3jSEoyFrGvbeb28hgrvrr4NdFCtJX+IjaNvSFozY0VZd/CGHF0zf/JDx7aEov864xd5uj0HQxxEWTQ==",
+            "version": "0.91.4",
+            "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
+            "integrity": "sha512-aUJ3rpjrdi5SbJ5G1Qjr3arytfRkEStTmHjBfWq2A2Q8MybacIzkScSvGJjQkdTk3djCK9C9SEOt39sSeZFwTw==",
             "dependencies": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",
@@ -27058,9 +27063,9 @@
             }
         },
         "node_modules/slate-history": {
-            "version": "0.66.0",
-            "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.66.0.tgz",
-            "integrity": "sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==",
+            "version": "0.86.0",
+            "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.86.0.tgz",
+            "integrity": "sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==",
             "dependencies": {
                 "is-plain-object": "^5.0.0"
             },
@@ -27096,10 +27101,11 @@
             }
         },
         "node_modules/slate-react": {
-            "version": "0.82.2",
-            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.82.2.tgz",
-            "integrity": "sha512-lNmSqqNOKQJG1i3Wx4MkggWr6dLhQ43n4exPf5NLmKVBHPBuQSRNaWhAAKm6HOEC36Q6xBfkVONIQWi3GSyIEQ==",
+            "version": "0.91.7",
+            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.91.7.tgz",
+            "integrity": "sha512-7EdZgICCTirSB5GTkwC7U9DedHgNOa+Gmf0ZfsYVXTTTVQ2jvKW7GMz35H8H3Uqpe1pplC+gdDUP12v0xnwAHw==",
             "dependencies": {
+                "@juggle/resize-observer": "^3.4.0",
                 "@types/is-hotkey": "^0.1.1",
                 "@types/lodash": "^4.14.149",
                 "direction": "^1.0.3",
@@ -31325,10 +31331,10 @@
         },
         "packages/slate-commons": {
             "name": "@prezly/slate-commons",
-            "version": "0.78.1",
+            "version": "0.79.4",
             "license": "MIT",
             "dependencies": {
-                "@prezly/slate-types": "^0.78.1",
+                "@prezly/slate-types": "^0.79.4",
                 "uuid": "^8.3.0"
             },
             "devDependencies": {
@@ -31337,9 +31343,9 @@
             },
             "peerDependencies": {
                 "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-                "slate": "^0.82.1",
-                "slate-history": "^0.66.0",
-                "slate-react": "^0.82.1"
+                "slate": "^0.91.4",
+                "slate-history": "^0.86.0",
+                "slate-react": "^0.91.7"
             }
         },
         "packages/slate-commons/node_modules/@types/node": {
@@ -31350,7 +31356,7 @@
         },
         "packages/slate-editor": {
             "name": "@prezly/slate-editor",
-            "version": "0.78.1",
+            "version": "0.79.4",
             "license": "MIT",
             "dependencies": {
                 "@popperjs/core": "^2.6.0",
@@ -31359,10 +31365,10 @@
                 "@prezly/linear-partition": "^1.0.3",
                 "@prezly/progress-promise": "^2.0.1",
                 "@prezly/sdk": "^13.0.0 || ^14.0.0",
-                "@prezly/slate-commons": "^0.78.1",
-                "@prezly/slate-lists": "^0.78.1",
-                "@prezly/slate-tables": "^0.78.1",
-                "@prezly/slate-types": "^0.78.1",
+                "@prezly/slate-commons": "^0.79.4",
+                "@prezly/slate-lists": "^0.79.4",
+                "@prezly/slate-tables": "^0.79.4",
+                "@prezly/slate-types": "^0.79.4",
                 "@prezly/uploadcare": "^2.4.0",
                 "@prezly/uploadcare-widget": "^3.16.1",
                 "@types/combine-reducers": "^1.0.1",
@@ -31412,9 +31418,9 @@
             "peerDependencies": {
                 "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
                 "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-                "slate": "^0.82.1",
-                "slate-history": "^0.66.0",
-                "slate-react": "^0.82.1"
+                "slate": "^0.91.4",
+                "slate-history": "^0.86.0",
+                "slate-react": "^0.91.7"
             }
         },
         "packages/slate-editor/node_modules/@jest/environment": {
@@ -31636,7 +31642,7 @@
         },
         "packages/slate-lists": {
             "name": "@prezly/slate-lists",
-            "version": "0.78.1",
+            "version": "0.79.4",
             "license": "MIT",
             "dependencies": {
                 "is-hotkey": "^0.2.0",
@@ -31649,8 +31655,8 @@
             },
             "peerDependencies": {
                 "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-                "slate": "^0.82.1",
-                "slate-react": "^0.82.1"
+                "slate": "^0.91.4",
+                "slate-react": "^0.91.7"
             }
         },
         "packages/slate-lists/node_modules/@types/node": {
@@ -31665,10 +31671,10 @@
         },
         "packages/slate-tables": {
             "name": "@prezly/slate-tables",
-            "version": "0.78.1",
+            "version": "0.79.4",
             "license": "MIT",
             "dependencies": {
-                "@prezly/slate-commons": "^0.78.1",
+                "@prezly/slate-commons": "^0.79.4",
                 "is-hotkey": "^0.2.0",
                 "lodash-es": "^4.17.21"
             },
@@ -31679,8 +31685,8 @@
             },
             "peerDependencies": {
                 "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-                "slate": "^0.82.1",
-                "slate-react": "^0.82.1"
+                "slate": "^0.91.4",
+                "slate-react": "^0.91.7"
             }
         },
         "packages/slate-tables/node_modules/@types/node": {
@@ -31695,7 +31701,7 @@
         },
         "packages/slate-types": {
             "name": "@prezly/slate-types",
-            "version": "0.78.1",
+            "version": "0.79.4",
             "license": "MIT",
             "dependencies": {
                 "@prezly/sdk": "^13.0.0 || ^14.0.0",
@@ -31706,7 +31712,7 @@
                 "@types/node": "^18.13.0"
             },
             "peerDependencies": {
-                "slate": "^0.82.1"
+                "slate": "^0.91.4"
             }
         },
         "packages/slate-types/node_modules/@prezly/uploads": {
@@ -33658,6 +33664,11 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+        },
         "@lerna/add": {
             "version": "3.21.0",
             "dev": true,
@@ -35098,7 +35109,7 @@
         "@prezly/slate-commons": {
             "version": "file:packages/slate-commons",
             "requires": {
-                "@prezly/slate-types": "^0.78.1",
+                "@prezly/slate-types": "^0.79.4",
                 "@types/node": "^18.13.0",
                 "@types/uuid": "^8.3.0",
                 "uuid": "^8.3.0"
@@ -35123,10 +35134,10 @@
                 "@prezly/linear-partition": "^1.0.3",
                 "@prezly/progress-promise": "^2.0.1",
                 "@prezly/sdk": "^13.0.0 || ^14.0.0",
-                "@prezly/slate-commons": "^0.78.1",
-                "@prezly/slate-lists": "^0.78.1",
-                "@prezly/slate-tables": "^0.78.1",
-                "@prezly/slate-types": "^0.78.1",
+                "@prezly/slate-commons": "^0.79.4",
+                "@prezly/slate-lists": "^0.79.4",
+                "@prezly/slate-tables": "^0.79.4",
+                "@prezly/slate-types": "^0.79.4",
                 "@prezly/uploadcare": "^2.4.0",
                 "@prezly/uploadcare-widget": "^3.16.1",
                 "@storybook/addon-actions": "^6.5.9",
@@ -35362,7 +35373,7 @@
         "@prezly/slate-tables": {
             "version": "file:packages/slate-tables",
             "requires": {
-                "@prezly/slate-commons": "^0.78.1",
+                "@prezly/slate-commons": "^0.79.4",
                 "@types/is-hotkey": "^0.1.7",
                 "@types/lodash-es": "^4.17.6",
                 "@types/node": "^18.13.0",
@@ -50242,9 +50253,9 @@
             "dev": true
         },
         "slate": {
-            "version": "0.82.1",
-            "resolved": "https://registry.npmjs.org/slate/-/slate-0.82.1.tgz",
-            "integrity": "sha512-3mdRdq7U3jSEoyFrGvbeb28hgrvrr4NdFCtJX+IjaNvSFozY0VZd/CGHF0zf/JDx7aEov864xd5uj0HQxxEWTQ==",
+            "version": "0.91.4",
+            "resolved": "https://registry.npmjs.org/slate/-/slate-0.91.4.tgz",
+            "integrity": "sha512-aUJ3rpjrdi5SbJ5G1Qjr3arytfRkEStTmHjBfWq2A2Q8MybacIzkScSvGJjQkdTk3djCK9C9SEOt39sSeZFwTw==",
             "requires": {
                 "immer": "^9.0.6",
                 "is-plain-object": "^5.0.0",
@@ -50257,9 +50268,9 @@
             }
         },
         "slate-history": {
-            "version": "0.66.0",
-            "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.66.0.tgz",
-            "integrity": "sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==",
+            "version": "0.86.0",
+            "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.86.0.tgz",
+            "integrity": "sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==",
             "requires": {
                 "is-plain-object": "^5.0.0"
             },
@@ -50285,10 +50296,11 @@
             }
         },
         "slate-react": {
-            "version": "0.82.2",
-            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.82.2.tgz",
-            "integrity": "sha512-lNmSqqNOKQJG1i3Wx4MkggWr6dLhQ43n4exPf5NLmKVBHPBuQSRNaWhAAKm6HOEC36Q6xBfkVONIQWi3GSyIEQ==",
+            "version": "0.91.7",
+            "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.91.7.tgz",
+            "integrity": "sha512-7EdZgICCTirSB5GTkwC7U9DedHgNOa+Gmf0ZfsYVXTTTVQ2jvKW7GMz35H8H3Uqpe1pplC+gdDUP12v0xnwAHw==",
             "requires": {
+                "@juggle/resize-observer": "^3.4.0",
                 "@types/is-hotkey": "^0.1.1",
                 "@types/lodash": "^4.14.149",
                 "direction": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-bootstrap": "=0.32.4",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.82.1",
-        "slate-history": "^0.66.0",
-        "slate-react": "^0.82.1"
+        "slate": "^0.91.4",
+        "slate-history": "^0.86.0",
+        "slate-react": "^0.91.7"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.10",

--- a/packages/slate-commons/package.json
+++ b/packages/slate-commons/package.json
@@ -43,9 +43,9 @@
     },
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.82.1",
-        "slate-history": "^0.66.0",
-        "slate-react": "^0.82.1"
+        "slate": "^0.91.4",
+        "slate-history": "^0.86.0",
+        "slate-react": "^0.91.7"
     },
     "dependencies": {
         "@prezly/slate-types": "^0.79.4",

--- a/packages/slate-commons/src/commands/getPrevChars.ts
+++ b/packages/slate-commons/src/commands/getPrevChars.ts
@@ -1,5 +1,7 @@
 import { Editor, Path, Text } from 'slate';
 
+import { isVoid } from './isVoid';
+
 export function getPrevChars(editor: Editor, length: number): string {
     const selection = editor.selection;
 
@@ -27,7 +29,7 @@ export function getPrevChars(editor: Editor, length: number): string {
             continue;
         }
 
-        if (Editor.isVoid(editor, node)) {
+        if (isVoid(editor, node)) {
             break;
         }
 

--- a/packages/slate-commons/src/commands/index.ts
+++ b/packages/slate-commons/src/commands/index.ts
@@ -11,6 +11,7 @@ export { getPrevChars } from './getPrevChars';
 export { hasVoidElements } from './hasVoidElements';
 export { insertEmptyParagraph } from './insertEmptyParagraph';
 export { insertNodes } from './insertNodes';
+export { isBlock } from './isBlock';
 export { isBlockActive } from './isBlockActive';
 export { isCursorInEmptyParagraph } from './isCursorInEmptyParagraph';
 export {
@@ -21,6 +22,7 @@ export {
 } from './isCursorOnEdgeOfContainer';
 export { isEmpty } from './isEmpty';
 export { isEmptyParagraphElement } from './isEmptyParagraphElement';
+export { isInline } from './isInline';
 export { isMarkActive } from './isMarkActive';
 export { isNodeEmpty } from './isNodeEmpty';
 export { isSelectionAtBlockEnd } from './isSelectionAtBlockEnd';

--- a/packages/slate-commons/src/commands/insertNodes.ts
+++ b/packages/slate-commons/src/commands/insertNodes.ts
@@ -5,7 +5,10 @@ import { Editor, Text, Transforms } from 'slate';
 
 import { getCurrentNodeEntry } from './getCurrentNodeEntry';
 import { insertEmptyParagraph } from './insertEmptyParagraph';
+import { isBlock } from './isBlock';
 import { isCursorInEmptyParagraph } from './isCursorInEmptyParagraph';
+import { isInline } from './isInline';
+import { isVoid } from './isVoid';
 
 interface Options {
     ensureEmptyParagraphAfter?: boolean;
@@ -29,7 +32,7 @@ export function insertNodes(editor: Editor, nodes: Node[], options: Options = {}
     const initialSelection = editor.selection;
     const wasInitialSelectionInEmptyParagraph = isCursorInEmptyParagraph(editor);
     const isAppendingToCurrentNode = Text.isText(nodes[0]) || Editor.isInline(editor, nodes[0]);
-    const isAddingAnyBlockNodes = nodes.some((node) => Editor.isBlock(editor, node));
+    const isAddingAnyBlockNodes = nodes.some((node) => isBlock(editor, node));
 
     for (const node of nodes) {
         const currentNodeEntry = getCurrentNodeEntry(editor);
@@ -37,11 +40,11 @@ export function insertNodes(editor: Editor, nodes: Node[], options: Options = {}
         if (currentNodeEntry) {
             const [currentNode] = currentNodeEntry;
 
-            if (Editor.isVoid(editor, currentNode) && !Editor.isBlock(editor, node)) {
+            if (isVoid(editor, currentNode) && !isBlock(editor, node)) {
                 insertEmptyParagraph(editor);
             }
 
-            if (Editor.isInline(editor, node)) {
+            if (isInline(editor, node)) {
                 // For some reason Slate will split existing block nodes when inserting inline nodes.
                 // We don't want that. Adding an empty text node before and after seems to do the
                 // trick. I don't know why.

--- a/packages/slate-commons/src/commands/isBlock.ts
+++ b/packages/slate-commons/src/commands/isBlock.ts
@@ -1,0 +1,10 @@
+import { Editor, Element } from 'slate';
+import type { Node } from 'slate';
+
+/**
+ * @param editor
+ * @param node
+ */
+export function isBlock(editor: Editor, node: Node): boolean {
+    return Element.isElement(node) && Editor.isBlock(editor, node);
+}

--- a/packages/slate-commons/src/commands/isInline.ts
+++ b/packages/slate-commons/src/commands/isInline.ts
@@ -1,0 +1,10 @@
+import { Editor, Element } from 'slate';
+import type { Node } from 'slate';
+
+/**
+ * @param editor
+ * @param node
+ */
+export function isInline(editor: Editor, node: Node): boolean {
+    return Element.isElement(node) && Editor.isInline(editor, node);
+}

--- a/packages/slate-commons/src/commands/isSelectionAtBlockEnd.ts
+++ b/packages/slate-commons/src/commands/isSelectionAtBlockEnd.ts
@@ -1,5 +1,7 @@
 import { Editor, Range } from 'slate';
 
+import { isBlock } from './isBlock';
+
 export function isSelectionAtBlockEnd(editor: Editor): boolean {
     if (!editor.selection) {
         // Cannot determine the location if there is no selection.
@@ -7,7 +9,7 @@ export function isSelectionAtBlockEnd(editor: Editor): boolean {
     }
 
     const endOfSelection = Range.end(editor.selection);
-    const blockAbove = Editor.above(editor, { match: (node) => Editor.isBlock(editor, node) });
+    const blockAbove = Editor.above(editor, { match: (node) => isBlock(editor, node) });
 
     if (!blockAbove) {
         return false;

--- a/packages/slate-commons/src/commands/isSelectionAtBlockStart.ts
+++ b/packages/slate-commons/src/commands/isSelectionAtBlockStart.ts
@@ -1,5 +1,7 @@
 import { Editor, Range } from 'slate';
 
+import { isBlock } from './isBlock';
+
 export function isSelectionAtBlockStart(editor: Editor): boolean {
     if (!editor.selection) {
         // Cannot determine the location if there is no selection.
@@ -8,7 +10,7 @@ export function isSelectionAtBlockStart(editor: Editor): boolean {
 
     const startOfSelection = Range.start(editor.selection);
     const blockAbove = Editor.above(editor, {
-        match: (node) => Editor.isBlock(editor, node),
+        match: (node) => isBlock(editor, node),
     });
 
     if (!blockAbove) {

--- a/packages/slate-commons/src/commands/isVoid.ts
+++ b/packages/slate-commons/src/commands/isVoid.ts
@@ -1,33 +1,10 @@
-import { Editor } from 'slate';
+import { Editor, Element } from 'slate';
 import type { Node } from 'slate';
 
 /**
- * This is a dumb proxy for `Editor.isVoid()` function.
- * The problem with the original function is that it is declared as a type-guard:
- *
- *    isVoid: (editor: Editor, value: any) => value is Element
- *
- * This has a logical problem with TS type system. As checking a node for `isVoid`
- * excludes the other branch of the condition, where the node is a non-void element.
- *
- *    if (Text.isText(editor, node)) {
- *        // Do something when node is TEXT.
- *        return;
- *    }
- *
- *    if (Editor.isVoid(editor, node)) {
- *        // Do something when node is VOID ELEMENT.
- *        return;
- *    }
- *
- *    // Do something when node is NON-VOID ELEMENT.
- *    // But TS thinks that node is `never`, as the `is Element`
- *    // branch is already excluded above.
- *
- *
  * @param editor
  * @param node
  */
 export function isVoid(editor: Editor, node: Node): boolean {
-    return Editor.isVoid(editor, node);
+    return Element.isElement(node) && Editor.isVoid(editor, node);
 }

--- a/packages/slate-commons/src/plugins/withBreaksOnExpandedSelection/withBreaksOnExpandedSelection.ts
+++ b/packages/slate-commons/src/plugins/withBreaksOnExpandedSelection/withBreaksOnExpandedSelection.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Editor, Range, Transforms } from 'slate';
 
-import { insertEmptyParagraph } from '../../commands';
+import { insertEmptyParagraph, isBlock } from '../../commands';
 
 export function withBreaksOnExpandedSelection<T extends Editor>(editor: T): T {
     const { insertBreak } = editor;
@@ -28,7 +28,7 @@ export function withBreaksOnExpandedSelection<T extends Editor>(editor: T): T {
             const nodes = Array.from(
                 Editor.nodes(editor, {
                     at: editor.selection,
-                    match: (node) => Editor.isBlock(editor, node),
+                    match: (node) => isBlock(editor, node),
                     mode: 'highest',
                     voids: true,
                 }),

--- a/packages/slate-commons/src/plugins/withBreaksOnVoidNodes/withBreaksOnVoidNodes.ts
+++ b/packages/slate-commons/src/plugins/withBreaksOnVoidNodes/withBreaksOnVoidNodes.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
-import { Editor } from 'slate';
+import type { Editor } from 'slate';
 
-import { getCurrentNodeEntry, insertEmptyParagraph } from '../../commands';
+import { getCurrentNodeEntry, insertEmptyParagraph, isVoid } from '../../commands';
 
 export function withBreaksOnVoidNodes<T extends Editor>(editor: T): T {
     const { insertBreak } = editor;
@@ -9,7 +9,7 @@ export function withBreaksOnVoidNodes<T extends Editor>(editor: T): T {
     editor.insertBreak = () => {
         const [currentNode] = getCurrentNodeEntry(editor) || [];
 
-        if (Editor.isVoid(editor, currentNode)) {
+        if (currentNode && isVoid(editor, currentNode)) {
             /**
              * When trying to insert a break (press Enter) on a void node, the break is not inserted.
              * Reported here: https://github.com/prezly/prezly/pull/8239#discussion_r460073101

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -88,9 +88,9 @@
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.82.1",
-        "slate-history": "^0.66.0",
-        "slate-react": "^0.82.1"
+        "slate": "^0.91.4",
+        "slate-history": "^0.86.0",
+        "slate-react": "^0.91.7"
     },
     "devDependencies": {
         "@babel/core": "^7.18.5",

--- a/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
+++ b/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
@@ -1,8 +1,9 @@
-import { ReactElement, Ref, ReactNode, useRef } from 'react';
+import type { ReactElement, Ref, ReactNode } from 'react';
+import { useRef } from 'react';
 import React, { useMemo, useReducer, useState } from 'react';
 import { useRootClose } from 'react-overlays';
-import { mergeRefs } from '#lib';
 
+import { mergeRefs } from '#lib';
 import {
     useDebounce,
     useFunction,

--- a/packages/slate-editor/src/extensions/autoformat/transforms/autoformatBlock.ts
+++ b/packages/slate-editor/src/extensions/autoformat/transforms/autoformatBlock.ts
@@ -8,7 +8,7 @@ import {
     someNode,
 } from '@udecode/plate-core';
 import { castArray } from 'lodash-es';
-import type { Range , Editor} from 'slate';
+import type { Range, Editor } from 'slate';
 import { Transforms } from 'slate';
 import { HistoryEditor } from 'slate-history';
 

--- a/packages/slate-editor/src/extensions/autoformat/transforms/autoformatBlock.ts
+++ b/packages/slate-editor/src/extensions/autoformat/transforms/autoformatBlock.ts
@@ -1,3 +1,4 @@
+import { EditorCommands } from '@prezly/slate-commons';
 import {
     ELEMENT_DEFAULT,
     getRangeBefore,
@@ -7,8 +8,8 @@ import {
     someNode,
 } from '@udecode/plate-core';
 import { castArray } from 'lodash-es';
-import type { Range } from 'slate';
-import { Editor, Transforms } from 'slate';
+import type { Range , Editor} from 'slate';
+import { Transforms } from 'slate';
 import { HistoryEditor } from 'slate-history';
 
 import type { AutoformatBlockRule } from '../types';
@@ -49,7 +50,7 @@ export function autoformatBlock(
             // Don't autoformat if there is void nodes.
             const hasVoidNode = someNode(editor, {
                 at: matchRange,
-                match: (n) => Editor.isVoid(editor, n),
+                match: (node) => EditorCommands.isVoid(editor, node),
             });
             if (hasVoidNode) continue;
 
@@ -82,7 +83,7 @@ export function autoformatBlock(
                 editor,
                 { type },
                 {
-                    match: (n) => Editor.isBlock(editor, n),
+                    match: (node) => EditorCommands.isBlock(editor, node),
                 },
             );
         } else {

--- a/packages/slate-editor/src/extensions/paste-slate-content/lib/withSlatePasting.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/lib/withSlatePasting.ts
@@ -54,7 +54,7 @@ function handlePastingIntoPreservedBlock(
     fragment: SlateFragment,
     isPreservedBlock: IsPreservedBlock,
 ) {
-    const nodesAbove = Editor.nodes(editor, { match: (node) => Editor.isBlock(editor, node) });
+    const nodesAbove = Editor.nodes(editor, { match: (node) => EditorCommands.isBlock(editor, node) });
     const [nearestBlock] = Array.from(nodesAbove).at(-1) ?? [];
 
     if (

--- a/packages/slate-editor/src/extensions/paste-slate-content/lib/withSlatePasting.ts
+++ b/packages/slate-editor/src/extensions/paste-slate-content/lib/withSlatePasting.ts
@@ -54,7 +54,9 @@ function handlePastingIntoPreservedBlock(
     fragment: SlateFragment,
     isPreservedBlock: IsPreservedBlock,
 ) {
-    const nodesAbove = Editor.nodes(editor, { match: (node) => EditorCommands.isBlock(editor, node) });
+    const nodesAbove = Editor.nodes(editor, {
+        match: (node) => EditorCommands.isBlock(editor, node),
+    });
     const [nearestBlock] = Array.from(nodesAbove).at(-1) ?? [];
 
     if (

--- a/packages/slate-editor/src/extensions/void/VoidExtension.tsx
+++ b/packages/slate-editor/src/extensions/void/VoidExtension.tsx
@@ -1,7 +1,7 @@
 import type { Extension } from '@prezly/slate-commons';
 import { EditorCommands } from '@prezly/slate-commons';
 import { isHotkey } from 'is-hotkey';
-import { Editor, Transforms } from 'slate';
+import { Transforms } from 'slate';
 
 import { isDeletingEvent } from '#lib';
 
@@ -15,7 +15,7 @@ export function VoidExtension(): Extension {
         onKeyDown: (event, editor) => {
             const [currentNode] = EditorCommands.getCurrentNodeEntry(editor) ?? [];
 
-            if (!currentNode || !editor.selection || !Editor.isVoid(editor, currentNode)) {
+            if (!currentNode || !editor.selection || !EditorCommands.isVoid(editor, currentNode)) {
                 return;
             }
 

--- a/packages/slate-editor/src/modules/editor/lib/createOnCut.ts
+++ b/packages/slate-editor/src/modules/editor/lib/createOnCut.ts
@@ -1,3 +1,4 @@
+import { EditorCommands } from '@prezly/slate-commons';
 import { Editor, Range, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
@@ -26,7 +27,7 @@ export function createOnCut(editor: Editor) {
 
         const [voidEntry] = Array.from(
             Editor.nodes(editor, {
-                match: (node) => Editor.isVoid(editor, node),
+                match: (node) => EditorCommands.isVoid(editor, node),
             }),
         );
 

--- a/packages/slate-editor/src/modules/editor/lib/useCursorInView.ts
+++ b/packages/slate-editor/src/modules/editor/lib/useCursorInView.ts
@@ -2,7 +2,7 @@ import { EditorCommands } from '@prezly/slate-commons';
 import { isImageNode } from '@prezly/slate-types';
 import jsonStableStringify from 'json-stable-stringify';
 import { useLayoutEffect } from 'react';
-import type { Editor} from 'slate';
+import type { Editor } from 'slate';
 import { Range } from 'slate';
 
 import { ensureElementInView, ensureRangeInView } from '#lib';
@@ -39,7 +39,11 @@ function ensureCursorInView(editor: Editor, parameters: Parameters): void {
         return;
     }
 
-    if (currentNode && EditorCommands.isBlock(editor, currentNode) && EditorCommands.isVoid(editor, currentNode)) {
+    if (
+        currentNode &&
+        EditorCommands.isBlock(editor, currentNode) &&
+        EditorCommands.isVoid(editor, currentNode)
+    ) {
         /**
          * Slate reports invalid `domRange` on void elements. The reported range points to
          * the `data-slate-zero-width` element which is inside [data-slate-spacer="true"]

--- a/packages/slate-editor/src/modules/editor/lib/useCursorInView.ts
+++ b/packages/slate-editor/src/modules/editor/lib/useCursorInView.ts
@@ -2,7 +2,8 @@ import { EditorCommands } from '@prezly/slate-commons';
 import { isImageNode } from '@prezly/slate-types';
 import jsonStableStringify from 'json-stable-stringify';
 import { useLayoutEffect } from 'react';
-import { Editor, Range } from 'slate';
+import type { Editor} from 'slate';
+import { Range } from 'slate';
 
 import { ensureElementInView, ensureRangeInView } from '#lib';
 
@@ -38,7 +39,7 @@ function ensureCursorInView(editor: Editor, parameters: Parameters): void {
         return;
     }
 
-    if (Editor.isBlock(editor, currentNode) && Editor.isVoid(editor, currentNode)) {
+    if (currentNode && EditorCommands.isBlock(editor, currentNode) && EditorCommands.isVoid(editor, currentNode)) {
         /**
          * Slate reports invalid `domRange` on void elements. The reported range points to
          * the `data-slate-zero-width` element which is inside [data-slate-spacer="true"]

--- a/packages/slate-lists/package.json
+++ b/packages/slate-lists/package.json
@@ -43,8 +43,8 @@
     },
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.82.1",
-        "slate-react": "^0.82.1"
+        "slate": "^0.91.4",
+        "slate-react": "^0.91.7"
     },
     "dependencies": {
         "is-hotkey": "^0.2.0",

--- a/packages/slate-tables/package.json
+++ b/packages/slate-tables/package.json
@@ -43,8 +43,8 @@
     },
     "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.82.1",
-        "slate-react": "^0.82.1"
+        "slate": "^0.91.4",
+        "slate-react": "^0.91.7"
     },
     "dependencies": {
         "@prezly/slate-commons": "^0.79.4",

--- a/packages/slate-types/package.json
+++ b/packages/slate-types/package.json
@@ -37,7 +37,7 @@
         "clean:build": "rimraf build/ *.tsbuildinfo"
     },
     "peerDependencies": {
-        "slate": "^0.82.1"
+        "slate": "^0.91.4"
     },
     "dependencies": {
         "@prezly/sdk": "^13.0.0 || ^14.0.0",


### PR DESCRIPTION
Fixes #367

I've introduced helper functions for `isBlock`, `isInline` and `isVoid` so we don't have to call `Editor.isElement` with every usage since the types [have been fixed now](https://github.com/ianstormtaylor/slate/pull/5254).