### PR TITLE
Fix - Compare options first before comparing references in contacts

### DIFF
--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -24,10 +24,7 @@ export const PressContactsExtension = (): Extension => ({
     },
     isElementEqual(element, another) {
         if (isContactNode(element) && isContactNode(another)) {
-            if (
-                !isEqual(element.layout, another.layout) ||
-                !isEqual(element.show_avatar, another.show_avatar)
-            ) {
+            if (element.layout !== another.layout || element.show_avatar !== another.show_avatar) {
                 return false;
             }
 

--- a/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/PressContactsExtension.tsx
@@ -24,6 +24,13 @@ export const PressContactsExtension = (): Extension => ({
     },
     isElementEqual(element, another) {
         if (isContactNode(element) && isContactNode(another)) {
+            if (
+                !isEqual(element.layout, another.layout) ||
+                !isEqual(element.show_avatar, another.show_avatar)
+            ) {
+                return false;
+            }
+
             // If these are contact references, then ContactInfo object is irrelevant
             if (element.reference || another.reference) {
                 return element.reference === another.reference;


### PR DESCRIPTION
This is a follow up to #418.

I've noticed changing the options in the contact's menu did not trigger a value change and then realised I forgot to update the equality checking function.