### PR TITLE
[DEV-7542] Fix faulty type guards definitions

### DIFF
--- a/packages/slate-types/src/nodes/HeadingNode.ts
+++ b/packages/slate-types/src/nodes/HeadingNode.ts
@@ -26,12 +26,14 @@ export function isHeadingNode(value: any, type?: string): boolean {
     );
 }
 
-export function isTitleHeadingNode(value: any): value is HeadingNode;
+export function isTitleHeadingNode(value: any): value is HeadingNode & { role: HeadingRole.TITLE };
 export function isTitleHeadingNode(value: any): boolean {
     return isHeadingNode(value) && value.role === HeadingRole.TITLE;
 }
 
-export function isSubtitleHeadingNode(value: any): value is HeadingNode;
+export function isSubtitleHeadingNode(
+    value: any,
+): value is HeadingNode & { role: HeadingRole.SUBTITLE };
 export function isSubtitleHeadingNode(value: any): boolean {
     return isHeadingNode(value) && value.role === HeadingRole.SUBTITLE;
 }


### PR DESCRIPTION
While technically `isTitleHeading` and `isSubtitlteHeading` do assert that the value is `HeadingNode`, the returning type info is not accurate, as the assertion is actually narrower than just a `is HeadingNode`.

- `isTitleHeadingNode`
- `isSubtitleHeadingNode`