### PR TITLE
[DEV-10938] Fix - Title/Subtitle placeholders causing kb arrow keys navigation issues

### DIFF
--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
@@ -37,7 +37,6 @@
         }
     }
 
-
     strong {
         font-weight: 900;
     }

--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.module.scss
@@ -26,15 +26,19 @@
         line-height: $editor-heading-two-line-height;
     }
 
+    &[data-placeholder] {
+        &::before {
+            content: attr(data-placeholder);
+            position: absolute;
+            top: 0;
+            left: 0;
+            opacity: 0.75;
+            pointer-events: none;
+        }
+    }
+
+
     strong {
         font-weight: 900;
     }
-}
-
-.placeholder {
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0.75;
-    pointer-events: none;
 }

--- a/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
+++ b/packages/slate-editor/src/extensions/heading/components/HeadingElement.tsx
@@ -16,51 +16,38 @@ interface Props extends HTMLAttributes<HTMLHeadingElement> {
 export const HeadingElement = forwardRef<HTMLHeadingElement, Props>(
     ({ children, className, element, ...props }, ref) => {
         const editor = useSlateStatic();
-        const Heading = element.type === HEADING_1_NODE_TYPE ? 'h3' : 'h4';
+        const Tag = element.type === HEADING_1_NODE_TYPE ? 'h3' : 'h4';
 
         const isHeadingOne = element.type === HEADING_1_NODE_TYPE;
         const isHeadingTwo = element.type === HEADING_2_NODE_TYPE;
         const isTitle = element.role === HeadingRole.TITLE;
         const isSubtitle = element.role === HeadingRole.SUBTITLE;
 
-        const finalClassNames = classNames(className, styles.HeadingElement, {
-            [styles.title]: isTitle,
-            [styles.subtitle]: isSubtitle,
-            [styles.headingOne]: !isTitle && isHeadingOne,
-            [styles.headingTwo]: !isSubtitle && isHeadingTwo,
-        });
+        let placeholder: string | undefined = undefined;
 
         if (isTitle && EditorCommands.isNodeEmpty(editor, element)) {
-            return (
-                <Heading {...props} ref={ref} className={finalClassNames}>
-                    {children}
-                    <span contentEditable={false} className={styles.placeholder}>
-                        Add a title
-                    </span>
-                </Heading>
-            );
+            placeholder = 'Add a title';
         }
 
         if (isSubtitle && EditorCommands.isNodeEmpty(editor, element)) {
-            return (
-                <Heading {...props} ref={ref} className={finalClassNames}>
-                    {children}
-                    <span contentEditable={false} className={styles.placeholder}>
-                        Add a subtitle
-                    </span>
-                </Heading>
-            );
+            placeholder = 'Add a subtitle';
         }
 
         return (
-            <Heading
+            <Tag
                 {...props}
                 ref={ref}
-                className={finalClassNames}
+                className={classNames(className, styles.HeadingElement, {
+                    [styles.title]: isTitle,
+                    [styles.subtitle]: isSubtitle,
+                    [styles.headingOne]: !isTitle && isHeadingOne,
+                    [styles.headingTwo]: !isSubtitle && isHeadingTwo,
+                })}
                 style={{ textAlign: element.align }}
+                data-placeholder={placeholder}
             >
                 {children}
-            </Heading>
+            </Tag>
         );
     },
 );


### PR DESCRIPTION
Change Title/Subtitle placeholders to not produce DOM structure

Otherwise, when navigating the editor content with keyboard arrow keys, it'll do an extra stop after empty title/subtitle nodes (requiring to press Down twice in order to move to the next node).