### PR TITLE
[CARE-1379] Quickfix - Prezly editor is very slow

### DIFF
--- a/packages/slate-editor/src/modules/nodes-hierarchy/hierarchySchema.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/hierarchySchema.ts
@@ -35,7 +35,7 @@ import {
     isInlineNode,
     isDescendantOf,
 } from './queries';
-import { ANY_NODE_TYPE, EDITOR_NODE_TYPE, TEXT_NODE_TYPE } from './types';
+import { EDITOR_NODE_TYPE, TEXT_NODE_TYPE } from './types';
 import type { NodesHierarchySchema } from './types';
 import { combineFixers } from './utils';
 
@@ -43,7 +43,9 @@ import { IMAGE_CANDIDATE_NODE_TYPE } from '#extensions/image/constants';
 
 /*eslint sort-keys-fix/sort-keys-fix: "error"*/
 export const hierarchySchema: NodesHierarchySchema = {
-    [ANY_NODE_TYPE]: [mustHaveChildren(fixers.removeNode)],
+    // Commented out to quickfix a performance issue we have
+    // @see CARE-1379 and CARE-1320
+    // // [ANY_NODE_TYPE]: [mustHaveChildren(fixers.removeNode)],
     [ATTACHMENT_NODE_TYPE]: [allowChildren(isEmptyTextNode, fixers.liftNodeNoSplit)],
     [BOOKMARK_NODE_TYPE]: [allowChildren(isEmptyTextNode, fixers.liftNodeNoSplit)],
     [CONTACT_NODE_TYPE]: [allowChildren(isEmptyTextNode, fixers.liftNodeNoSplit)],

--- a/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/allowChildren.test.tsx
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/allowChildren.test.tsx
@@ -56,8 +56,8 @@ describe('allowChildren', () => {
             </editor-pure>
         ) as unknown as Editor;
 
-        editor.normalizeNode = ([, path]) => {
-            return normilizer(editor, path);
+        editor.normalizeNode = ([node, path]) => {
+            return normilizer(editor, node, path);
         };
 
         const expected = (

--- a/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/allowChildren.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/allowChildren.ts
@@ -6,9 +6,7 @@ export function allowChildren(
     isAllowed: HierarchyNodeQuery,
     fix: HierarchyFixer,
 ): HierarchyNormalizer {
-    return (editor, path) => {
-        const node = Node.get(editor, path);
-
+    return (editor, node, path) => {
         if ('children' in node) {
             for (const [childNode, childPath] of Node.children(editor, path)) {
                 if (!isAllowed(childNode, childPath, editor)) {

--- a/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/disallowMark.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/disallowMark.ts
@@ -1,6 +1,6 @@
 import { EditorCommands } from '@prezly/slate-commons';
 import type { TextNode } from '@prezly/slate-types';
-import { Node, Text } from 'slate';
+import { Text } from 'slate';
 
 import type { HierarchyNormalizer, HierarchyNodeQuery } from '../types';
 
@@ -8,9 +8,7 @@ export function disallowMark(
     mark: keyof Omit<TextNode, 'text'>,
     match: HierarchyNodeQuery,
 ): HierarchyNormalizer {
-    return (editor, path) => {
-        const node = Node.get(editor, path);
-
+    return (editor, node, path) => {
         if (Text.isText(node)) {
             if (!node[mark]) {
                 return false;

--- a/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/mustHaveChildren.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/mustHaveChildren.ts
@@ -1,11 +1,7 @@
-import { Node } from 'slate';
-
 import type { HierarchyFixer, HierarchyNormalizer } from '../types';
 
 export function mustHaveChildren(fix: HierarchyFixer): HierarchyNormalizer {
-    return (editor, path) => {
-        const node = Node.get(editor, path);
-
+    return (editor, node, path) => {
         if ('children' in node && node.children.length === 0) {
             const at = [...path, 0];
             return fix(editor, [node, at]);

--- a/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/removeWhenNoChildren.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/normilizers/removeWhenNoChildren.ts
@@ -1,11 +1,9 @@
-import { Node, Transforms } from 'slate';
+import { Transforms } from 'slate';
 
 import type { HierarchyNormalizer } from '../types';
 
 export function removeWhenNoChildren(): HierarchyNormalizer {
-    return (editor, path) => {
-        const node = Node.get(editor, path);
-
+    return (editor, node, path) => {
         if ('children' in node && node.children.length === 0) {
             Transforms.removeNodes(editor, { at: path, match: (n) => n === node });
             return true;

--- a/packages/slate-editor/src/modules/nodes-hierarchy/tests/AnyNode.test.tsx
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/tests/AnyNode.test.tsx
@@ -6,7 +6,12 @@ import { Editor } from 'slate';
 
 import { jsx } from '../../../jsx';
 
-describe('nodes-hierarchy / Any Node', () => {
+/**
+ * Note: xdescribe()
+ * This test is skipped.
+ * Reverted the fix for performance reasons. See CARE-1379 and CARE-1320
+ */
+xdescribe('nodes-hierarchy / Any Node', () => {
     it('should remove nodes without children', () => {
         const editor = (
             <editor>

--- a/packages/slate-editor/src/modules/nodes-hierarchy/types.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/types.ts
@@ -1,7 +1,7 @@
 import type { Editor, Path, Node, NodeEntry } from 'slate';
 
 export type HierarchyNodeQuery = (node: Node, path: Path, editor: Editor) => boolean;
-export type HierarchyNormalizer = (editor: Editor, path: Path) => boolean;
+export type HierarchyNormalizer = (editor: Editor, node: Node, path: Path) => boolean;
 export type HierarchyFixer = (editor: Editor, entry: NodeEntry) => boolean;
 
 export const EDITOR_NODE_TYPE = Symbol('EDITOR');

--- a/packages/slate-editor/src/modules/nodes-hierarchy/withNodesHierarchy.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/withNodesHierarchy.ts
@@ -18,7 +18,7 @@ export function withNodesHierarchy(schema: NodesHierarchySchema) {
             }
 
             for (const normalizer of normalizers) {
-                const isNormalized = normalizer(editor, path);
+                const isNormalized = normalizer(editor, node, path);
 
                 if (isNormalized) {
                     return;


### PR DESCRIPTION
- Revert fix for CARE-1320 (see #404)
  The problem with this fix was that it's calling normalization _on absolutely every node_ in the document tree _on every keystroke_, which is A LOT for large documents. This was causing a major hit on the editor performance.
- Minor optimization on avoiding calling `Node.get()` in every normalizer