### PR TITLE
[DEV-10754] Allow triggering search via events, minor text changes

### DIFF
--- a/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
+++ b/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
@@ -71,7 +71,7 @@ export function SearchInput<T = unknown>({
         isNotDisabled,
     );
 
-    async function search(query: string) {
+    const search = useFunction(async (query: string) => {
         if (latest.current.state.loading[query]) {
             return;
         }
@@ -81,7 +81,7 @@ export function SearchInput<T = unknown>({
         dispatch({ type: 'search', query });
         const suggestions = await getSuggestions(query);
         dispatch({ type: 'results', query, suggestions });
-    }
+    });
 
     useMount(async () => {
         await search('');

--- a/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
+++ b/packages/slate-editor/src/components/SearchInput/SearchInput.tsx
@@ -1,8 +1,10 @@
 import { isNotUndefined } from '@technically/is-not-undefined';
 import type { ReactElement, Ref, ReactNode } from 'react';
+import { useEffect } from 'react';
 import { useRef } from 'react';
 import React, { useMemo, useReducer, useState } from 'react';
 import { useRootClose } from 'react-overlays';
+import { useSlateStatic } from 'slate-react';
 
 import { mergeRefs } from '#lib';
 import {
@@ -13,6 +15,8 @@ import {
     useMemoryBuffer,
     useMount,
 } from '#lib';
+
+import { EventsEditor } from '#modules/events';
 
 import { Input, type Props as BaseProps } from '../Input';
 
@@ -40,6 +44,7 @@ export function SearchInput<T = unknown>({
     onSelect,
     ...attributes
 }: SearchInput.Props<T>) {
+    const editor = useSlateStatic();
     const rootRef = useRef<HTMLInputElement | null>(null);
     const reducer = useMemo(() => createReducer<T>(), []);
     const initialState = useMemo(() => reducer(undefined, { type: undefined }), [reducer]);
@@ -91,6 +96,13 @@ export function SearchInput<T = unknown>({
     );
 
     useRootClose(rootRef, () => setOpen(false));
+
+    useEffect(() => {
+        const unlisten = EventsEditor.addEventListener(editor, 'contact-dialog-searched', () =>
+            search(query),
+        );
+        return unlisten;
+    }, []);
 
     return (
         <Input

--- a/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.tsx
@@ -74,7 +74,7 @@ export function ContactPlaceholderElement({
                 </SearchInput.Suggestions>
             )}
             inputTitle="Site contacts"
-            inputDescription="Search for an existing site contact or create a new one"
+            inputDescription="Add a contact card to your stories, campaigns and pitches"
             inputPlaceholder="Search site contacts"
             onSelect={handleSelect}
             removable={removable}

--- a/packages/slate-editor/src/modules/editor/menuOptions.tsx
+++ b/packages/slate-editor/src/modules/editor/menuOptions.tsx
@@ -246,7 +246,7 @@ function* generateOptions(
             action: MenuAction.ADD_CONTACT,
             icon: Icons.ComponentContact,
             group: Group.PREZLY_CONTENT,
-            text: 'Contact',
+            text: 'Site contact',
             keywords: ['signature'],
             description: 'Add your site contacts',
         };

--- a/packages/slate-editor/src/modules/events/EventsEditor.ts
+++ b/packages/slate-editor/src/modules/events/EventsEditor.ts
@@ -3,8 +3,19 @@ import { Editor } from 'slate';
 
 import { EVENTS_PROPERTY } from './constants';
 import type { EditorEventMap } from './types';
+import type { EditorEventHandlers } from './types';
 
 export abstract class EventsEditor {
+    static addEventListener<Event extends keyof EditorEventMap>(
+        editor: Editor,
+        event: Event,
+        listener: EditorEventHandlers[Event],
+    ): void {
+        if (EventsEditor.isEventsEditor(editor)) {
+            editor[EVENTS_PROPERTY].addEventListener(event, listener);
+        }
+    }
+
     static dispatchEvent<Event extends keyof EditorEventMap>(
         editor: Editor,
         event: Event,

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -37,6 +37,7 @@ export type EditorEventMap = {
         uuid: string;
     };
     'contact-dialog-opened': never;
+    'contact-dialog-searched': never;
     'contact-dialog-search-used': never;
     'contact-dialog-submitted': {
         contact_id: NewsroomContact['uuid'];


### PR DESCRIPTION
Added an event listener that allows us to trigger the search from outside of the editor, example usage [can be found here](https://github.com/prezly/prezly/pull/13210/files#diff-ecc8a3a52125ed26cf02f50a1cc681c82d79ab001c491a275262e6ebec91db06R36-R38).