### PR TITLE
[DEV-10911] Render placeholders for Title/Subtitle headings, disable other features

### DIFF
--- a/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
+++ b/packages/slate-editor/src/extensions/floating-add-menu/lib/shouldShowMenuButton.ts
@@ -1,5 +1,10 @@
 import { EditorCommands } from '@prezly/slate-commons';
-import { isHeadingNode, isParagraphNode } from '@prezly/slate-types';
+import {
+    isHeadingNode,
+    isParagraphNode,
+    isSubtitleHeadingNode,
+    isTitleHeadingNode,
+} from '@prezly/slate-types';
 import type { Editor } from 'slate';
 import { Node, Range } from 'slate';
 
@@ -17,6 +22,10 @@ export function shouldShowMenuButton(editor: Editor): boolean {
     }
 
     if (!isParagraphNode(currentNode) && !isHeadingNode(currentNode)) {
+        return false;
+    }
+
+    if (isTitleHeadingNode(currentNode) || isSubtitleHeadingNode(currentNode)) {
         return false;
     }
 

--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
@@ -1,8 +1,20 @@
 @import "styles/variables";
 
 .HeadingElement {
+    position: relative;
     color: $editor-text-color;
-    font-weight: bold;
+    font-weight: 600;
+
+    &.title {
+        font-size: 40px;
+        line-height: 48px;
+    }
+
+    &.subtitle {
+        font-size: 22px;
+        font-weight: 500;
+        line-height: 32px;
+    }
 
     &.headingOne {
         font-size: $editor-heading-one-font-size;
@@ -17,4 +29,12 @@
     strong {
         font-weight: 900;
     }
+}
+
+.placeholder {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0.75;
+    pointer-events: none;
 }

--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
@@ -1,8 +1,11 @@
+import { EditorCommands } from '@prezly/slate-commons';
 import type { HeadingNode } from '@prezly/slate-types';
+import { HeadingRole } from '@prezly/slate-types';
 import { HEADING_1_NODE_TYPE, HEADING_2_NODE_TYPE } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
+import { useSlateStatic } from 'slate-react';
 
 import styles from './HeadingElement.module.scss';
 
@@ -12,15 +15,44 @@ interface Props extends HTMLAttributes<HTMLHeadingElement> {
 
 export const HeadingElement = forwardRef<HTMLHeadingElement, Props>(
     ({ children, className, element, ...props }, ref) => {
+        const editor = useSlateStatic();
         const Heading = element.type === HEADING_1_NODE_TYPE ? 'h3' : 'h4';
+
+        const isHeadingOne = element.type === HEADING_1_NODE_TYPE;
+        const isHeadingTwo = element.type === HEADING_2_NODE_TYPE;
+        const isTitle = element.role === HeadingRole.TITLE;
+        const isSubtitle = element.role === HeadingRole.SUBTITLE;
+
+        const finalClassNames = classNames(className, styles.HeadingElement, {
+            [styles.title]: isTitle,
+            [styles.subtitle]: isSubtitle,
+            [styles.headingOne]: !isTitle && isHeadingOne,
+            [styles.headingTwo]: !isSubtitle && isHeadingTwo,
+        });
+
+        if (isTitle && EditorCommands.isNodeEmpty(editor, element)) {
+            return (
+                <Heading {...props} ref={ref} className={finalClassNames}>
+                    {children}
+                    <span contentEditable={false} className={styles.placeholder}>Add a title</span>
+                </Heading>
+            );
+        }
+
+        if (isSubtitle && EditorCommands.isNodeEmpty(editor, element)) {
+            return (
+                <Heading {...props} ref={ref} className={finalClassNames}>
+                    {children}
+                    <span contentEditable={false} className={styles.placeholder}>Add a subtitle</span>
+                </Heading>
+            );
+        }
+
         return (
             <Heading
                 {...props}
                 ref={ref}
-                className={classNames(className, styles.HeadingElement, {
-                    [styles.headingOne]: element.type === HEADING_1_NODE_TYPE,
-                    [styles.headingTwo]: element.type === HEADING_2_NODE_TYPE,
-                })}
+                className={finalClassNames}
                 style={{ textAlign: element.align }}
             >
                 {children}

--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
@@ -34,7 +34,9 @@ export const HeadingElement = forwardRef<HTMLHeadingElement, Props>(
             return (
                 <Heading {...props} ref={ref} className={finalClassNames}>
                     {children}
-                    <span contentEditable={false} className={styles.placeholder}>Add a title</span>
+                    <span contentEditable={false} className={styles.placeholder}>
+                        Add a title
+                    </span>
                 </Heading>
             );
         }
@@ -43,7 +45,9 @@ export const HeadingElement = forwardRef<HTMLHeadingElement, Props>(
             return (
                 <Heading {...props} ref={ref} className={finalClassNames}>
                     {children}
-                    <span contentEditable={false} className={styles.placeholder}>Add a subtitle</span>
+                    <span contentEditable={false} className={styles.placeholder}>
+                        Add a subtitle
+                    </span>
                 </Heading>
             );
         }

--- a/packages/slate-editor/src/extensions/mentions/useMentions.ts
+++ b/packages/slate-editor/src/extensions/mentions/useMentions.ts
@@ -1,3 +1,4 @@
+import { stubTrue } from '@technically/lodash';
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
 import { useCallback, useMemo, useState } from 'react';
@@ -26,7 +27,7 @@ export interface Mentions<V> {
 
 export function useMentions<V>({
     createMentionElement,
-    isEnabled = () => true,
+    isEnabled = stubTrue,
     options,
     trigger,
 }: Parameters<V>): Mentions<V> {

--- a/packages/slate-editor/src/extensions/mentions/useMentions.ts
+++ b/packages/slate-editor/src/extensions/mentions/useMentions.ts
@@ -9,7 +9,7 @@ import type { MentionElementType, Option } from './types';
 
 interface Parameters<V> {
     createMentionElement: (option: Option<V>) => MentionElementType;
-    isEnabled: (target: Range | null) => boolean;
+    isEnabled?: (target: Range | null) => boolean;
     options: Option<V>[];
     trigger: string;
 }
@@ -26,7 +26,7 @@ export interface Mentions<V> {
 
 export function useMentions<V>({
     createMentionElement,
-    isEnabled,
+    isEnabled = () => true,
     options,
     trigger,
 }: Parameters<V>): Mentions<V> {

--- a/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
+++ b/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
@@ -21,7 +21,6 @@ export function useUserMentions({ users }: UserMentionsExtensionParameters = DEF
 
     return useMentions<User>({
         createMentionElement: (option) => createUserMention(option.value),
-        isEnabled: () => true,
         options,
         trigger: '@',
     });

--- a/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
+++ b/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
@@ -1,7 +1,4 @@
-import { isSubtitleHeadingNode, isTitleHeadingNode } from '@prezly/slate-types';
-import { useCallback, useMemo } from 'react';
-import type { BaseRange } from 'slate';
-import { Editor } from 'slate';
+import { useMemo } from 'react';
 
 import type { Option } from '#extensions/mentions';
 import { useMentions } from '#extensions/mentions';
@@ -19,31 +16,12 @@ function userToOption(user: User): Option<User> {
 
 const DEFAULT_PARAMETERS: UserMentionsExtensionParameters = { users: [] };
 
-export function useUserMentions(
-    editor: Editor,
-    { users }: UserMentionsExtensionParameters = DEFAULT_PARAMETERS,
-) {
+export function useUserMentions({ users }: UserMentionsExtensionParameters = DEFAULT_PARAMETERS) {
     const options = useMemo(() => users.map(userToOption), [users]);
-    const isEnabled = useCallback(
-        (range: BaseRange | null) => {
-            if (!range) {
-                return true;
-            }
-
-            const nodes = Array.from(
-                Editor.nodes(editor, {
-                    at: range,
-                    match: (node) => isTitleHeadingNode(node) || isSubtitleHeadingNode(node),
-                }),
-            );
-            return nodes.length === 0;
-        },
-        [editor],
-    );
 
     return useMentions<User>({
         createMentionElement: (option) => createUserMention(option.value),
-        isEnabled,
+        isEnabled: () => true,
         options,
         trigger: '@',
     });

--- a/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
+++ b/packages/slate-editor/src/extensions/user-mentions/useUserMentions.ts
@@ -1,4 +1,7 @@
-import { useMemo } from 'react';
+import { isSubtitleHeadingNode, isTitleHeadingNode } from '@prezly/slate-types';
+import { useCallback, useMemo } from 'react';
+import type { BaseRange } from 'slate';
+import { Editor } from 'slate';
 
 import type { Option } from '#extensions/mentions';
 import { useMentions } from '#extensions/mentions';
@@ -16,11 +19,31 @@ function userToOption(user: User): Option<User> {
 
 const DEFAULT_PARAMETERS: UserMentionsExtensionParameters = { users: [] };
 
-export function useUserMentions({ users }: UserMentionsExtensionParameters = DEFAULT_PARAMETERS) {
+export function useUserMentions(
+    editor: Editor,
+    { users }: UserMentionsExtensionParameters = DEFAULT_PARAMETERS,
+) {
     const options = useMemo(() => users.map(userToOption), [users]);
+    const isEnabled = useCallback(
+        (range: BaseRange | null) => {
+            if (!range) {
+                return true;
+            }
+
+            const nodes = Array.from(
+                Editor.nodes(editor, {
+                    at: range,
+                    match: (node) => isTitleHeadingNode(node) || isSubtitleHeadingNode(node),
+                }),
+            );
+            return nodes.length === 0;
+        },
+        [editor],
+    );
 
     return useMentions<User>({
         createMentionElement: (option) => createUserMention(option.value),
+        isEnabled,
         options,
         trigger: '@',
     });

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -269,8 +269,8 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
         }),
     );
 
-    const variables = useVariables(withVariables || undefined);
-    const userMentions = useUserMentions(withUserMentions || undefined);
+    const variables = useVariables(editor, withVariables || undefined);
+    const userMentions = useUserMentions(editor, withUserMentions || undefined);
 
     const [
         { isOpen: isFloatingStoryEmbedInputOpen },

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -270,7 +270,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
     );
 
     const variables = useVariables(editor, withVariables || undefined);
-    const userMentions = useUserMentions(editor, withUserMentions || undefined);
+    const userMentions = useUserMentions(withUserMentions || undefined);
 
     const [
         { isOpen: isFloatingStoryEmbedInputOpen },

--- a/packages/slate-editor/src/modules/nodes-hierarchy/fixers/unwrapNode.ts
+++ b/packages/slate-editor/src/modules/nodes-hierarchy/fixers/unwrapNode.ts
@@ -1,10 +1,11 @@
+import { stubTrue } from '@technically/lodash';
 import { Editor, Element, Transforms } from 'slate';
 import type { NodeEntry, Ancestor } from 'slate';
 
 export function unwrapNode(
     editor: Editor,
     [node, path]: NodeEntry,
-    match: (entry: NodeEntry, ancestor: NodeEntry<Ancestor>) => boolean = () => true,
+    match: (entry: NodeEntry, ancestor: NodeEntry<Ancestor>) => boolean = stubTrue,
 ) {
     const ancestor = Editor.above(editor, { at: path });
 


### PR DESCRIPTION
- renders "Add a title"/"Add a subtitle" for Title and Subtitle headings that have no text
- disables the floating add button for those nodes
- disables variables for those nodes
- no need to disable `#` and `##` shortcuts as those only work on paragraphs