### PR TITLE
[CARE-1580] Refactor - Replace react-bootstrap's `Dropdown` with headlessui's `Listbox` in `Menu.Dropdown`

### DIFF
--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -49,6 +49,7 @@
         "storybook:build": "pnpm install --dir ./storybook && pnpm run --dir ./storybook build"
     },
     "dependencies": {
+        "@headlessui/react": "^1.7.14",
         "@popperjs/core": "^2.6.0",
         "@prezly/docx-cleaner": "^0.5.2",
         "@prezly/events": "^2.0.3",

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -13,12 +13,13 @@
     }
 
     .DropdownToggle {
+        border: none;
+        outline: none;
         width: 100%;
         height: 40px;
         padding: 0 $spacing-2;
         font-size: 13px;
         background: none;
-        border: 0;
         text-align: left;
         color: $toolbar-dark-theme-text-color;
         position: relative;
@@ -59,6 +60,8 @@
     }
 
     .DropdownMenu {
+        border: none;
+        outline: none;
         position: absolute;
         top: 100%;
         left: 0;
@@ -79,7 +82,6 @@
 
     .MenuItem {
         min-height: 34px;
-        width: 100%;
         display: flex;
         align-items: center;
         flex-wrap: wrap;

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -4,7 +4,6 @@
 .Dropdown {
     display: inline-block;
     width: 180px;
-    vertical-align: top;
     border-color: $toolbar-dark-theme-border-color;
     position: relative;
     font-weight: normal;

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -5,50 +5,24 @@
     display: inline-block;
     width: 180px;
     vertical-align: top;
-
     border-color: $toolbar-dark-theme-border-color;
+    position: relative;
+    font-weight: normal;
 
     &:last-child {
         border-right: none;
     }
 
-    &,
-    &:global(.open) {
-        :global(.dropdown-toggle) {
-            &,
-            &:hover,
-            &:focus {
-                color: $toolbar-dark-theme-text-color;
-                background: none;
-                box-shadow: none;
-            }
-        }
-    }
-
-    &:global(.open) {
-        &:after {
-            content: "";
-            position: absolute;
-            width: $border-radius-base * 2 + 2px;
-            height: $border-radius-base * 2 + 2px;
-            right: 0;
-            bottom: 0;
-            display: block;
-            background-color: $toolbar-dark-theme-bg;
-        }
-    }
-
-    :global(.dropdown-toggle) {
+    .DropdownToggle {
         width: 100%;
         height: 40px;
         padding: 0 $spacing-2;
         font-size: 13px;
         background: none;
         border: 0;
-        border-radius: 0;
-        font-weight: normal;
         text-align: left;
         color: $toolbar-dark-theme-text-color;
+        position: relative;
 
         &:hover {
             color: $toolbar-dark-theme-text-hover-color;
@@ -68,68 +42,69 @@
             }
         }
 
-        :global(.caret) {
+        .Caret {
             position: absolute;
             top: 50%;
             right: $spacing-2;
+            color: $toolbar-dark-theme-icon-color;
             margin-top: -2px;
-            // beat `.btn-default .caret` !important rule specificity
-            color: $toolbar-dark-theme-icon-color !important;
+            margin-left: 2px;
+            display: inline-block;
+            width: 0;
+            height: 0;
+            vertical-align: middle;
+            border-top: 4px dashed;
+            border-right: 4px solid transparent;
+            border-left: 4px solid transparent;
         }
     }
 
-    :global(.dropdown-menu) {
+    .DropdownMenu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        min-width: 160px;
+        text-align: left;
+        list-style: none;
+        background-clip: padding-box;
+        display: flex;
+        flex-direction: column;
         width: 181px; // we need +1 px to align with the toggle button
         margin: 0 0 0 -1px;
         overflow: auto;
         padding: $spacing-1 0;
-        border: none;
         background-color: $toolbar-dark-theme-bg;
         border-radius: 0 0 $border-radius-base * 2 $border-radius-base * 2;
         box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.11), inset 0 1px 0 $toolbar-dark-theme-border-color;
-
-        a {
-            text-decoration: none;
-        }
     }
 
     .MenuItem {
-        margin-bottom: 0;
         min-height: 34px;
-        // Workaround to center the text inside a fixed-height container.
-        // Using `flex` doesn't work because it breaks the hover highlight,
-        // which is set on the child `a`.
-        display: table;
         width: 100%;
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        position: relative;
+        padding: 0 $spacing-2;
+        color: $toolbar-dark-theme-icon-color;
+        border-top: 1px solid transparent;
+        cursor: pointer;
 
-        > a {
-            display: table-cell;
-            vertical-align: middle;
-            position: relative;
-            padding: 0 $spacing-2;
-            color: $toolbar-dark-theme-icon-color;
-            border-top: 1px solid transparent;
-
-            &,
-            &:hover {
-                background-color: transparent;
-            }
-
-            &:hover {
-                color: $toolbar-dark-theme-text-hover-color;
-            }
-
-            &:focus::before {
-                top: $spacing-half;
-                bottom: $spacing-half;
-                left: $spacing-base;
-                right: $spacing-base;
-                display: block;
-                outline: $spacing-half solid $toolbar-dark-theme-focus-outline;
-            }
+        > span {
+            font-size: 14px;
         }
 
-        &.selected > a {
+        &:focus::before {
+            top: $spacing-half;
+            bottom: $spacing-half;
+            left: $spacing-base;
+            right: $spacing-base;
+            display: block;
+            outline: $spacing-half solid $toolbar-dark-theme-focus-outline;
+        }
+
+        &.selected,
+        &.active {
             color: $toolbar-dark-theme-icon-active-color;
 
             &::before {
@@ -143,6 +118,15 @@
                 left: $spacing-base;
                 right: $spacing-base;
                 background-color: $toolbar-dark-theme-hover-bg;
+            }
+        }
+
+        // Keyboard navigation and hover styles
+        &.active:not(.selected) {
+            color: $toolbar-dark-theme-text-hover-color;
+
+            &::before {
+                opacity: 0.5;
             }
         }
     }

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -25,6 +25,7 @@
         position: relative;
 
         &:hover {
+            cursor: pointer;
             color: $toolbar-dark-theme-text-hover-color;
 
             &::before {

--- a/packages/slate-editor/src/components/Menu/Dropdown.tsx
+++ b/packages/slate-editor/src/components/Menu/Dropdown.tsx
@@ -1,9 +1,9 @@
+import { Listbox } from '@headlessui/react';
+import type { ListboxProps } from '@headlessui/react';
 import classNames from 'classnames';
 import type { ComponentType, FunctionComponent } from 'react';
-import { useState } from 'react';
+import { Fragment } from 'react';
 import React from 'react';
-import type { DropdownProps } from 'react-bootstrap';
-import { Dropdown as BootstrapDropdown, MenuItem } from 'react-bootstrap';
 
 import styles from './Dropdown.module.scss';
 
@@ -14,11 +14,13 @@ export namespace Dropdown {
         value: Value;
     }
 
-    export interface Props<Value extends string> extends Omit<DropdownProps, 'onChange'> {
+    export interface Props<Value extends string>
+        extends Omit<ListboxProps<'div', Value, Value>, 'onChange' | 'className'> {
         onChange: (value: Value) => void;
         options: Option<Value>[];
         renderOption?: ComponentType<{ option: Option<Value>; selected: boolean }>;
         value?: Value;
+        className?: string;
     }
 }
 
@@ -30,9 +32,8 @@ export function Dropdown<Value extends string = string>({
     value,
     ...props
 }: Dropdown.Props<Value>): ReturnType<FunctionComponent<Dropdown.Props<Value>>> {
-    const [open, setOpen] = useState(false);
     const RenderOption = renderOption;
-    const selectedOption = options.find((option) => option.value === value);
+    const selected = options.find((option) => option.value === value);
     const visibleOptions = options.filter(({ hidden }) => !hidden);
 
     function handleSelect(newValue: any) {
@@ -44,30 +45,36 @@ export function Dropdown<Value extends string = string>({
     }
 
     return (
-        <BootstrapDropdown
-            {...props}
+        <Listbox
             className={classNames(styles.Dropdown, className)}
-            onSelect={handleSelect}
-            open={open}
-            onToggle={(isOpen, _, meta) => meta.source !== 'rootClose' && setOpen(isOpen)}
+            as="div"
+            {...props}
+            value={selected}
+            onChange={handleSelect}
         >
-            <BootstrapDropdown.Toggle>{selectedOption?.label}</BootstrapDropdown.Toggle>
-            <BootstrapDropdown.Menu>
-                {visibleOptions.map((option) => {
-                    return (
-                        <MenuItem
-                            className={classNames(styles.MenuItem, {
-                                [styles.selected]: option.value === value,
-                            })}
-                            eventKey={option.value}
-                            key={option.value}
-                        >
-                            <RenderOption option={option} selected={option.value === value} />
-                        </MenuItem>
-                    );
-                })}
-            </BootstrapDropdown.Menu>
-        </BootstrapDropdown>
+            <Listbox.Button className={styles.DropdownToggle}>
+                {selected?.label}
+                <span className={styles.Caret} />
+            </Listbox.Button>
+            <Listbox.Options className={styles.DropdownMenu}>
+                {visibleOptions.map((option) => (
+                    <Listbox.Option key={option.value} as={Fragment} value={option.value}>
+                        {({ selected, active }) => (
+                            <li
+                                className={classNames(styles.MenuItem, {
+                                    [styles.selected]: option.value === value,
+                                    [styles.active]: active,
+                                })}
+                            >
+                                <span>
+                                    <RenderOption option={option} selected={selected} />
+                                </span>
+                            </li>
+                        )}
+                    </Listbox.Option>
+                ))}
+            </Listbox.Options>
+        </Listbox>
     );
 }
 

--- a/packages/slate-editor/src/components/Menu/Menu.module.scss
+++ b/packages/slate-editor/src/components/Menu/Menu.module.scss
@@ -104,6 +104,8 @@
         }
 
         &:hover {
+            cursor: pointer;
+
             &::before {
                 // Trick to display smaller hover background square,
                 // while keeping the button area as big as possible (for a11y)

--- a/packages/slate-editor/src/components/Menu/Menu.module.scss
+++ b/packages/slate-editor/src/components/Menu/Menu.module.scss
@@ -187,4 +187,26 @@
             margin-right: -$spacing-half;
         }
     }
+
+    // Un-round bottom corner of `Menu` if last child is an open `Dropdown`
+
+    &:has(> *:last-child[data-headlessui-state="open"]) {
+        border-bottom-right-radius: 0;
+    }
+
+    // Firefox doesn't support `has` selector yet
+    // https://stackoverflow.com/a/1014958/6622233
+    // This is a workaround to apply the same effect
+    @include firefox-only {
+        > *:last-child[data-headlessui-state="open"]::after {
+            content: "";
+            position: absolute;
+            height: $border-radius-base * 2 + 2px;
+            width: $border-radius-base * 2 + 2px;
+            right: 0;
+            bottom: 0;
+            display: block;
+            background-color: $toolbar-dark-theme-bg;
+        }
+    }
 }

--- a/packages/slate-editor/src/components/Menu/Menu.module.scss
+++ b/packages/slate-editor/src/components/Menu/Menu.module.scss
@@ -197,16 +197,21 @@
     // Firefox doesn't support `has` selector yet
     // https://stackoverflow.com/a/1014958/6622233
     // This is a workaround to apply the same effect
+    // Adds a triangle at bottom-right corner: ◢
     @include firefox-only {
         > *:last-child[data-headlessui-state="open"]::after {
+            $size: ($border-radius-base * 2 + 2px);
+
             content: "";
             position: absolute;
-            height: $border-radius-base * 2 + 2px;
-            width: $border-radius-base * 2 + 2px;
+            height: 0;
+            width: 0;
+            border-left: $size solid transparent;
+            border-bottom: $size solid $toolbar-dark-theme-bg;
             right: 0;
             bottom: 0;
             display: block;
-            background-color: $toolbar-dark-theme-bg;
+            z-index: -10;
         }
     }
 }

--- a/packages/slate-editor/src/components/Menu/Menu.stories.tsx
+++ b/packages/slate-editor/src/components/Menu/Menu.stories.tsx
@@ -48,7 +48,6 @@ export function FloatingMenu() {
         <div
             ref={setContainer}
             style={{
-                background: 'rgba(31, 32, 35, 0.5)',
                 height: 200,
                 marginTop: 100,
                 maxWidth: 900,
@@ -90,6 +89,53 @@ export function FloatingMenu() {
                         <Menu.Icon icon={Icons.Delete} />
                     </Menu.Button>
                 </Menu.ButtonGroup>
+            </Menu.FloatingMenu>
+        </div>
+    );
+}
+
+export function FloatingMenuWithDropdownLast() {
+    const [container, setContainer] = useState<HTMLDivElement | null>(null);
+    const [alignment, onAlignmentChange] = useState('left');
+    const [appearance, onAppearanceChange] = useState('intro');
+
+    return (
+        <div
+            ref={setContainer}
+            style={{
+                height: 200,
+                marginTop: 100,
+                maxWidth: 900,
+            }}
+        >
+            <Menu.FloatingMenu
+                className="settings-menu"
+                containerRef={{ current: container }}
+                element={container}
+            >
+                <Menu.Link href={`/stories/1`} target="_blank">
+                    Edit story
+                </Menu.Link>
+
+                <Menu.ButtonGroup>
+                    {ALIGNMENT_OPTIONS.map((option) => (
+                        <Menu.Button
+                            active={alignment === option.value}
+                            key={option.value}
+                            onMouseDown={() => onAlignmentChange(option.value)}
+                            title={option.label}
+                        >
+                            <Menu.Icon icon={option.icon} />
+                        </Menu.Button>
+                    ))}
+                </Menu.ButtonGroup>
+
+                <Menu.Dropdown
+                    id="story-appearance"
+                    onChange={onAppearanceChange}
+                    options={APPEARANCE_OPTIONS}
+                    value={appearance}
+                />
             </Menu.FloatingMenu>
         </div>
     );

--- a/packages/slate-editor/src/styles/helpers.scss
+++ b/packages/slate-editor/src/styles/helpers.scss
@@ -75,3 +75,9 @@
         }
     }
 }
+
+@mixin firefox-only {
+    @-moz-document url-prefix() {
+        @content;
+    }
+}


### PR DESCRIPTION
There are two other places that need to be replaced:

- [MentionsDropdown](https://github.com/prezly/slate/blob/950cd7787fae1ec1a36ad3eb461ff8dbf5c0ef79/packages/slate-editor/src/extensions/mentions/components/MentionsDropdown.tsx#LL6C3-L6C3)
- [Dropdown (floating-add-menu)](https://github.com/prezly/slate/blob/950cd7787fae1ec1a36ad3eb461ff8dbf5c0ef79/packages/slate-editor/src/extensions/floating-add-menu/components/Dropdown.tsx#LL6C3-L6C3)

Will replace them in their corresponding PRs.

---

It now supports a focus trap as well as keyboard navigation:


https://github.com/prezly/slate/assets/67554982/df1f0383-ffcb-4358-a348-68862b387ce3

