### PR TITLE
[DEV-10988] Fix - Image caption not a part of page flow

### DIFF
--- a/packages/slate-editor/src/extensions/image/components/ImageElement.tsx
+++ b/packages/slate-editor/src/extensions/image/components/ImageElement.tsx
@@ -113,7 +113,7 @@ export function ImageElement({
                 isSupportingCaptions && (
                     <div
                         className={classNames(styles.Caption, {
-                            [styles.empty]: isCaptionEmpty,
+                            [styles.empty]: isCaptionEmpty && !isCaptionPlaceholderVisible,
                             [styles.withPlaceholder]: isCaptionPlaceholderVisible,
                             [styles.visible]: isCaptionVisible,
                             [styles.alignLeft]: align === Alignment.LEFT,


### PR DESCRIPTION
Caption will be hidden unless it's filled in or the image node is selected.

![Screenshot 2023-06-12 at 16 16 16](https://github.com/prezly/slate/assets/4209081/a604d306-a0cd-43a0-a439-ae7f53dfdb8f)

After:
![Screenshot 2023-06-12 at 16 16 21](https://github.com/prezly/slate/assets/4209081/7e110791-8089-4b87-a049-2a5d5580677c)
