### PR TITLE
[CARE-1293] Snippet doesn't match when pasted

### DIFF
--- a/packages/slate-editor/src/extensions/snippet/lib/useFloatingSnippetInput.ts
+++ b/packages/slate-editor/src/extensions/snippet/lib/useFloatingSnippetInput.ts
@@ -45,7 +45,7 @@ export function useFloatingSnippetInput(editor: Editor): [State, Actions] {
                 return;
             }
 
-            EditorCommands.insertNodes(editor, node.children);
+            EditorCommands.insertNodes(editor, node.children, { mode: 'highest' });
 
             editor.flash(node.children.at(0), node.children.at(-1));
             savedSelection.restore(editor, { focus: true });


### PR DESCRIPTION
https://linear.app/prezly/issue/CARE-1293/snippet-doesnt-match-when-pasted-in-a-campaignstory