### PR TITLE
[CARE-1802] Refactor - `slate-lists` plugin to not mutate editor instance

### DIFF
--- a/packages/slate-editor/src/extensions/list/ListExtension.tsx
+++ b/packages/slate-editor/src/extensions/list/ListExtension.tsx
@@ -4,7 +4,7 @@ import {
     ListsEditor,
     normalizeNode,
     onKeyDown,
-    withLists,
+    withListsSchema,
     withListsReact,
 } from '@prezly/slate-lists';
 import { TablesEditor } from '@prezly/slate-tables';
@@ -92,7 +92,7 @@ export function ListExtension(): Extension {
             return undefined;
         },
         withOverrides: (editor) => {
-            return withListsReact(withLists(schema)(editor));
+            return withListsReact(withListsSchema(schema)(editor));
         },
     };
 }

--- a/packages/slate-editor/src/extensions/list/ListExtension.tsx
+++ b/packages/slate-editor/src/extensions/list/ListExtension.tsx
@@ -1,15 +1,21 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
-import { ListsEditor, onKeyDown, normalizeNode } from '@prezly/slate-lists';
+import {
+    ListsEditor,
+    normalizeNode,
+    onKeyDown,
+    withLists,
+    withListsReact,
+} from '@prezly/slate-lists';
 import { TablesEditor } from '@prezly/slate-tables';
 import {
     BULLETED_LIST_NODE_TYPE,
-    NUMBERED_LIST_NODE_TYPE,
-    LIST_ITEM_NODE_TYPE,
-    LIST_ITEM_TEXT_NODE_TYPE,
-    isListNode,
     isListItemNode,
     isListItemTextNode,
+    isListNode,
+    LIST_ITEM_NODE_TYPE,
+    LIST_ITEM_TEXT_NODE_TYPE,
+    NUMBERED_LIST_NODE_TYPE,
 } from '@prezly/slate-types';
 import React from 'react';
 
@@ -17,7 +23,7 @@ import { composeElementDeserializer } from '#modules/html-deserialization';
 
 import { ListElement, ListItemElement, ListItemTextElement } from './components';
 import { normalizeRedundantAttributes, parseList, parseListItem, parseListItemText } from './lib';
-import { withListsFormatting } from './withListsFormatting';
+import { schema } from './schema';
 
 export const EXTENSION_ID = 'ListExtension';
 
@@ -49,7 +55,7 @@ export function ListExtension(): Extension {
         },
         normalizeNode: [normalizeNode, normalizeRedundantAttributes],
         onKeyDown(event, editor) {
-            if (ListsEditor.isListsEditor(editor)) {
+            if (ListsEditor.isListsEnabled(editor)) {
                 if (
                     TablesEditor.isTablesEditor(editor) &&
                     TablesEditor.isInTable(editor) &&
@@ -85,6 +91,8 @@ export function ListExtension(): Extension {
             }
             return undefined;
         },
-        withOverrides: withListsFormatting,
+        withOverrides: (editor) => {
+            return withListsReact(withLists(schema)(editor));
+        },
     };
 }

--- a/packages/slate-editor/src/extensions/list/schema.ts
+++ b/packages/slate-editor/src/extensions/list/schema.ts
@@ -1,23 +1,22 @@
-import type { ListsEditor, ListsSchema } from '@prezly/slate-lists';
-import { ListType, withLists, withListsReact } from '@prezly/slate-lists';
+import type { ListsSchema } from '@prezly/slate-lists';
+import { ListType } from '@prezly/slate-lists';
 import type { ListItemNode, ListNode } from '@prezly/slate-types';
 import {
     BULLETED_LIST_NODE_TYPE,
-    NUMBERED_LIST_NODE_TYPE,
     isHeadingNode,
     isListItemNode,
     isListItemTextNode,
     isListNode,
     isParagraphNode,
     isQuoteNode,
+    NUMBERED_LIST_NODE_TYPE,
 } from '@prezly/slate-types';
-import type { Editor } from 'slate';
 
 import { createParagraph } from '#extensions/paragraphs';
 
 import { createList, createListItem, createListItemText } from './lib';
 
-const SCHEMA: ListsSchema = {
+export const schema: ListsSchema = {
     isConvertibleToListTextNode(node) {
         return isParagraphNode(node) || isHeadingNode(node) || isQuoteNode(node);
     },
@@ -51,7 +50,3 @@ const SCHEMA: ListsSchema = {
         return createListItemText(props);
     },
 };
-
-export function withListsFormatting<T extends Editor>(editor: T): T & ListsEditor {
-    return withListsReact(withLists(SCHEMA, { normalizations: false })(editor));
-}

--- a/packages/slate-editor/src/modules/rich-formatting-menu/lib/toggleBlock.ts
+++ b/packages/slate-editor/src/modules/rich-formatting-menu/lib/toggleBlock.ts
@@ -12,19 +12,19 @@ export function toggleBlock<T extends ElementNode>(editor: Editor, type: T['type
         return;
     }
 
-    if (type === BULLETED_LIST_NODE_TYPE && ListsEditor.isListsEditor(editor)) {
+    if (type === BULLETED_LIST_NODE_TYPE && ListsEditor.isListsEnabled(editor)) {
         ListsEditor.wrapInList(editor, ListType.UNORDERED);
         ListsEditor.setListType(editor, ListType.UNORDERED);
         return;
     }
 
-    if (type === NUMBERED_LIST_NODE_TYPE && ListsEditor.isListsEditor(editor)) {
+    if (type === NUMBERED_LIST_NODE_TYPE && ListsEditor.isListsEnabled(editor)) {
         ListsEditor.wrapInList(editor, ListType.ORDERED);
         ListsEditor.setListType(editor, ListType.ORDERED);
         return;
     }
 
-    if (ListsEditor.isListsEditor(editor)) {
+    if (ListsEditor.isListsEnabled(editor)) {
         ListsEditor.unwrapList(editor);
     }
 

--- a/packages/slate-lists/README.md
+++ b/packages/slate-lists/README.md
@@ -132,7 +132,7 @@ const initialValue: Descendant[] = [{ type: Type.PARAGRAPH, children: [{ text: '
 
 export function MyEditor() {
     const [value, setValue] = useState(initialValue);
-    const editor = useMemo(() => withHistory(withReact(createEditor() as ReactEditor)), []);
+    const editor = useMemo(() => withHistory(withReact(createEditor())), []);
 
     return (
         <Slate editor={editor} value={value} onChange={setValue}>
@@ -238,7 +238,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-1-list-node
  
  export function MyEditor() {
      const [value, setValue] = useState(initialValue);
-     const editor = useMemo(() => withHistory(withReact(createEditor() as ReactEditor)), []);
+     const editor = useMemo(() => withHistory(withReact(createEditor())), []);
 
      return (
          <Slate editor={editor} value={value} onChange={setValue}>
@@ -261,7 +261,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
  import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
  import { withHistory } from 'slate-history';
  import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, withLists } from '@prezly/slate-lists';
++import { ListType, withLists, withListsNormalization } from '@prezly/slate-lists';
  
  declare module 'slate' {
      interface CustomTypes {
@@ -277,7 +277,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
      LIST_ITEM_TEXT = 'list-item-text',
  }
  
-+const withListsPlugin = withLists({
++const withListsPlugin = withListsNormalization(withLists({
 +    isConvertibleToListTextNode(node: Node) {
 +        return Element.isElementType(node, Type.PARAGRAPH);
 +    },
@@ -312,7 +312,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
 +    createListItemTextNode(props = {}) {
 +        return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
 +    },
-+});
++}));
  
  function renderElement({ element, attributes, children }: RenderElementProps) {
      switch (element.type) {
@@ -369,7 +369,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
  
  export function MyEditor() {
      const [value, setValue] = useState(initialValue);
-+    const editor = useMemo(() => withListsPlugin(withHistory(withReact(createEditor() as ReactEditor))), []);
++    const editor = useMemo(() => withListsPlugin(withHistory(withReact(createEditor()))), []);
  
      return (
          <Slate editor={editor} value={value} onChange={setValue}>
@@ -392,7 +392,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-3-add-withl
  import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
  import { withHistory } from 'slate-history';
  import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, withLists, withListsReact } from '@prezly/slate-lists';
++import { ListType, withLists, withListsNormalization, withListsReact } from '@prezly/slate-lists';
  
  declare module 'slate' {
      interface CustomTypes {
@@ -408,7 +408,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-3-add-withl
      LIST_ITEM_TEXT = 'list-item-text',
  }
  
- const withListsPlugin = withLists({
+ const withListsPlugin = withListsNormalization(withLists({
      isConvertibleToListTextNode(node: Node) {
          return Element.isElementType(node, Type.PARAGRAPH);
      },
@@ -443,7 +443,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-3-add-withl
      createListItemTextNode(props = {}) {
          return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
      },
- });
+ }));
  
  function renderElement({ element, attributes, children }: RenderElementProps) {
      switch (element.type) {
@@ -501,7 +501,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-3-add-withl
  export function MyEditor() {
      const [value, setValue] = useState(initialValue);
      const editor = useMemo(
-+        () => withListsReact(withListsPlugin(withHistory(withReact(createEditor() as ReactEditor)))),
++        () => withListsReact(withListsPlugin(withHistory(withReact(createEditor())))),
          [],
      );
  
@@ -526,7 +526,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
  import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
  import { withHistory } from 'slate-history';
  import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, onKeyDown, withLists, withListsReact } from '@prezly/slate-lists';
++import { ListType, onKeyDown, withLists, withListsNormalization, withListsReact } from '@prezly/slate-lists';
  
  declare module 'slate' {
      interface CustomTypes {
@@ -542,7 +542,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
      LIST_ITEM_TEXT = 'list-item-text',
  }
  
- const withListsPlugin = withLists({
+ const withListsPlugin = withListsNormalization(withLists({
      isConvertibleToListTextNode(node: Node) {
          return Element.isElementType(node, Type.PARAGRAPH);
      },
@@ -577,7 +577,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
      createListItemTextNode(props = {}) {
          return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
      },
- });
+ }));
  
  function renderElement({ element, attributes, children }: RenderElementProps) {
      switch (element.type) {
@@ -637,7 +637,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
  export function MyEditor() {
      const [value, setValue] = useState(initialValue);
      const editor = useMemo(
-         () => withListsReact(withListsPlugin(withHistory(withReact(createEditor() as ReactEditor)))),
+         () => withListsReact(withListsPlugin(withHistory(withReact(createEditor())))),
          [],
      );
  
@@ -667,8 +667,9 @@ Only core API is documented although all utility functions are exposed. Should y
 
 -   [`ListsSchema`](#ListsSchema)
 -   [`withLists`](#withLists)
+-   [`withListsNormalization`](#withListsNormalization)
 -   [`withListsReact`](#withListsReact)
--   [`Lists`](#Lists)
+-   [`ListsEditor`](#ListsEditor)
 
 ### [`ListsSchema`](src/types.ts)
 
@@ -687,21 +688,23 @@ It is designed with 100% customization in mind, not depending on any specific no
 | `createListItemNode`          | Create a new list item node.                                                                                           |
 | `createListItemTextNode`      | Create a new list item text node.                                                                                      |
 
-### [`ListsEditor`](src/types.ts)
-
-ListsEditor is an instance of Slate `Editor`, extends with `ListsSchema` methods:
-
-```ts
-type ListsEditor = Editor & ListsSchema;
-```
-
 ### [`withLists`](src/lib/withLists.ts)
 
 ```ts
 /**
- * Enables normalizations that enforce schema constraints and recover from unsupported cases.
+ * Bind the given ListsSchema to the editor instance.
+ * The schema is used by all lists operations.
  */
-withLists(schema: ListsSchema) => (<T extends Editor>(editor: T) => T & ListsEditor)
+withLists(schema: ListsSchema) => (<T extends Editor>(editor: T) => T)
+```
+
+### [`withListsNormalization`](src/lib/withListsNormalization.ts)
+
+```ts
+/**
+ * Enable normalizations that enforce schema constraints and recover from unsupported cases.
+ */
+withListsNormalization<T extends Editor>(editor: T): T
 ```
 
 ### [`withListsReact`](src/lib/withListsReact.ts)
@@ -711,13 +714,16 @@ withLists(schema: ListsSchema) => (<T extends Editor>(editor: T) => T & ListsEdi
  * Enables Range.prototype.cloneContents monkey patch to improve pasting behavior
  * in few edge cases.
  */
-withListsReact<T extends ReactEditor & ListsEditor>(editor: T): T
+withListsReact<T extends ReactEditor>(editor: T): T
 ```
 
 ### [`ListsEditor`](src/index.ts)
 
 `ListsEditor` is a namespace export with all list-related editor utility functions. 
-Most of them require an instance of [`ListsEditor`](#ListsEditor) as the first argument.  
+Most of them require an instance of `Editor` as the first argument.
+
+> **Warning**: all `ListsEditor` methods expect a ListsSchema to be bound 
+> to the editor instance with `withLists()` function prior to using them. 
 
 Here are the functions methods:
 

--- a/packages/slate-lists/README.md
+++ b/packages/slate-lists/README.md
@@ -248,7 +248,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-1-list-node
  }
 ```
 
-### 2. Define lists plugin schema and connect [`withLists`](src/lib/withLists.ts) plugin to your model
+### 2. Define lists plugin schema and connect [`withLists`](src/lib/withLists.ts) plugin to your model.
 
 [`withLists`](src/lib/withLists.ts) is a [Slate plugin](https://docs.slatejs.org/concepts/07-plugins) 
 that enables [normalizations](https://docs.slatejs.org/concepts/10-normalizing) 
@@ -261,7 +261,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
  import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
  import { withHistory } from 'slate-history';
  import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, withLists, withListsNormalization } from '@prezly/slate-lists';
++import { ListType, withLists } from '@prezly/slate-lists';
  
  declare module 'slate' {
      interface CustomTypes {
@@ -277,7 +277,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
      LIST_ITEM_TEXT = 'list-item-text',
  }
  
-+const withListsPlugin = withListsNormalization(withLists({
++const withListsPlugin = withLists({
 +    isConvertibleToListTextNode(node: Node) {
 +        return Element.isElementType(node, Type.PARAGRAPH);
 +    },
@@ -312,7 +312,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
 +    createListItemTextNode(props = {}) {
 +        return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
 +    },
-+}));
++});
  
  function renderElement({ element, attributes, children }: RenderElementProps) {
      switch (element.type) {
@@ -379,141 +379,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-2-add-withl
  }
 ```
 
-### 3. Use [`withListsReact`](src/lib/withListsReact.ts) plugin
-
-[`withListsReact`](src/lib/withListsReact.ts) is useful on the client-side - 
-it's a [Slate plugin](https://docs.slatejs.org/concepts/07-plugins) - that overrides `editor.setFragmentData`. 
-It enables `Range.prototype.cloneContents` monkey patch to improve copying behavior in some edge cases.
-
-Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-3-add-withlistsreact-plugin-t81im0?file=/src/MyEditor.tsx
-
-```diff
- import { useMemo, useState } from 'react';
- import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
- import { withHistory } from 'slate-history';
- import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, withLists, withListsNormalization, withListsReact } from '@prezly/slate-lists';
- 
- declare module 'slate' {
-     interface CustomTypes {
-         Element: { type: Type } & BaseElement;
-     }
- }
- 
- enum Type {
-     PARAGRAPH = 'paragraph',
-     ORDERED_LIST = 'ordered-list',
-     UNORDERED_LIST = 'unordered-list',
-     LIST_ITEM = 'list-item',
-     LIST_ITEM_TEXT = 'list-item-text',
- }
- 
- const withListsPlugin = withListsNormalization(withLists({
-     isConvertibleToListTextNode(node: Node) {
-         return Element.isElementType(node, Type.PARAGRAPH);
-     },
-     isDefaultTextNode(node: Node) {
-         return Element.isElementType(node, Type.PARAGRAPH);
-     },
-     isListNode(node: Node, type: ListType) {
-         if (type) {
-             return Element.isElementType(node, type);
-         }
-         return (
-             Element.isElementType(node, Type.ORDERED_LIST) ||
-             Element.isElementType(node, Type.UNORDERED_LIST)
-         );
-     },
-     isListItemNode(node: Node) {
-         return Element.isElementType(node, Type.LIST_ITEM);
-     },
-     isListItemTextNode(node: Node) {
-         return Element.isElementType(node, Type.LIST_ITEM_TEXT);
-     },
-     createDefaultTextNode(props = {}) {
-         return { children: [{ text: '' }], ...props, type: Type.PARAGRAPH };
-     },
-     createListNode(type: ListType = ListType.UNORDERED, props = {}) {
-         const nodeType = type === ListType.ORDERED ? Type.ORDERED_LIST : Type.UNORDERED_LIST;
-         return { children: [{ text: '' }], ...props, type: nodeType };
-     },
-     createListItemNode(props = {}) {
-         return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM };
-     },
-     createListItemTextNode(props = {}) {
-         return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
-     },
- }));
- 
- function renderElement({ element, attributes, children }: RenderElementProps) {
-     switch (element.type) {
-         case Type.PARAGRAPH:
-             return <p {...attributes}>{children}</p>;
-         case Type.ORDERED_LIST:
-             return <ol {...attributes}>{children}</ol>;
-         case Type.UNORDERED_LIST:
-             return <ul {...attributes}>{children}</ul>;
-         case Type.LIST_ITEM:
-             return <li {...attributes}>{children}</li>;
-         case Type.LIST_ITEM_TEXT:
-             return <div {...attributes}>{children}</div>;
-     }
- }
- 
- const initialValue: Descendant[] = [
-     { type: Type.PARAGRAPH, children: [{ text: 'Hello world!' }] },
-     {
-         type: Type.ORDERED_LIST,
-         children: [
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'One' }] }],
-             },
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'Two' }] }],
-             },
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'Three' }] }],
-             },
-         ],
-     },
-     {
-         type: Type.UNORDERED_LIST,
-         children: [
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'Red' }] }],
-             },
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'Green' }] }],
-             },
-             {
-                 type: Type.LIST_ITEM,
-                 children: [{ type: Type.LIST_ITEM_TEXT, children: [{ text: 'Blue' }] }],
-             },
-         ],
-     },
- ];
- 
- export function MyEditor() {
-     const [value, setValue] = useState(initialValue);
-     const editor = useMemo(
-+        () => withListsReact(withListsPlugin(withHistory(withReact(createEditor())))),
-         [],
-     );
- 
-     return (
-         <Slate editor={editor} value={value} onChange={setValue}>
-             <Editable renderElement={renderElement} />
-         </Slate>
-     );
- }
-```
-
-### 4. Add `onKeyDown` handler
+### 3. Add `onKeyDown` handler
 
 `@prezly/slate-lists` comes with a pre-defined `onKeyDown` handler to implement keyboard interactions for lists.
 For example, pressing `Tab` in a list will indent the current list item one level deeper. 
@@ -542,7 +408,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
      LIST_ITEM_TEXT = 'list-item-text',
  }
  
- const withListsPlugin = withListsNormalization(withLists({
+ const withListsPlugin = withLists({
      isConvertibleToListTextNode(node: Node) {
          return Element.isElementType(node, Type.PARAGRAPH);
      },
@@ -577,7 +443,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
      createListItemTextNode(props = {}) {
          return { children: [{ text: '' }], ...props, type: Type.LIST_ITEM_TEXT };
      },
- }));
+ });
  
  function renderElement({ element, attributes, children }: RenderElementProps) {
      switch (element.type) {
@@ -637,7 +503,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
  export function MyEditor() {
      const [value, setValue] = useState(initialValue);
      const editor = useMemo(
-         () => withListsReact(withListsPlugin(withHistory(withReact(createEditor())))),
+         () => withListsPlugin(withHistory(withReact(createEditor()))),
          [],
      );
  
@@ -667,6 +533,7 @@ Only core API is documented although all utility functions are exposed. Should y
 
 -   [`ListsSchema`](#ListsSchema)
 -   [`withLists`](#withLists)
+-   [`withListsSchema`](#withListsSchema)
 -   [`withListsNormalization`](#withListsNormalization)
 -   [`withListsReact`](#withListsReact)
 -   [`ListsEditor`](#ListsEditor)
@@ -690,15 +557,31 @@ It is designed with 100% customization in mind, not depending on any specific no
 
 ### [`withLists`](src/lib/withLists.ts)
 
+`withLists()` is an all-in-one plugin initializer. 
+It calls `withListsSchema()`, `withListsReact()`, and `withListsNormalization()` internall. 
+
+```ts
+/**
+ * Mutate the Editor instance by adding all lists plugin functionality on top of it.
+ */
+withLists(schema: ListsSchema) => (<T extends Editor>(editor: T) => T)
+```
+
+### [`withListsSchema`](src/lib/withListsSchema.ts)
+
+*Note: this is already included into `withLists()`.*
+
 ```ts
 /**
  * Bind the given ListsSchema to the editor instance.
  * The schema is used by all lists operations.
  */
-withLists(schema: ListsSchema) => (<T extends Editor>(editor: T) => T)
+withListsSchema(schema: ListsSchema) => (<T extends Editor>(editor: T) => T)
 ```
 
 ### [`withListsNormalization`](src/lib/withListsNormalization.ts)
+
+*Note: this is already included into `withLists()`.* 
 
 ```ts
 /**
@@ -708,6 +591,8 @@ withListsNormalization<T extends Editor>(editor: T): T
 ```
 
 ### [`withListsReact`](src/lib/withListsReact.ts)
+
+*Note: this is already included into `withLists()`.*
 
 ```ts
 /**
@@ -731,30 +616,30 @@ Here are the functions methods:
 /**
  * Returns true when editor.deleteBackward() is safe to call (it won't break the structure).
  */
-canDeleteBackward(editor: ListsEditor) => boolean
+canDeleteBackward(editor: Editor) => boolean
 
 /**
  * Decreases nesting depth of all "list-items" in the current selection.
  * All "list-items" in the root "list" will become "default" nodes.
  */
-decreaseDepth(editor: ListsEditor) => void
+decreaseDepth(editor: Editor) => void
 
 /**
  * Decreases nesting depth of "list-item" at a given Path.
  */
-decreaseListItemDepth(editor: ListsEditor, listItemPath: Path) => void
+decreaseListItemDepth(editor: Editor, listItemPath: Path) => void
 
 /**
  * Returns all "list-items" in a given Range.
  * @param at defaults to current selection if not specified
  */
-getListItemsInRange(editor: ListsEditor, at: Range | null | undefined) => NodeEntry<Node>[]
+getListItemsInRange(editor: Editor, at: Range | null | undefined) => NodeEntry<Node>[]
 
 /**
  * Returns all "lists" in a given Range.
  * @param at defaults to current selection if not specified
  */
-getListsInRange(editor: ListsEditor, at: Range | null | undefined) => NodeEntry<Node>[]
+getListsInRange(editor: Editor, at: Range | null | undefined) => NodeEntry<Node>[]
 
 /**
  * Returns the "type" of a given list node.
@@ -765,79 +650,79 @@ getListType(node: Node) => string
  * Returns "list" node nested in "list-item" at a given path.
  * Returns null if there is no nested "list".
  */
-getNestedList(editor: ListsEditor, listItemPath: Path) => NodeEntry<Element> | null
+getNestedList(editor: Editor, listItemPath: Path) => NodeEntry<Element> | null
 
 /**
  * Returns parent "list" node of "list-item" at a given path.
  * Returns null if there is no parent "list".
  */
-getParentList(editor: ListsEditor, listItemPath: Path) => NodeEntry<Element> | null
+getParentList(editor: Editor, listItemPath: Path) => NodeEntry<Element> | null
 
 /**
  * Returns parent "list-item" node of "list-item" at a given path.
  * Returns null if there is no parent "list-item".
  */
-getParentListItem(editor: ListsEditor, listItemPath: Path) => NodeEntry<Element> | null
+getParentListItem(editor: Editor, listItemPath: Path) => NodeEntry<Element> | null
 
 /**
  * Increases nesting depth of all "list-items" in the current selection.
  * All nodes matching options.wrappableTypes in the selection will be converted to "list-items" and wrapped in a "list".
  */
-increaseDepth(editor: ListsEditor) => void
+increaseDepth(editor: Editor) => void
 
 /**
  * Increases nesting depth of "list-item" at a given Path.
  */
-increaseListItemDepth(editor: ListsEditor, listItemPath: Path) => void
+increaseListItemDepth(editor: Editor, listItemPath: Path) => void
 
 /**
  * Returns true when editor has collapsed selection and the cursor is in an empty "list-item".
  */
-isCursorInEmptyListItem(editor: ListsEditor) => boolean
+isCursorInEmptyListItem(editor: Editor) => boolean
 
 /**
  * Returns true when editor has collapsed selection and the cursor is at the beginning of a "list-item".
  */
-isCursorAtStartOfListItem(editor: ListsEditor) => boolean
+isCursorAtStartOfListItem(editor: Editor) => boolean
 
 /**
  * Returns true if given "list-item" node contains a non-empty "list-item-text" node.
  */
-isListItemContainingText(editor: ListsEditor, node: Node) => boolean
+isListItemContainingText(editor: Editor, node: Node) => boolean
 
 /**
  * Moves all "list-items" from one "list" to the end of another "list".
  */
-moveListItemsToAnotherList(editor: ListsEditor, parameters: { at: NodeEntry<Node>; to: NodeEntry<Node>; }) => void
+moveListItemsToAnotherList(editor: Editor, parameters: { at: NodeEntry<Node>; to: NodeEntry<Node>; }) => void
 
 /**
  * Nests (moves) given "list" in a given "list-item".
  */
-moveListToListItem(editor: ListsEditor, parameters: { at: NodeEntry<Node>; to: NodeEntry<Node>; }) => void
+moveListToListItem(editor: Editor, parameters: { at: NodeEntry<Node>; to: NodeEntry<Node>; }) => void
 
 /**
  * Sets "type" of all "list" nodes in the current selection.
  */
-setListType(editor: ListsEditor, listType: string) => void
+setListType(editor: Editor, listType: string) => void
 
 /**
  * Collapses the current selection (by removing everything in it) and if the cursor
  * ends up in a "list-item" node, it will break that "list-item" into 2 nodes, splitting
  * the text at the cursor location.
  */
-splitListItem(editor: ListsEditor) => void
+splitListItem(editor: Editor) => void
 
 /**
  * Unwraps all "list-items" in the current selection.
  * No list be left in the current selection.
  */
-unwrapList(editor: ListsEditor) => void
+unwrapList(editor: Editor) => void
 
 /**
  * All nodes matching options.wrappableTypes in the current selection
  * will be converted to "list-items" and wrapped in "lists".
  */
-wrapInList(editor: ListsEditor, listType: ListType) => void
+wrapInList(editor: Editor, listType: ListType) => void
 ```
 
 ----

--- a/packages/slate-lists/README.md
+++ b/packages/slate-lists/README.md
@@ -392,7 +392,7 @@ Live example: https://codesandbox.io/s/prezly-slate-lists-user-guide-4-add-onkey
  import { createEditor, BaseElement, Descendant, Element, Node } from 'slate';
  import { withHistory } from 'slate-history';
  import { Editable, ReactEditor, RenderElementProps, Slate, withReact } from 'slate-react';
-+import { ListType, onKeyDown, withLists, withListsNormalization, withListsReact } from '@prezly/slate-lists';
++import { ListType, onKeyDown, withLists } from '@prezly/slate-lists';
  
  declare module 'slate' {
      interface CustomTypes {

--- a/packages/slate-lists/src/ListsEditor.ts
+++ b/packages/slate-lists/src/ListsEditor.ts
@@ -1,4 +1,4 @@
-import type { Editor } from 'slate';
+import type { Editor, Location, Node, NodeEntry, Path, Range } from 'slate';
 
 import {
     canDeleteBackward,
@@ -13,6 +13,7 @@ import {
     isInList,
     isListItemContainingText,
 } from './lib';
+import * as Registry from './registry';
 import {
     decreaseDepth,
     decreaseListItemDepth,
@@ -26,35 +27,87 @@ import {
     unwrapList,
     wrapInList,
 } from './transformations';
-import type { ListsEditor as Type } from './types';
+import { ListType } from './types';
 
-export type ListsEditor = Type; // Workaround name collision
+function schema(editor: Editor) {
+    return Registry.get(editor);
+}
 
 export const ListsEditor = {
-    isListsEditor<T extends Editor>(editor: T): editor is T & ListsEditor {
-        return 'isListNode' in editor;
+    isListsEnabled(editor: Editor): boolean {
+        return Registry.has(editor);
+    },
+    getListsSchema(editor: Editor) {
+        return Registry.has(editor) ? Registry.get(editor) : undefined;
     },
 
-    canDeleteBackward,
-    decreaseDepth,
-    decreaseListItemDepth,
-    getListItemsInRange,
-    getListsInRange,
-    getListType,
-    getNestedList,
-    getParentList,
-    getParentListItem,
-    increaseDepth,
-    increaseListItemDepth,
-    isCursorAtStartOfListItem,
-    isCursorInEmptyListItem,
-    isInList,
-    isListItemContainingText,
-    mergeListWithPreviousSiblingList,
-    moveListItemsToAnotherList,
-    moveListToListItem,
-    setListType,
-    splitListItem,
-    unwrapList,
-    wrapInList,
+    canDeleteBackward(editor: Editor) {
+        return canDeleteBackward(editor, schema(editor));
+    },
+    decreaseDepth(editor: Editor, at?: Location | null) {
+        return decreaseDepth(editor, schema(editor), at);
+    },
+    decreaseListItemDepth(editor: Editor, listItemPath: Path) {
+        return decreaseListItemDepth(editor, schema(editor), listItemPath);
+    },
+    getListItemsInRange(editor: Editor, at?: Location | null) {
+        return getListItemsInRange(editor, schema(editor), at);
+    },
+    getListsInRange(editor: Editor, at: Range | null) {
+        return getListsInRange(editor, schema(editor), at);
+    },
+    getListType(editor: Editor, node: Node) {
+        return getListType(schema(editor), node);
+    },
+    getNestedList(editor: Editor, path: Path) {
+        return getNestedList(editor, schema(editor), path);
+    },
+    getParentList(editor: Editor, path: Path) {
+        return getParentList(editor, schema(editor), path);
+    },
+    getParentListItem(editor: Editor, path: Path) {
+        return getParentListItem(editor, schema(editor), path);
+    },
+    increaseDepth(editor: Editor) {
+        return increaseDepth(editor, schema(editor));
+    },
+    increaseListItemDepth(editor: Editor, listItemPath: Path) {
+        return increaseListItemDepth(editor, schema(editor), listItemPath);
+    },
+    isCursorAtStartOfListItem(editor: Editor) {
+        return isCursorAtStartOfListItem(editor, schema(editor));
+    },
+    isCursorInEmptyListItem(editor: Editor) {
+        return isCursorInEmptyListItem(editor, schema(editor));
+    },
+    isInList(editor: Editor, location?: Location | null) {
+        return isInList(editor, schema(editor), location);
+    },
+    isListItemContainingText(editor: Editor, node: Node) {
+        return isListItemContainingText(editor, schema(editor), node);
+    },
+    mergeListWithPreviousSiblingList(editor: Editor, entry: NodeEntry) {
+        return mergeListWithPreviousSiblingList(editor, schema(editor), entry);
+    },
+    moveListItemsToAnotherList(
+        editor: Editor,
+        parameters: Parameters<typeof moveListItemsToAnotherList>[2],
+    ) {
+        return moveListItemsToAnotherList(editor, schema(editor), parameters);
+    },
+    moveListToListItem(editor: Editor, parameters: Parameters<typeof moveListToListItem>[2]) {
+        return moveListToListItem(editor, schema(editor), parameters);
+    },
+    setListType(editor: Editor, listType: ListType) {
+        return setListType(editor, schema(editor), listType);
+    },
+    splitListItem(editor: Editor) {
+        return splitListItem(editor, schema(editor));
+    },
+    unwrapList(editor: Editor) {
+        return unwrapList(editor, schema(editor));
+    },
+    wrapInList(editor: Editor, listType = ListType.UNORDERED) {
+        return wrapInList(editor, schema(editor), listType);
+    },
 };

--- a/packages/slate-lists/src/ListsEditor.ts
+++ b/packages/slate-lists/src/ListsEditor.ts
@@ -1,4 +1,5 @@
 import type { Editor, Location, Node, NodeEntry, Path, Range } from 'slate';
+import type { Element } from 'slate';
 
 import {
     canDeleteBackward,
@@ -27,6 +28,7 @@ import {
     unwrapList,
     wrapInList,
 } from './transformations';
+import type { ListsSchema } from './types';
 import { ListType } from './types';
 
 function schema(editor: Editor) {
@@ -34,13 +36,44 @@ function schema(editor: Editor) {
 }
 
 export const ListsEditor = {
+    // ListsEditor schema availability
     isListsEnabled(editor: Editor): boolean {
         return Registry.has(editor);
     },
-    getListsSchema(editor: Editor) {
+    getListsSchema(editor: Editor): ListsSchema | undefined {
         return Registry.has(editor) ? Registry.get(editor) : undefined;
     },
 
+    // Schema proxies
+    isConvertibleToListTextNode(editor: Editor, node: Node): boolean {
+        return schema(editor).isConvertibleToListTextNode(node);
+    },
+    isDefaultTextNode(editor: Editor, node: Node): boolean {
+        return schema(editor).isDefaultTextNode(node);
+    },
+    isListNode(editor: Editor, node: Node, type?: ListType): boolean {
+        return schema(editor).isListNode(node, type);
+    },
+    isListItemNode(editor: Editor, node: Node): boolean {
+        return schema(editor).isListItemNode(node);
+    },
+    isListItemTextNode(editor: Editor, node: Node): boolean {
+        return schema(editor).isListItemTextNode(node);
+    },
+    createDefaultTextNode(editor: Editor, props?: Partial<Element>): Element {
+        return schema(editor).createDefaultTextNode(props);
+    },
+    createListNode(editor: Editor, type?: ListType, props?: Partial<Element>): Element {
+        return schema(editor).createListNode(type, props);
+    },
+    createListItemNode(editor: Editor, props?: Partial<Element>): Element {
+        return schema(editor).createListItemNode(props);
+    },
+    createListItemTextNode(editor: Editor, props?: Partial<Element>): Element {
+        return schema(editor).createListItemTextNode(props);
+    },
+
+    // Own API
     canDeleteBackward(editor: Editor) {
         return canDeleteBackward(editor, schema(editor));
     },

--- a/packages/slate-lists/src/hyperscript.ts
+++ b/packages/slate-lists/src/hyperscript.ts
@@ -40,7 +40,7 @@ export const ListItemText = LIST_ITEM_TEXT_TYPE as any as ComponentType<{ childr
 const INLINE_ELEMENTS = [LINK_TYPE];
 const VOID_ELEMENTS = [DIVIDER_TYPE];
 
-const SCHEMA: ListsSchema = {
+export const SCHEMA: ListsSchema = {
     isConvertibleToListTextNode(node) {
         return Element.isElementType(node, PARAGRAPH_TYPE);
     },

--- a/packages/slate-lists/src/hyperscript.ts
+++ b/packages/slate-lists/src/hyperscript.ts
@@ -6,7 +6,7 @@ import { createEditor as createEditorFactory, createHyperscript } from 'slate-hy
 
 import type { ListsSchema } from './types';
 import { ListType } from './types';
-import { withLists } from './withLists';
+import { withListsSchema } from './withListsSchema';
 
 type AllOrNothing<T extends object> = { [key in keyof T]: T[key] } | { [key in keyof T]?: never };
 
@@ -94,7 +94,7 @@ export const hyperscript = createHyperscript({
             const { normalizeNode, ...rest } = attributes;
 
             const factory = createEditorFactory(function () {
-                const decorators = [withInlineElements, withVoidElements, withLists(SCHEMA)];
+                const decorators = [withInlineElements, withVoidElements, withListsSchema(SCHEMA)];
 
                 return decorators.reduce((editor, decorate) => decorate(editor), createEditor());
             });

--- a/packages/slate-lists/src/index.ts
+++ b/packages/slate-lists/src/index.ts
@@ -3,4 +3,5 @@ export { normalizeNode } from './normalizeNode';
 export { onKeyDown } from './onKeyDown';
 export { ListType, type ListsSchema } from './types';
 export { withLists } from './withLists';
+export { withListsNormalization } from './withListsNormalization';
 export { withListsReact } from './withListsReact';

--- a/packages/slate-lists/src/index.ts
+++ b/packages/slate-lists/src/index.ts
@@ -3,5 +3,6 @@ export { normalizeNode } from './normalizeNode';
 export { onKeyDown } from './onKeyDown';
 export { ListType, type ListsSchema } from './types';
 export { withLists } from './withLists';
+export { withListsSchema } from './withListsSchema';
 export { withListsNormalization } from './withListsNormalization';
 export { withListsReact } from './withListsReact';

--- a/packages/slate-lists/src/lib/canDeleteBackward.ts
+++ b/packages/slate-lists/src/lib/canDeleteBackward.ts
@@ -1,4 +1,6 @@
-import type { ListsEditor } from '../types';
+import type { Editor } from 'slate';
+
+import type { ListsSchema } from '../types';
 
 import { getListItemsInRange } from './getListItemsInRange';
 import { getParentListItem } from './getParentListItem';
@@ -8,15 +10,15 @@ import { isCursorAtStartOfListItem } from './isCursorAtStartOfListItem';
 /**
  * Returns true when editor.deleteBackward() is safe to call (it won't break the structure).
  */
-export function canDeleteBackward(editor: ListsEditor): boolean {
-    const listItemsInSelection = getListItemsInRange(editor, editor.selection);
+export function canDeleteBackward(editor: Editor, schema: ListsSchema): boolean {
+    const listItemsInSelection = getListItemsInRange(editor, schema, editor.selection);
 
     if (listItemsInSelection.length === 0) {
         return true;
     }
 
     const [[, listItemPath]] = listItemsInSelection;
-    const isInNestedList = getParentListItem(editor, listItemPath) !== null;
+    const isInNestedList = getParentListItem(editor, schema, listItemPath) !== null;
     const isFirstListItem = getPrevSibling(editor, listItemPath) === null;
-    return isInNestedList || !isFirstListItem || !isCursorAtStartOfListItem(editor);
+    return isInNestedList || !isFirstListItem || !isCursorAtStartOfListItem(editor, schema);
 }

--- a/packages/slate-lists/src/lib/getListItemsInRange.test.tsx
+++ b/packages/slate-lists/src/lib/getListItemsInRange.test.tsx
@@ -1,15 +1,18 @@
 /** @jsx hyperscript */
 
+import type * as Slate from 'slate';
+
 import {
-    hyperscript,
+    Anchor,
     Editor,
-    OrderedList,
-    UnorderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
+    OrderedList,
+    SCHEMA,
     Text,
-    Anchor,
-    Focus,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 
@@ -53,8 +56,8 @@ describe('getListItemsInRange', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        const listItemsInRange = getListItemsInRange(editor, editor.selection);
-        expect(listItemsInRange).toEqual([]);
+        const lists = getListItemsInRange(editor, SCHEMA, editor.selection);
+        expect(lists).toEqual([]);
     });
 
     it('Finds all partially selected list items', () => {
@@ -149,12 +152,12 @@ describe('getListItemsInRange', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate.Editor;
 
-        const listItemsInRange = getListItemsInRange(editor, editor.selection);
-        const listItemsPathsInRange = listItemsInRange.map(([, path]) => path);
+        const lists = getListItemsInRange(editor, SCHEMA, editor.selection);
+        const paths = lists.map(([, path]) => path);
 
-        expect(listItemsPathsInRange).toEqual([
+        expect(paths).toEqual([
             [0, 0, 1, 1],
             [0, 0, 1, 1, 1, 0],
             [0, 0, 1, 1, 1, 1],

--- a/packages/slate-lists/src/lib/getListItemsInRange.test.tsx
+++ b/packages/slate-lists/src/lib/getListItemsInRange.test.tsx
@@ -1,6 +1,6 @@
 /** @jsx hyperscript */
 
-import type * as Slate from 'slate';
+import type { Editor as Slate } from 'slate';
 
 import {
     Anchor,
@@ -14,7 +14,6 @@ import {
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
 
 import { getListItemsInRange } from './getListItemsInRange';
 
@@ -54,7 +53,7 @@ describe('getListItemsInRange', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const lists = getListItemsInRange(editor, SCHEMA, editor.selection);
         expect(lists).toEqual([]);
@@ -152,7 +151,7 @@ describe('getListItemsInRange', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as Slate.Editor;
+        ) as unknown as Slate;
 
         const lists = getListItemsInRange(editor, SCHEMA, editor.selection);
         const paths = lists.map(([, path]) => path);

--- a/packages/slate-lists/src/lib/getListItemsInRange.ts
+++ b/packages/slate-lists/src/lib/getListItemsInRange.ts
@@ -1,13 +1,14 @@
 import type { Element, Location, NodeEntry } from 'slate';
 import { Editor, Path, Point, Range } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Returns all "list-items" in a given Range.
  */
 export function getListItemsInRange(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     at: Location | null = editor.selection,
 ): NodeEntry<Element>[] {
     if (!at) {
@@ -17,7 +18,7 @@ export function getListItemsInRange(
     const start = getLocationStart(at);
     const listItems = Editor.nodes(editor, {
         at,
-        match: editor.isListItemNode,
+        match: schema.isListItemNode,
     });
 
     return Array.from(listItems).filter(([, path]) => {

--- a/packages/slate-lists/src/lib/getListType.ts
+++ b/packages/slate-lists/src/lib/getListType.ts
@@ -1,20 +1,20 @@
 import type { Node } from 'slate';
 import { Element } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 import { ListType } from '../types';
 
 /**
  * Returns the "type" of a given list node.
  */
-export function getListType(editor: ListsEditor, node: Node): ListType {
+export function getListType(schema: ListsSchema, node: Node): ListType {
     const isElement = Element.isElement(node);
 
-    if (isElement && editor.isListNode(node, ListType.ORDERED)) {
+    if (isElement && schema.isListNode(node, ListType.ORDERED)) {
         return ListType.ORDERED;
     }
 
-    if (isElement && editor.isListNode(node, ListType.UNORDERED)) {
+    if (isElement && schema.isListNode(node, ListType.UNORDERED)) {
         return ListType.UNORDERED;
     }
 

--- a/packages/slate-lists/src/lib/getListsInRange.ts
+++ b/packages/slate-lists/src/lib/getListsInRange.ts
@@ -1,6 +1,6 @@
-import type { Element, NodeEntry, Range } from 'slate';
+import type { Editor, Element, NodeEntry, Range } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 import { getListItemsInRange } from './getListItemsInRange';
 import { getParentList } from './getParentList';
@@ -8,10 +8,14 @@ import { getParentList } from './getParentList';
 /**
  * Get all lists in the given Range.
  */
-export function getListsInRange(editor: ListsEditor, at: Range | null): NodeEntry<Element>[] {
-    const listItemsInRange = getListItemsInRange(editor, at);
+export function getListsInRange(
+    editor: Editor,
+    schema: ListsSchema,
+    at: Range | null,
+): NodeEntry<Element>[] {
+    const listItemsInRange = getListItemsInRange(editor, schema, at);
     const lists = listItemsInRange
-        .map(([, listItemPath]) => getParentList(editor, listItemPath))
+        .map(([, listItemPath]) => getParentList(editor, schema, listItemPath))
         .filter((list) => list !== null);
     // TypeScript complains about `null`s even though we filter for them, hence the typecast.
     return lists as NodeEntry<Element>[];

--- a/packages/slate-lists/src/lib/getNestedList.ts
+++ b/packages/slate-lists/src/lib/getNestedList.ts
@@ -1,14 +1,18 @@
-import type { NodeEntry, Path } from 'slate';
-import { Node, Element } from 'slate';
+import type { Editor, NodeEntry, Path } from 'slate';
+import { Element, Node } from 'slate';
 
 import { NESTED_LIST_PATH_INDEX } from '../constants';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Returns "list" node nested in "list-item" at a given path.
  * Returns null if there is no nested "list".
  */
-export function getNestedList(editor: ListsEditor, path: Path): NodeEntry<Element> | null {
+export function getNestedList(
+    editor: Editor,
+    schema: ListsSchema,
+    path: Path,
+): NodeEntry<Element> | null {
     const nestedListPath = [...path, NESTED_LIST_PATH_INDEX];
 
     if (!Node.has(editor, nestedListPath)) {
@@ -17,7 +21,7 @@ export function getNestedList(editor: ListsEditor, path: Path): NodeEntry<Elemen
 
     const nestedList = Node.get(editor, nestedListPath);
 
-    if (Element.isElement(nestedList) && editor.isListNode(nestedList)) {
+    if (Element.isElement(nestedList) && schema.isListNode(nestedList)) {
         // Sanity check.
         return [nestedList, nestedListPath];
     }

--- a/packages/slate-lists/src/lib/getParentList.ts
+++ b/packages/slate-lists/src/lib/getParentList.ts
@@ -1,16 +1,20 @@
 import type { Element, NodeEntry, Path } from 'slate';
 import { Editor } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Returns parent "list" node of "list-item" at a given path.
  * Returns null if there is no parent "list".
  */
-export function getParentList(editor: ListsEditor, path: Path): NodeEntry<Element> | null {
+export function getParentList(
+    editor: Editor,
+    schema: ListsSchema,
+    path: Path,
+): NodeEntry<Element> | null {
     const parentList = Editor.above(editor, {
         at: path,
-        match: (node): node is Element => editor.isListNode(node),
+        match: (node) => schema.isListNode(node),
     });
 
     return parentList ?? null;

--- a/packages/slate-lists/src/lib/getParentListItem.ts
+++ b/packages/slate-lists/src/lib/getParentListItem.ts
@@ -1,16 +1,20 @@
 import type { Element, NodeEntry, Path } from 'slate';
 import { Editor } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Returns parent "list-item" node of "list-item" at a given path.
  * Returns null if there is no parent "list-item".
  */
-export function getParentListItem(editor: ListsEditor, path: Path): NodeEntry<Element> | null {
-    const parentListItem = Editor.above<Element>(editor, {
+export function getParentListItem(
+    editor: Editor,
+    schema: ListsSchema,
+    path: Path,
+): NodeEntry<Element> | null {
+    const parentListItem = Editor.above(editor, {
         at: path,
-        match: (node) => editor.isListItemNode(node),
+        match: (node) => schema.isListItemNode(node),
     });
 
     return parentListItem ?? null;

--- a/packages/slate-lists/src/lib/isCursorAtStartOfListItem.ts
+++ b/packages/slate-lists/src/lib/isCursorAtStartOfListItem.ts
@@ -1,6 +1,7 @@
+import type { Editor } from 'slate';
 import { Range } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 import { getCursorPositionInNode } from './getCursorPositionInNode';
 import { getListItemsInRange } from './getListItemsInRange';
@@ -8,12 +9,12 @@ import { getListItemsInRange } from './getListItemsInRange';
 /**
  * Returns true when editor has collapsed selection and the cursor is at the beginning of a "list-item".
  */
-export function isCursorAtStartOfListItem(editor: ListsEditor): boolean {
+export function isCursorAtStartOfListItem(editor: Editor, schema: ListsSchema): boolean {
     if (!editor.selection || Range.isExpanded(editor.selection)) {
         return false;
     }
 
-    const listItemsInSelection = getListItemsInRange(editor, editor.selection);
+    const listItemsInSelection = getListItemsInRange(editor, schema, editor.selection);
 
     if (listItemsInSelection.length !== 1) {
         return false;

--- a/packages/slate-lists/src/lib/isCursorInEmptyListItem.ts
+++ b/packages/slate-lists/src/lib/isCursorInEmptyListItem.ts
@@ -1,6 +1,7 @@
+import type { Editor } from 'slate';
 import { Range } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 import { getListItemsInRange } from './getListItemsInRange';
 import { isListItemContainingText } from './isListItemContainingText';
@@ -8,12 +9,12 @@ import { isListItemContainingText } from './isListItemContainingText';
 /**
  * Returns true when editor has collapsed selection and the cursor is in an empty "list-item".
  */
-export function isCursorInEmptyListItem(editor: ListsEditor): boolean {
+export function isCursorInEmptyListItem(editor: Editor, schema: ListsSchema): boolean {
     if (!editor.selection || Range.isExpanded(editor.selection)) {
         return false;
     }
 
-    const listItemsInSelection = getListItemsInRange(editor, editor.selection);
+    const listItemsInSelection = getListItemsInRange(editor, schema, editor.selection);
 
     if (listItemsInSelection.length !== 1) {
         return false;
@@ -21,5 +22,5 @@ export function isCursorInEmptyListItem(editor: ListsEditor): boolean {
 
     const [[listItemNode]] = listItemsInSelection;
 
-    return !isListItemContainingText(editor, listItemNode);
+    return !isListItemContainingText(editor, schema, listItemNode);
 }

--- a/packages/slate-lists/src/lib/isInList.ts
+++ b/packages/slate-lists/src/lib/isInList.ts
@@ -1,15 +1,19 @@
 import type { Location } from 'slate';
 import { Editor } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
-export function isInList(editor: ListsEditor, location: Location | null = editor.selection) {
+export function isInList(
+    editor: Editor,
+    schema: ListsSchema,
+    location: Location | null = editor.selection,
+) {
     if (!location) {
         return false;
     }
 
     for (const [currentNode] of Editor.levels(editor, { at: location })) {
-        if (editor.isListNode(currentNode)) {
+        if (schema.isListNode(currentNode)) {
             return true;
         }
     }

--- a/packages/slate-lists/src/lib/isListItemContainingText.ts
+++ b/packages/slate-lists/src/lib/isListItemContainingText.ts
@@ -1,17 +1,17 @@
 import type { Node } from 'slate';
 import { Editor, Element } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Returns true if given "list-item" node contains a non-empty "list-item-text" node.
  */
-export function isListItemContainingText(editor: ListsEditor, node: Node): boolean {
-    if (Element.isElement(node) && editor.isListItemNode(node)) {
+export function isListItemContainingText(editor: Editor, schema: ListsSchema, node: Node): boolean {
+    if (Element.isElement(node) && schema.isListItemNode(node)) {
         return node.children.some((node) => {
             return (
                 Element.isElement(node) &&
-                editor.isListItemTextNode(node) &&
+                schema.isListItemTextNode(node) &&
                 !Editor.isEmpty(editor, node)
             );
         });

--- a/packages/slate-lists/src/normalizations/normalizeListChildren.ts
+++ b/packages/slate-lists/src/normalizations/normalizeListChildren.ts
@@ -1,15 +1,19 @@
-import type { NodeEntry } from 'slate';
+import type { Editor, NodeEntry } from 'slate';
 import { Element, Node, Text, Transforms } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * All children of a "list" have to be "list-items". It can happen (e.g. during pasting) that
  * this will not be true, so we have to convert all non-"list-item" children of a "list"
  * into "list-items".
  */
-export function normalizeListChildren(editor: ListsEditor, [node, path]: NodeEntry<Node>): boolean {
-    if (!editor.isListNode(node)) {
+export function normalizeListChildren(
+    editor: Editor,
+    schema: ListsSchema,
+    [node, path]: NodeEntry<Node>,
+): boolean {
+    if (!schema.isListNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
@@ -43,8 +47,8 @@ export function normalizeListChildren(editor: ListsEditor, [node, path]: NodeEnt
 
             Transforms.wrapNodes(
                 editor,
-                editor.createListItemNode({
-                    children: [editor.createListItemTextNode({ children: [childNode] })],
+                schema.createListItemNode({
+                    children: [schema.createListItemTextNode({ children: [childNode] })],
                 }),
                 { at: childPath },
             );
@@ -56,22 +60,22 @@ export function normalizeListChildren(editor: ListsEditor, [node, path]: NodeEnt
             return;
         }
 
-        if (editor.isListItemTextNode(childNode)) {
-            Transforms.wrapNodes(editor, editor.createListItemNode(), { at: childPath });
+        if (schema.isListItemTextNode(childNode)) {
+            Transforms.wrapNodes(editor, schema.createListItemNode(), { at: childPath });
             normalized = true;
             return;
         }
 
-        if (editor.isListNode(childNode)) {
+        if (schema.isListNode(childNode)) {
             // Wrap it into a list item so that `normalizeOrphanNestedList` can take care of it.
-            Transforms.wrapNodes(editor, editor.createListItemNode(), { at: childPath });
+            Transforms.wrapNodes(editor, schema.createListItemNode(), { at: childPath });
             normalized = true;
             return;
         }
 
-        if (!editor.isListItemNode(childNode)) {
-            Transforms.setNodes(editor, editor.createListItemTextNode(), { at: childPath });
-            Transforms.wrapNodes(editor, editor.createListItemNode(), { at: childPath });
+        if (!schema.isListItemNode(childNode)) {
+            Transforms.setNodes(editor, schema.createListItemTextNode(), { at: childPath });
+            Transforms.wrapNodes(editor, schema.createListItemNode(), { at: childPath });
             normalized = true;
         }
     });

--- a/packages/slate-lists/src/normalizations/normalizeListItemChildren.ts
+++ b/packages/slate-lists/src/normalizations/normalizeListItemChildren.ts
@@ -1,16 +1,17 @@
-import type { NodeEntry } from 'slate';
+import type { Editor, NodeEntry } from 'slate';
 import { Node, Text, Transforms } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * A "list-item" can have a single "list-item-text" and optionally an extra "list" as a child.
  */
 export function normalizeListItemChildren(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListItemNode(node)) {
+    if (!schema.isListItemNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
@@ -21,7 +22,7 @@ export function normalizeListItemChildren(
         const [childNode, childPath] = children[childIndex];
 
         if (Text.isText(childNode) || editor.isInline(childNode)) {
-            const listItemText = editor.createListItemTextNode({
+            const listItemText = schema.createListItemTextNode({
                 children: [childNode],
             });
             Transforms.wrapNodes(editor, listItemText, { at: childPath });
@@ -29,7 +30,7 @@ export function normalizeListItemChildren(
             if (childIndex > 0) {
                 const [previousChildNode] = children[childIndex - 1];
 
-                if (editor.isListItemTextNode(previousChildNode)) {
+                if (schema.isListItemTextNode(previousChildNode)) {
                     Transforms.mergeNodes(editor, { at: childPath });
                 }
             }
@@ -37,18 +38,18 @@ export function normalizeListItemChildren(
             return true;
         }
 
-        if (editor.isListItemNode(childNode)) {
+        if (schema.isListItemNode(childNode)) {
             Transforms.liftNodes(editor, { at: childPath });
             return true;
         }
 
-        if (editor.isListItemTextNode(childNode) && childIndex !== 0) {
-            Transforms.wrapNodes(editor, editor.createListItemNode(), { at: childPath });
+        if (schema.isListItemTextNode(childNode) && childIndex !== 0) {
+            Transforms.wrapNodes(editor, schema.createListItemNode(), { at: childPath });
             return true;
         }
 
-        if (!editor.isListItemTextNode(childNode) && !editor.isListNode(childNode)) {
-            Transforms.setNodes(editor, editor.createListItemTextNode(), { at: childPath });
+        if (!schema.isListItemTextNode(childNode) && !schema.isListNode(childNode)) {
+            Transforms.setNodes(editor, schema.createListItemTextNode(), { at: childPath });
             return true;
         }
     }

--- a/packages/slate-lists/src/normalizations/normalizeListItemTextChildren.ts
+++ b/packages/slate-lists/src/normalizations/normalizeListItemTextChildren.ts
@@ -1,16 +1,17 @@
 import type { NodeEntry } from 'slate';
 import { Editor, Element, Node, Transforms } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * A "list-item-text" can have only inline nodes in it.
  */
 export function normalizeListItemTextChildren(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListItemTextNode(node)) {
+    if (!schema.isListItemTextNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }

--- a/packages/slate-lists/src/normalizations/normalizeOrphanListItem.ts
+++ b/packages/slate-lists/src/normalizations/normalizeOrphanListItem.ts
@@ -2,7 +2,7 @@ import type { Node, NodeEntry } from 'slate';
 import { Editor, Transforms } from 'slate';
 
 import { getParentList } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * If "list-item" somehow (e.g. by deleting everything around it) ends up
@@ -13,15 +13,16 @@ import type { ListsEditor } from '../types';
  * pasting, so we have a separate rule for that in `deserializeHtml`.
  */
 export function normalizeOrphanListItem(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListItemNode(node)) {
+    if (!schema.isListItemNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
 
-    const parentList = getParentList(editor, path);
+    const parentList = getParentList(editor, schema, path);
 
     if (parentList) {
         // If there is a parent "list", then the fix does not apply.
@@ -30,7 +31,7 @@ export function normalizeOrphanListItem(
 
     Editor.withoutNormalizing(editor, () => {
         Transforms.unwrapNodes(editor, { at: path });
-        Transforms.setNodes(editor, editor.createDefaultTextNode(), { at: path });
+        Transforms.setNodes(editor, schema.createDefaultTextNode(), { at: path });
     });
 
     return true;

--- a/packages/slate-lists/src/normalizations/normalizeOrphanListItemText.ts
+++ b/packages/slate-lists/src/normalizations/normalizeOrphanListItemText.ts
@@ -1,8 +1,8 @@
-import type { Node, NodeEntry } from 'slate';
+import type { Editor, Node, NodeEntry } from 'slate';
 import { Transforms } from 'slate';
 
 import { getParentListItem } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * If "list-item-text" somehow (e.g. by deleting everything around it) ends up
@@ -13,22 +13,23 @@ import type { ListsEditor } from '../types';
  * pasting, so we have a separate rule for that in `deserializeHtml`.
  */
 export function normalizeOrphanListItemText(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListItemTextNode(node)) {
+    if (!schema.isListItemTextNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
 
-    const parentListItem = getParentListItem(editor, path);
+    const parentListItem = getParentListItem(editor, schema, path);
 
     if (parentListItem) {
         // If there is a parent "list-item", then the fix does not apply.
         return false;
     }
 
-    Transforms.setNodes(editor, editor.createDefaultTextNode(), { at: path });
+    Transforms.setNodes(editor, schema.createDefaultTextNode(), { at: path });
 
     return true;
 }

--- a/packages/slate-lists/src/normalizations/normalizeOrphanNestedList.ts
+++ b/packages/slate-lists/src/normalizations/normalizeOrphanNestedList.ts
@@ -1,19 +1,20 @@
-import type { NodeEntry } from 'slate';
+import type { Editor, NodeEntry } from 'slate';
 import { Node, Transforms } from 'slate';
 
 import { getNestedList, getPrevSibling } from '../lib';
 import { moveListItemsToAnotherList, moveListToListItem } from '../transformations';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * If there is a nested "list" inside a "list-item" without a "list-item-text"
  * unwrap that nested "list" and try to nest it in previous sibling "list-item".
  */
 export function normalizeOrphanNestedList(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListItemNode(node)) {
+    if (!schema.isListItemNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
@@ -27,7 +28,7 @@ export function normalizeOrphanNestedList(
     const [list] = children;
     const [listNode, listPath] = list;
 
-    if (!editor.isListNode(listNode)) {
+    if (!schema.isListNode(listNode)) {
         // If the first child is not a "list", then this fix does not apply.
         return false;
     }
@@ -36,15 +37,15 @@ export function normalizeOrphanNestedList(
 
     if (previousListItem) {
         const [, previousListItemPath] = previousListItem;
-        const previousListItemNestedList = getNestedList(editor, previousListItemPath);
+        const previousListItemNestedList = getNestedList(editor, schema, previousListItemPath);
 
         if (previousListItemNestedList) {
-            moveListItemsToAnotherList(editor, {
+            moveListItemsToAnotherList(editor, schema, {
                 at: list,
                 to: previousListItemNestedList,
             });
         } else {
-            moveListToListItem(editor, {
+            moveListToListItem(editor, schema, {
                 at: list,
                 to: previousListItem,
             });

--- a/packages/slate-lists/src/normalizations/normalizeSiblingLists.ts
+++ b/packages/slate-lists/src/normalizations/normalizeSiblingLists.ts
@@ -1,15 +1,19 @@
-import type { Node, NodeEntry } from 'slate';
+import type { Editor, Node, NodeEntry } from 'slate';
 
 import { getNextSibling } from '../lib';
 import { mergeListWithPreviousSiblingList } from '../transformations';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * If there are 2 "lists" of the same type next to each other, merge them together.
  * If there are 2 nested "lists" next to each other, merge them together.
  */
-export function normalizeSiblingLists(editor: ListsEditor, entry: NodeEntry<Node>): boolean {
-    const normalized = mergeListWithPreviousSiblingList(editor, entry);
+export function normalizeSiblingLists(
+    editor: Editor,
+    schema: ListsSchema,
+    entry: NodeEntry<Node>,
+): boolean {
+    const normalized = mergeListWithPreviousSiblingList(editor, schema, entry);
 
     if (normalized) {
         return true;
@@ -22,5 +26,5 @@ export function normalizeSiblingLists(editor: ListsEditor, entry: NodeEntry<Node
         return false;
     }
 
-    return mergeListWithPreviousSiblingList(editor, nextSibling);
+    return mergeListWithPreviousSiblingList(editor, schema, nextSibling);
 }

--- a/packages/slate-lists/src/normalizeNode.ts
+++ b/packages/slate-lists/src/normalizeNode.ts
@@ -7,15 +7,16 @@ import * as Normalizations from './normalizations';
  * All plugin normalizations combined into a single function.
  */
 export function normalizeNode(editor: Editor, entry: NodeEntry): boolean {
-    if (ListsEditor.isListsEditor(editor)) {
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema) {
         return (
-            normalizeNode.normalizeListChildren(editor, entry) ||
-            normalizeNode.normalizeListItemChildren(editor, entry) ||
-            normalizeNode.normalizeListItemTextChildren(editor, entry) ||
-            normalizeNode.normalizeOrphanListItem(editor, entry) ||
-            normalizeNode.normalizeOrphanListItemText(editor, entry) ||
-            normalizeNode.normalizeOrphanNestedList(editor, entry) ||
-            normalizeNode.normalizeSiblingLists(editor, entry)
+            normalizeNode.normalizeListChildren(editor, schema, entry) ||
+            normalizeNode.normalizeListItemChildren(editor, schema, entry) ||
+            normalizeNode.normalizeListItemTextChildren(editor, schema, entry) ||
+            normalizeNode.normalizeOrphanListItem(editor, schema, entry) ||
+            normalizeNode.normalizeOrphanListItemText(editor, schema, entry) ||
+            normalizeNode.normalizeOrphanNestedList(editor, schema, entry) ||
+            normalizeNode.normalizeSiblingLists(editor, schema, entry)
         );
     }
     return false;

--- a/packages/slate-lists/src/on-key-down/onBackspaceDecreaseListDepth.ts
+++ b/packages/slate-lists/src/on-key-down/onBackspaceDecreaseListDepth.ts
@@ -1,17 +1,16 @@
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { ReactEditor } from 'slate-react';
+import type { Editor } from 'slate';
 
 import { canDeleteBackward } from '../lib';
+import { ListsEditor } from '../ListsEditor';
 import { decreaseDepth } from '../transformations';
-import type { ListsEditor } from '../types';
-
-type Editor = ListsEditor & ReactEditor;
 
 export function onBackspaceDecreaseListDepth(editor: Editor, event: KeyboardEvent) {
-    if (isHotkey('backspace', event.nativeEvent) && !canDeleteBackward(editor)) {
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema && isHotkey('backspace', event.nativeEvent) && !canDeleteBackward(editor, schema)) {
         event.preventDefault();
-        return decreaseDepth(editor);
+        return decreaseDepth(editor, schema);
     }
     return false;
 }

--- a/packages/slate-lists/src/on-key-down/onEnterEscapeFromEmptyList.ts
+++ b/packages/slate-lists/src/on-key-down/onEnterEscapeFromEmptyList.ts
@@ -1,18 +1,17 @@
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { ReactEditor } from 'slate-react';
+import type { Editor } from 'slate';
 
 import { isCursorInEmptyListItem } from '../lib';
+import { ListsEditor } from '../ListsEditor';
 import { decreaseDepth } from '../transformations';
-import type { ListsEditor } from '../types';
-
-type Editor = ListsEditor & ReactEditor;
 
 export function onEnterEscapeFromEmptyList(editor: Editor, event: KeyboardEvent) {
-    if (isHotkey('enter', event.nativeEvent)) {
-        if (isCursorInEmptyListItem(editor)) {
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema && isHotkey('enter', event.nativeEvent)) {
+        if (isCursorInEmptyListItem(editor, schema)) {
             event.preventDefault();
-            return decreaseDepth(editor);
+            return decreaseDepth(editor, schema);
         }
     }
     return false;

--- a/packages/slate-lists/src/on-key-down/onEnterSplitNonEmptyList.ts
+++ b/packages/slate-lists/src/on-key-down/onEnterSplitNonEmptyList.ts
@@ -1,19 +1,18 @@
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { ReactEditor } from 'slate-react';
+import type { Editor } from 'slate';
 
 import { getListItemsInRange } from '../lib';
+import { ListsEditor } from '../ListsEditor';
 import { splitListItem } from '../transformations';
-import type { ListsEditor } from '../types';
-
-type Editor = ListsEditor & ReactEditor;
 
 export function onEnterSplitNonEmptyList(editor: Editor, event: KeyboardEvent) {
-    if (isHotkey('enter', event.nativeEvent)) {
-        const listItemsInSelection = getListItemsInRange(editor, editor.selection);
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema && isHotkey('enter', event.nativeEvent)) {
+        const listItemsInSelection = getListItemsInRange(editor, schema, editor.selection);
         if (listItemsInSelection.length > 0) {
             event.preventDefault();
-            return splitListItem(editor);
+            return splitListItem(editor, schema);
         }
     }
     return false;

--- a/packages/slate-lists/src/on-key-down/onShiftTabDecreaseListDepth.ts
+++ b/packages/slate-lists/src/on-key-down/onShiftTabDecreaseListDepth.ts
@@ -1,16 +1,15 @@
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { ReactEditor } from 'slate-react';
+import type { Editor } from 'slate';
 
+import { ListsEditor } from '../ListsEditor';
 import { decreaseDepth } from '../transformations';
-import type { ListsEditor } from '../types';
-
-type Editor = ListsEditor & ReactEditor;
 
 export function onShiftTabDecreaseListDepth(editor: Editor, event: KeyboardEvent) {
-    if (isHotkey('shift+tab', event.nativeEvent)) {
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema && isHotkey('shift+tab', event.nativeEvent)) {
         event.preventDefault();
-        return decreaseDepth(editor);
+        return decreaseDepth(editor, schema);
     }
     return false;
 }

--- a/packages/slate-lists/src/on-key-down/onTabIncreaseListDepth.ts
+++ b/packages/slate-lists/src/on-key-down/onTabIncreaseListDepth.ts
@@ -1,16 +1,15 @@
 import { isHotkey } from 'is-hotkey';
 import type { KeyboardEvent } from 'react';
-import type { ReactEditor } from 'slate-react';
+import type { Editor } from 'slate';
 
+import { ListsEditor } from '../ListsEditor';
 import { increaseDepth } from '../transformations';
-import type { ListsEditor } from '../types';
-
-type Editor = ListsEditor & ReactEditor;
 
 export function onTabIncreaseListDepth(editor: Editor, event: KeyboardEvent) {
-    if (isHotkey('tab', event.nativeEvent)) {
+    const schema = ListsEditor.getListsSchema(editor);
+    if (schema && isHotkey('tab', event.nativeEvent)) {
         event.preventDefault();
-        return increaseDepth(editor);
+        return increaseDepth(editor, schema);
     }
     return false;
 }

--- a/packages/slate-lists/src/onKeyDown.ts
+++ b/packages/slate-lists/src/onKeyDown.ts
@@ -1,13 +1,14 @@
 import type { KeyboardEvent } from 'react';
 import { Editor } from 'slate';
-import type { ReactEditor } from 'slate-react';
 
+import { ListsEditor } from './ListsEditor';
 import * as OnKeyDownHandlers from './on-key-down';
-import type { ListsEditor } from './types';
 
-type CompatibleEditor = ListsEditor & ReactEditor;
+export function onKeyDown(editor: Editor, event: KeyboardEvent): boolean | void {
+    if (!ListsEditor.isListsEnabled(editor)) {
+        return;
+    }
 
-export function onKeyDown(editor: CompatibleEditor, event: KeyboardEvent): boolean | void {
     try {
         return (
             onKeyDown.onTabIncreaseListDepth(editor, event) ||

--- a/packages/slate-lists/src/registry.ts
+++ b/packages/slate-lists/src/registry.ts
@@ -1,0 +1,27 @@
+import type { Editor } from 'slate';
+
+import type { ListsSchema } from './types';
+
+const EDITOR_LISTS_SCHEMA = new WeakMap<Editor, ListsSchema>();
+
+export function register(editor: Editor, schema: ListsSchema): void {
+    EDITOR_LISTS_SCHEMA.set(editor, schema);
+}
+
+export function unregister(editor: Editor): void {
+    EDITOR_LISTS_SCHEMA.delete(editor);
+}
+
+export function has(editor: Editor) {
+    return EDITOR_LISTS_SCHEMA.has(editor);
+}
+
+export function get(editor: Editor): ListsSchema {
+    const schema = EDITOR_LISTS_SCHEMA.get(editor);
+    if (!schema) {
+        throw new Error(
+            'This editor instance does not have a ListsSchema associated. Make sure you initialize it with withLists() before using ListsEditor functionality.',
+        );
+    }
+    return schema;
+}

--- a/packages/slate-lists/src/transformations/decreaseDepth.test.tsx
+++ b/packages/slate-lists/src/transformations/decreaseDepth.test.tsx
@@ -1,5 +1,7 @@
 /** @jsx hyperscript */
 
+import type { Editor as Slate } from 'slate';
+
 import {
     Anchor,
     Cursor,
@@ -8,21 +10,19 @@ import {
     hyperscript,
     ListItem,
     ListItemText,
-    noop,
     OrderedList,
     Paragraph,
     SCHEMA,
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
 
 import { decreaseDepth } from './decreaseDepth';
 
 describe('decreaseDepth', () => {
     it('should do nothing when there is no selection', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -31,10 +31,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -43,7 +43,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -53,7 +53,7 @@ describe('decreaseDepth', () => {
 
     it('should do nothing when there are no list items is the selection', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -69,10 +69,10 @@ describe('decreaseDepth', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -88,7 +88,7 @@ describe('decreaseDepth', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -98,7 +98,7 @@ describe('decreaseDepth', () => {
 
     it('should convert the selected list item to a paragraph when there is no grandparent list', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -110,10 +110,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <Paragraph>
                     <Text>
                         lorem ipsum
@@ -121,7 +121,7 @@ describe('decreaseDepth', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -131,7 +131,7 @@ describe('decreaseDepth', () => {
 
     it('should move the selected list-item to the grandparent list', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -155,10 +155,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -182,7 +182,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -192,7 +192,7 @@ describe('decreaseDepth', () => {
 
     it('should move the selected list item to the grandparent list and removes the parent list if empty', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -211,10 +211,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -231,7 +231,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -241,7 +241,7 @@ describe('decreaseDepth', () => {
 
     it('should move the selected list-item to the grandparent list and succeeding siblings into a new nested list', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -275,10 +275,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -314,7 +314,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -324,7 +324,7 @@ describe('decreaseDepth', () => {
 
     it('should convert the selected list-item into a paragraph, move it out of the list and move succeeding siblings into a new list', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -358,10 +358,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -395,7 +395,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -405,7 +405,7 @@ describe('decreaseDepth', () => {
 
     it('should decrease depth of all selected list items in selection that have no list items ancestors in selection', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -495,10 +495,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -586,7 +586,7 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA);
 
@@ -596,7 +596,7 @@ describe('decreaseDepth', () => {
 
     it('should convert list items to paragraphs', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -621,10 +621,10 @@ describe('decreaseDepth', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <Paragraph>
                     <Text>
                         <Focus />
@@ -641,7 +641,7 @@ describe('decreaseDepth', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         decreaseDepth(editor, SCHEMA, [0, 0]);
         decreaseDepth(editor, SCHEMA, [1, 0]);

--- a/packages/slate-lists/src/transformations/decreaseDepth.test.tsx
+++ b/packages/slate-lists/src/transformations/decreaseDepth.test.tsx
@@ -1,18 +1,19 @@
 /** @jsx hyperscript */
 
 import {
-    hyperscript,
+    Anchor,
+    Cursor,
     Editor,
-    OrderedList,
-    UnorderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
-    Text,
-    Paragraph,
-    Cursor,
-    Anchor,
-    Focus,
     noop,
+    OrderedList,
+    Paragraph,
+    SCHEMA,
+    Text,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 
@@ -44,7 +45,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -89,7 +90,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -122,7 +123,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -183,7 +184,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -232,7 +233,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -315,7 +316,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -396,7 +397,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -587,7 +588,7 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor);
+        decreaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -642,9 +643,9 @@ describe('decreaseDepth', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        decreaseDepth(editor, [0, 0]);
-        decreaseDepth(editor, [1, 0]);
-        decreaseDepth(editor, [2, 0]);
+        decreaseDepth(editor, SCHEMA, [0, 0]);
+        decreaseDepth(editor, SCHEMA, [1, 0]);
+        decreaseDepth(editor, SCHEMA, [2, 0]);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/decreaseDepth.ts
+++ b/packages/slate-lists/src/transformations/decreaseDepth.ts
@@ -2,7 +2,7 @@ import type { Location } from 'slate';
 import { Editor } from 'slate';
 
 import { getListItemsInRange, pickSubtreesRoots } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 import { decreaseListItemDepth } from './decreaseListItemDepth';
 
@@ -13,14 +13,15 @@ import { decreaseListItemDepth } from './decreaseListItemDepth';
  * @returns {boolean} True, if the editor state has been changed.
  */
 export function decreaseDepth(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     at: Location | null = editor.selection,
 ): boolean {
     if (!at) {
         return false;
     }
 
-    const listItems = getListItemsInRange(editor, at);
+    const listItems = getListItemsInRange(editor, schema, at);
 
     // When calling `decreaseListItemDepth` the paths and references to "list-items"
     // can change, so we need a way of marking the "list-items" scheduled for transformation.
@@ -30,7 +31,7 @@ export function decreaseDepth(
 
     refs.forEach((ref) => {
         if (ref.current) {
-            handled = decreaseListItemDepth(editor, ref.current) || handled;
+            handled = decreaseListItemDepth(editor, schema, ref.current) || handled;
         }
 
         ref.unref();

--- a/packages/slate-lists/src/transformations/increaseDepth.test.tsx
+++ b/packages/slate-lists/src/transformations/increaseDepth.test.tsx
@@ -1,5 +1,7 @@
 /** @jsx hyperscript */
 
+import type { Editor as Slate } from 'slate';
+
 import {
     Anchor,
     Cursor,
@@ -8,21 +10,19 @@ import {
     hyperscript,
     ListItem,
     ListItemText,
-    noop,
     OrderedList,
     Paragraph,
     SCHEMA,
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
 
 import { increaseDepth } from './increaseDepth';
 
 describe('increaseDepth - no selected items', () => {
     it('Does nothing when there is no selection', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -31,10 +31,10 @@ describe('increaseDepth - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -43,7 +43,7 @@ describe('increaseDepth - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -55,7 +55,7 @@ describe('increaseDepth - no selected items', () => {
 describe('increaseDepth - single item selected', () => {
     it('Does nothing when there is no preceding sibling list item', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -67,10 +67,10 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -82,7 +82,7 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -92,7 +92,7 @@ describe('increaseDepth - single item selected', () => {
 
     it('Moves list-item to the child list of a preceding sibling list item', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -116,10 +116,10 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -143,7 +143,7 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -153,7 +153,7 @@ describe('increaseDepth - single item selected', () => {
 
     it('Creates a child list in preceding sibling list item and moves list-item there', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -170,10 +170,10 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -192,7 +192,7 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -202,7 +202,7 @@ describe('increaseDepth - single item selected', () => {
 
     it('Creates a child list in preceding sibling list item and moves list-item there, maintaining list type', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <OrderedList>
                     <ListItem>
                         <ListItemText>
@@ -219,10 +219,10 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </OrderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <OrderedList>
                     <ListItem>
                         <ListItemText>
@@ -241,7 +241,7 @@ describe('increaseDepth - single item selected', () => {
                     </ListItem>
                 </OrderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -253,7 +253,7 @@ describe('increaseDepth - single item selected', () => {
 describe('increaseDepth - multiple items selected', () => {
     it('Increases depth of all indentable list items in selection that have no list items ancestors in selection (A)', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -278,10 +278,10 @@ describe('increaseDepth - multiple items selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -308,7 +308,7 @@ describe('increaseDepth - multiple items selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -318,7 +318,7 @@ describe('increaseDepth - multiple items selected', () => {
 
     it('Increases depth of all indentable list items in selection that have no list items ancestors in selection (B)', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -408,10 +408,10 @@ describe('increaseDepth - multiple items selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -501,7 +501,7 @@ describe('increaseDepth - multiple items selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 
@@ -513,7 +513,7 @@ describe('increaseDepth - multiple items selected', () => {
 describe('increaseDepth - multiple items and paragraphs selected', () => {
     it('Converts paragraphs into lists items and merges them together', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <Paragraph>
                     <Text>
                         <Anchor />
@@ -544,10 +544,10 @@ describe('increaseDepth - multiple items and paragraphs selected', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -588,7 +588,7 @@ describe('increaseDepth - multiple items and paragraphs selected', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         increaseDepth(editor, SCHEMA);
 

--- a/packages/slate-lists/src/transformations/increaseDepth.test.tsx
+++ b/packages/slate-lists/src/transformations/increaseDepth.test.tsx
@@ -1,18 +1,19 @@
 /** @jsx hyperscript */
 
 import {
-    hyperscript,
+    Anchor,
+    Cursor,
     Editor,
-    UnorderedList,
-    OrderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
-    Text,
-    Paragraph,
-    Anchor,
-    Focus,
-    Cursor,
     noop,
+    OrderedList,
+    Paragraph,
+    SCHEMA,
+    Text,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 
@@ -44,7 +45,7 @@ describe('increaseDepth - no selected items', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -83,7 +84,7 @@ describe('increaseDepth - single item selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -144,7 +145,7 @@ describe('increaseDepth - single item selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -193,7 +194,7 @@ describe('increaseDepth - single item selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -242,7 +243,7 @@ describe('increaseDepth - single item selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -309,7 +310,7 @@ describe('increaseDepth - multiple items selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -502,7 +503,7 @@ describe('increaseDepth - multiple items selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -589,7 +590,7 @@ describe('increaseDepth - multiple items and paragraphs selected', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        increaseDepth(editor);
+        increaseDepth(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/increaseDepth.ts
+++ b/packages/slate-lists/src/transformations/increaseDepth.ts
@@ -1,7 +1,7 @@
 import { Editor } from 'slate';
 
 import { getListItemsInRange, getPrevSibling, pickSubtreesRoots } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 import { ListType } from '../types';
 
 import { increaseListItemDepth } from './increaseListItemDepth';
@@ -13,12 +13,12 @@ import { wrapInList } from './wrapInList';
  *
  * @returns {boolean} True, if the editor state has been changed.
  */
-export function increaseDepth(editor: ListsEditor): boolean {
+export function increaseDepth(editor: Editor, schema: ListsSchema): boolean {
     if (!editor.selection) {
         return false;
     }
 
-    const listItems = getListItemsInRange(editor, editor.selection);
+    const listItems = getListItemsInRange(editor, schema, editor.selection);
     const indentableListItems = listItems.filter(([, listItemPath]) => {
         const previousListItem = getPrevSibling(editor, listItemPath);
         return previousListItem !== null;
@@ -32,11 +32,11 @@ export function increaseDepth(editor: ListsEditor): boolean {
 
     Editor.withoutNormalizing(editor, () => {
         // Before we indent "list-items", we want to convert every non list-related block in selection to a "list".
-        wrapInList(editor, ListType.UNORDERED);
+        wrapInList(editor, schema, ListType.UNORDERED);
 
         refs.forEach((ref) => {
             if (ref.current) {
-                increaseListItemDepth(editor, ref.current);
+                increaseListItemDepth(editor, schema, ref.current);
             }
             ref.unref();
         });

--- a/packages/slate-lists/src/transformations/increaseListItemDepth.ts
+++ b/packages/slate-lists/src/transformations/increaseListItemDepth.ts
@@ -2,12 +2,16 @@ import { Editor, Element, Node, Path, Transforms } from 'slate';
 
 import { NESTED_LIST_PATH_INDEX } from '../constants';
 import { getListType, getPrevSibling } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Increases nesting depth of "list-item" at a given Path.
  */
-export function increaseListItemDepth(editor: ListsEditor, listItemPath: Path): void {
+export function increaseListItemDepth(
+    editor: Editor,
+    schema: ListsSchema,
+    listItemPath: Path,
+): void {
     const previousListItem = getPrevSibling(editor, listItemPath);
 
     if (!previousListItem) {
@@ -18,7 +22,7 @@ export function increaseListItemDepth(editor: ListsEditor, listItemPath: Path): 
 
     const [previousListItemNode, previousListItemPath] = previousListItem;
 
-    if (!editor.isListItemNode(previousListItemNode)) {
+    if (!schema.isListItemNode(previousListItemNode)) {
         // Sanity check.
         return;
     }
@@ -33,7 +37,7 @@ export function increaseListItemDepth(editor: ListsEditor, listItemPath: Path): 
             const listNode = Node.get(editor, listNodePath);
             Transforms.insertNodes(
                 editor,
-                editor.createListNode(getListType(editor, listNode), { children: [] }),
+                schema.createListNode(getListType(schema, listNode), { children: [] }),
                 {
                     at: previousListItemChildListPath,
                 },
@@ -44,7 +48,7 @@ export function increaseListItemDepth(editor: ListsEditor, listItemPath: Path): 
 
         if (
             Element.isElement(previousListItemChildList) &&
-            editor.isListNode(previousListItemChildList)
+            schema.isListNode(previousListItemChildList)
         ) {
             const index = previousListItemHasChildList
                 ? previousListItemChildList.children.length

--- a/packages/slate-lists/src/transformations/mergeListWithPreviousSiblingList.ts
+++ b/packages/slate-lists/src/transformations/mergeListWithPreviousSiblingList.ts
@@ -1,14 +1,15 @@
-import type { Node, NodeEntry } from 'slate';
+import type { Editor, Node, NodeEntry } from 'slate';
 import { Transforms } from 'slate';
 
 import { getListType, getParentListItem, getPrevSibling } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 export function mergeListWithPreviousSiblingList(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     [node, path]: NodeEntry<Node>,
 ): boolean {
-    if (!editor.isListNode(node)) {
+    if (!schema.isListNode(node)) {
         // This function does not know how to normalize other nodes.
         return false;
     }
@@ -22,13 +23,13 @@ export function mergeListWithPreviousSiblingList(
 
     const [previousSiblingNode] = previousSibling;
 
-    if (!editor.isListNode(previousSiblingNode)) {
+    if (!schema.isListNode(previousSiblingNode)) {
         return false;
     }
 
-    const isNestedList = Boolean(getParentListItem(editor, path));
+    const isNestedList = Boolean(getParentListItem(editor, schema, path));
     const isPreviousSiblingSameListType =
-        getListType(editor, previousSiblingNode) === getListType(editor, node);
+        getListType(schema, previousSiblingNode) === getListType(schema, node);
 
     if (!isPreviousSiblingSameListType && !isNestedList) {
         // If previous sibling "list" is of a different type, then this fix does not apply

--- a/packages/slate-lists/src/transformations/moveListItemsToAnotherList.ts
+++ b/packages/slate-lists/src/transformations/moveListItemsToAnotherList.ts
@@ -1,13 +1,14 @@
-import type { Node, NodeEntry } from 'slate';
+import type { Editor, Node, NodeEntry } from 'slate';
 import { Element, Transforms } from 'slate';
 
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Moves all "list-items" from one "list" to the end of another "list".
  */
 export function moveListItemsToAnotherList(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     parameters: {
         at: NodeEntry<Node>;
         to: NodeEntry<Node>;
@@ -19,8 +20,8 @@ export function moveListItemsToAnotherList(
     if (
         Element.isElement(sourceListNode) &&
         Element.isElement(targetListNode) &&
-        editor.isListNode(sourceListNode) &&
-        editor.isListNode(targetListNode)
+        schema.isListNode(sourceListNode) &&
+        schema.isListNode(targetListNode)
     ) {
         // Sanity check.
         for (let i = 0; i < sourceListNode.children.length; ++i) {

--- a/packages/slate-lists/src/transformations/moveListToListItem.ts
+++ b/packages/slate-lists/src/transformations/moveListToListItem.ts
@@ -1,14 +1,15 @@
-import type { Node, NodeEntry } from 'slate';
+import type { Editor, Node, NodeEntry } from 'slate';
 import { Transforms } from 'slate';
 
 import { NESTED_LIST_PATH_INDEX } from '../constants';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 /**
  * Nests (moves) given "list" in a given "list-item".
  */
 export function moveListToListItem(
-    editor: ListsEditor,
+    editor: Editor,
+    schema: ListsSchema,
     parameters: {
         at: NodeEntry<Node>;
         to: NodeEntry<Node>;
@@ -17,7 +18,7 @@ export function moveListToListItem(
     const [sourceListNode, sourceListPath] = parameters.at;
     const [targetListNode, targetListPath] = parameters.to;
 
-    if (!editor.isListNode(sourceListNode) || !editor.isListItemNode(targetListNode)) {
+    if (!schema.isListNode(sourceListNode) || !schema.isListItemNode(targetListNode)) {
         // Sanity check.
         return;
     }

--- a/packages/slate-lists/src/transformations/setListType.test.tsx
+++ b/packages/slate-lists/src/transformations/setListType.test.tsx
@@ -1,5 +1,7 @@
 /** @jsx hyperscript */
 
+import type { Editor as Slate } from 'slate';
+
 import {
     Anchor,
     Editor,
@@ -12,7 +14,6 @@ import {
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
 import { ListType } from '../types';
 
 import { setListType } from './setListType';
@@ -29,7 +30,7 @@ describe('setListType', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -41,7 +42,7 @@ describe('setListType', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         setListType(editor, SCHEMA, ListType.ORDERED);
 
@@ -112,7 +113,7 @@ describe('setListType', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -176,7 +177,7 @@ describe('setListType', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         setListType(editor, SCHEMA, ListType.ORDERED);
 

--- a/packages/slate-lists/src/transformations/setListType.test.tsx
+++ b/packages/slate-lists/src/transformations/setListType.test.tsx
@@ -1,15 +1,16 @@
 /** @jsx hyperscript */
 
 import {
-    hyperscript,
+    Anchor,
     Editor,
-    OrderedList,
-    UnorderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
+    OrderedList,
+    SCHEMA,
     Text,
-    Anchor,
-    Focus,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 import { ListType } from '../types';
@@ -42,7 +43,7 @@ describe('setListType', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        setListType(editor, ListType.ORDERED);
+        setListType(editor, SCHEMA, ListType.ORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -177,7 +178,7 @@ describe('setListType', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        setListType(editor, ListType.ORDERED);
+        setListType(editor, SCHEMA, ListType.ORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/setListType.ts
+++ b/packages/slate-lists/src/transformations/setListType.ts
@@ -1,17 +1,17 @@
-import { type Element, Editor, Node, Transforms } from 'slate';
+import { Editor, type Element, Node, Transforms } from 'slate';
 
 import { getListsInRange } from '../lib';
-import type { ListType, ListsEditor } from '../types';
+import type { ListsSchema, ListType } from '../types';
 
 /**
  * Sets "type" of all "list" nodes in the current selection.
  */
-export function setListType(editor: ListsEditor, listType: ListType): void {
+export function setListType(editor: Editor, schema: ListsSchema, listType: ListType): void {
     if (!editor.selection) {
         return;
     }
 
-    const lists = getListsInRange(editor, editor.selection);
+    const lists = getListsInRange(editor, schema, editor.selection);
     const refs = lists.map(([_, path]) => Editor.pathRef(editor, path));
 
     refs.forEach((ref) => {
@@ -19,7 +19,7 @@ export function setListType(editor: ListsEditor, listType: ListType): void {
         const node = path ? Node.get(editor, path) : null;
 
         if (node && path) {
-            Transforms.setNodes(editor, editor.createListNode(listType, node as Element), {
+            Transforms.setNodes(editor, schema.createListNode(listType, node as Element), {
                 at: path,
             });
         }

--- a/packages/slate-lists/src/transformations/splitListItem.test.tsx
+++ b/packages/slate-lists/src/transformations/splitListItem.test.tsx
@@ -1,17 +1,18 @@
 /** @jsx hyperscript */
 
 import {
-    hyperscript,
+    Anchor,
+    Cursor,
     Editor,
-    UnorderedList,
-    OrderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
-    Text,
+    OrderedList,
     Paragraph,
-    Cursor,
-    Anchor,
-    Focus,
+    SCHEMA,
+    Text,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 
@@ -43,7 +44,7 @@ describe('splitListItem - no selected items', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -86,7 +87,7 @@ describe('splitListItem - no selected items', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -129,7 +130,7 @@ describe('splitListItem - collapsed selection', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -171,7 +172,7 @@ describe('splitListItem - collapsed selection', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -214,7 +215,7 @@ describe('splitListItem - collapsed selection', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -281,7 +282,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -347,7 +348,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -414,7 +415,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -495,7 +496,7 @@ describe('splitListItem - collapsed selection - deeply nested lists', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -586,7 +587,7 @@ describe('splitListItem - expanded selection - deeply nested lists', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        splitListItem(editor);
+        splitListItem(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/splitListItem.test.tsx
+++ b/packages/slate-lists/src/transformations/splitListItem.test.tsx
@@ -1,5 +1,7 @@
 /** @jsx hyperscript */
 
+import type { Editor as Slate } from 'slate';
+
 import {
     Anchor,
     Cursor,
@@ -14,14 +16,14 @@ import {
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
+import { normalizeNode } from '../normalizeNode';
 
 import { splitListItem } from './splitListItem';
 
 describe('splitListItem - no selected items', () => {
     it('Does nothing when there is no selection', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -30,7 +32,7 @@ describe('splitListItem - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -42,7 +44,7 @@ describe('splitListItem - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -52,7 +54,7 @@ describe('splitListItem - no selected items', () => {
 
     it('Does nothing when there are no list items in selection', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <Paragraph>
                     <Text>
                         lorem
@@ -67,7 +69,7 @@ describe('splitListItem - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -85,7 +87,7 @@ describe('splitListItem - no selected items', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -97,7 +99,7 @@ describe('splitListItem - no selected items', () => {
 describe('splitListItem - collapsed selection', () => {
     it('Creates new empty sibling list item when cursor is at the end of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -109,7 +111,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -128,7 +130,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -138,7 +140,7 @@ describe('splitListItem - collapsed selection', () => {
 
     it('Creates new empty sibling list item when cursor is at the beginning of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -150,7 +152,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -170,7 +172,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -180,7 +182,7 @@ describe('splitListItem - collapsed selection', () => {
 
     it('Creates a new sibling list item when cursor is in the middle of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -193,7 +195,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -213,7 +215,7 @@ describe('splitListItem - collapsed selection', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -225,7 +227,7 @@ describe('splitListItem - collapsed selection', () => {
 describe('splitListItem - collapsed selection - nested lists', () => {
     it('Creates new sibling list item in nested list when cursor is at the end of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -249,7 +251,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -280,7 +282,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -290,7 +292,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
 
     it('Creates new sibling list item in nested list when cursor is at the beginning of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -314,7 +316,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -346,7 +348,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -356,7 +358,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
 
     it('Creates new sibling list item in nested list when cursor is in the middle of an item', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -381,7 +383,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -413,7 +415,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -425,7 +427,7 @@ describe('splitListItem - collapsed selection - nested lists', () => {
 describe('splitListItem - collapsed selection - deeply nested lists', () => {
     it('Creates new sibling list item in nested list when cursor is at the end of an item with nested list', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -456,7 +458,7 @@ describe('splitListItem - collapsed selection - deeply nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -494,7 +496,7 @@ describe('splitListItem - collapsed selection - deeply nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 
@@ -508,7 +510,7 @@ describe('splitListItem - expanded selection - deeply nested lists', () => {
         // it's an interesting case because Transforms.delete will break <ListItem> in half,
         // leaving <UnorderedList> as its only child which will be normalized by withLists
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -547,7 +549,7 @@ describe('splitListItem - expanded selection - deeply nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -585,7 +587,7 @@ describe('splitListItem - expanded selection - deeply nested lists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         splitListItem(editor, SCHEMA);
 

--- a/packages/slate-lists/src/transformations/unwrapList.test.tsx
+++ b/packages/slate-lists/src/transformations/unwrapList.test.tsx
@@ -1,18 +1,19 @@
 /** @jsx hyperscript */
 
 import {
-    hyperscript,
+    Anchor,
+    Cursor,
     Editor,
-    OrderedList,
-    UnorderedList,
+    Focus,
+    hyperscript,
     ListItem,
     ListItemText,
-    Text,
-    Paragraph,
-    Cursor,
-    Focus,
-    Anchor,
     noop,
+    OrderedList,
+    Paragraph,
+    SCHEMA,
+    Text,
+    UnorderedList,
 } from '../hyperscript';
 import type { ListsEditor } from '../types';
 
@@ -44,7 +45,7 @@ describe('unwrapList', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        unwrapList(editor);
+        unwrapList(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -77,7 +78,7 @@ describe('unwrapList', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        unwrapList(editor);
+        unwrapList(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -134,7 +135,7 @@ describe('unwrapList', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        unwrapList(editor);
+        unwrapList(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -225,7 +226,7 @@ describe('unwrapList', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        unwrapList(editor);
+        unwrapList(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -280,7 +281,7 @@ describe('unwrapList', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        unwrapList(editor);
+        unwrapList(editor, SCHEMA);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/unwrapList.test.tsx
+++ b/packages/slate-lists/src/transformations/unwrapList.test.tsx
@@ -1,4 +1,5 @@
 /** @jsx hyperscript */
+import type { Editor as Slate } from 'slate';
 
 import {
     Anchor,
@@ -8,21 +9,19 @@ import {
     hyperscript,
     ListItem,
     ListItemText,
-    noop,
     OrderedList,
     Paragraph,
     SCHEMA,
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
 
 import { unwrapList } from './unwrapList';
 
 describe('unwrapList', () => {
     it('should do nothing when there is no selection', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -31,10 +30,10 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -43,7 +42,7 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         unwrapList(editor, SCHEMA);
 
@@ -53,7 +52,7 @@ describe('unwrapList', () => {
 
     it('should convert the only selected list item into a paragraph', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -65,10 +64,10 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <Paragraph>
                     <Text>
                         lorem
@@ -76,7 +75,7 @@ describe('unwrapList', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         unwrapList(editor, SCHEMA);
 
@@ -86,7 +85,7 @@ describe('unwrapList', () => {
 
     it('should convert middle list item into a paragraph', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -108,10 +107,10 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -133,7 +132,7 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         unwrapList(editor, SCHEMA);
 
@@ -143,7 +142,7 @@ describe('unwrapList', () => {
 
     it('should convert nested middle list item into a paragraph', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -182,10 +181,10 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -224,7 +223,7 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         unwrapList(editor, SCHEMA);
 
@@ -234,7 +233,7 @@ describe('unwrapList', () => {
 
     it('should convert a multi-item list into paragraphs', () => {
         const editor = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -259,10 +258,10 @@ describe('unwrapList', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor normalizeNode={noop}>
+            <Editor normalizeNode="disabled">
                 <Paragraph>
                     <Text>
                         <Focus />
@@ -279,7 +278,7 @@ describe('unwrapList', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         unwrapList(editor, SCHEMA);
 

--- a/packages/slate-lists/src/transformations/unwrapList.ts
+++ b/packages/slate-lists/src/transformations/unwrapList.ts
@@ -1,7 +1,7 @@
 import { Editor } from 'slate';
 
 import { getListItemsInRange } from '../lib';
-import type { ListsEditor } from '../types';
+import type { ListsSchema } from '../types';
 
 import { decreaseDepth } from './decreaseDepth';
 
@@ -9,14 +9,14 @@ import { decreaseDepth } from './decreaseDepth';
  * Unwraps all "list-items" in the current selection.
  * No lists will be left in the current selection.
  */
-export function unwrapList(editor: ListsEditor): void {
+export function unwrapList(editor: Editor, schema: ListsSchema): void {
     Editor.withoutNormalizing(editor, () => {
         let iterations = 0;
 
-        while (getListItemsInRange(editor, editor.selection).length > 0) {
+        while (getListItemsInRange(editor, schema, editor.selection).length > 0) {
             iterations++;
 
-            decreaseDepth(editor);
+            decreaseDepth(editor, schema);
 
             if (iterations > 1000) {
                 throw new Error(

--- a/packages/slate-lists/src/transformations/wrapInList.test.tsx
+++ b/packages/slate-lists/src/transformations/wrapInList.test.tsx
@@ -1,5 +1,7 @@
 /** @jsx hyperscript */
 
+import type { Editor as Slate } from 'slate';
+
 import {
     Anchor,
     Divider,
@@ -13,7 +15,7 @@ import {
     Text,
     UnorderedList,
 } from '../hyperscript';
-import type { ListsEditor } from '../types';
+import { normalizeNode } from '../normalizeNode';
 import { ListType } from '../types';
 
 import { wrapInList } from './wrapInList';
@@ -21,7 +23,7 @@ import { wrapInList } from './wrapInList';
 describe('wrapInList - no selection', () => {
     it('Does nothing when there is no selection', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <Paragraph>
                     <Text>aaa</Text>
                 </Paragraph>
@@ -36,7 +38,7 @@ describe('wrapInList - no selection', () => {
                     <Text>bbb</Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -54,7 +56,7 @@ describe('wrapInList - no selection', () => {
                     <Text>bbb</Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
@@ -66,7 +68,7 @@ describe('wrapInList - no selection', () => {
 describe('wrapInList - selection with wrappable nodes', () => {
     it('Converts wrappable node into list', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <Paragraph>
                     <Text>
                         <Anchor />
@@ -75,7 +77,7 @@ describe('wrapInList - selection with wrappable nodes', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -91,7 +93,7 @@ describe('wrapInList - selection with wrappable nodes', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
@@ -103,7 +105,7 @@ describe('wrapInList - selection with wrappable nodes', () => {
 describe('wrapInList - selection with lists and wrappable nodes', () => {
     it('Converts wrappable nodes into lists items and merges them together', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <Paragraph>
                     <Text>
                         <Anchor />
@@ -124,10 +126,10 @@ describe('wrapInList - selection with lists and wrappable nodes', () => {
                     </Text>
                 </Paragraph>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     <ListItem>
                         <ListItemText>
@@ -152,7 +154,7 @@ describe('wrapInList - selection with lists and wrappable nodes', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
@@ -164,7 +166,7 @@ describe('wrapInList - selection with lists and wrappable nodes', () => {
 describe('wrapInList - selection with lists, wrappable & unwrappable nodes', () => {
     it('Converts wrappable nodes into lists items and merges them together, but leaves out unwrappable nodes', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <Paragraph>
                     <Text>
                         <Anchor />
@@ -181,7 +183,7 @@ describe('wrapInList - selection with lists, wrappable & unwrappable nodes', () 
                     </Text>
                 </Divider>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -207,7 +209,7 @@ describe('wrapInList - selection with lists, wrappable & unwrappable nodes', () 
                     </Text>
                 </Divider>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         wrapInList(editor, SCHEMA, ListType.UNORDERED);
 

--- a/packages/slate-lists/src/transformations/wrapInList.test.tsx
+++ b/packages/slate-lists/src/transformations/wrapInList.test.tsx
@@ -9,6 +9,7 @@ import {
     ListItem,
     ListItemText,
     Paragraph,
+    SCHEMA,
     Text,
     UnorderedList,
 } from '../hyperscript';
@@ -55,7 +56,7 @@ describe('wrapInList - no selection', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        wrapInList(editor, ListType.UNORDERED);
+        wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -92,7 +93,7 @@ describe('wrapInList - selection with wrappable nodes', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        wrapInList(editor, ListType.UNORDERED);
+        wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -153,7 +154,7 @@ describe('wrapInList - selection with lists and wrappable nodes', () => {
             </Editor>
         ) as unknown as ListsEditor;
 
-        wrapInList(editor, ListType.UNORDERED);
+        wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -208,7 +209,7 @@ describe('wrapInList - selection with lists, wrappable & unwrappable nodes', () 
             </Editor>
         ) as unknown as ListsEditor;
 
-        wrapInList(editor, ListType.UNORDERED);
+        wrapInList(editor, SCHEMA, ListType.UNORDERED);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-lists/src/transformations/wrapInList.ts
+++ b/packages/slate-lists/src/transformations/wrapInList.ts
@@ -1,15 +1,14 @@
 import { Editor, Element, Transforms } from 'slate';
 
-import type { ListsEditor } from '../types';
-import type { ListType } from '../types';
+import type { ListsSchema, ListType } from '../types';
 
 /**
  * All nodes matching `isConvertibleToListTextNode()` in the current selection
  * will be converted to list items and then wrapped in lists.
  *
- * @see ListsEditor.isConvertibleToListTextNode()
+ * @see ListsSchema.isConvertibleToListTextNode()
  */
-export function wrapInList(editor: ListsEditor, listType: ListType): void {
+export function wrapInList(editor: Editor, schema: ListsSchema, listType: ListType): void {
     if (!editor.selection) {
         return;
     }
@@ -20,10 +19,10 @@ export function wrapInList(editor: ListsEditor, listType: ListType): void {
             match: (node) => {
                 return (
                     Element.isElement(node) &&
-                    !editor.isListNode(node) &&
-                    !editor.isListItemNode(node) &&
-                    !editor.isListItemTextNode(node) &&
-                    editor.isConvertibleToListTextNode(node)
+                    !schema.isListNode(node) &&
+                    !schema.isListItemNode(node) &&
+                    !schema.isListItemTextNode(node) &&
+                    schema.isConvertibleToListTextNode(node)
                 );
             },
         }),
@@ -35,9 +34,9 @@ export function wrapInList(editor: ListsEditor, listType: ListType): void {
         const path = ref.current;
         if (path) {
             Editor.withoutNormalizing(editor, () => {
-                Transforms.setNodes(editor, editor.createListItemTextNode(), { at: path });
-                Transforms.wrapNodes(editor, editor.createListItemNode(), { at: path });
-                Transforms.wrapNodes(editor, editor.createListNode(listType), { at: path });
+                Transforms.setNodes(editor, schema.createListItemTextNode(), { at: path });
+                Transforms.wrapNodes(editor, schema.createListItemNode(), { at: path });
+                Transforms.wrapNodes(editor, schema.createListNode(listType), { at: path });
             });
         }
         ref.unref();

--- a/packages/slate-lists/src/types.ts
+++ b/packages/slate-lists/src/types.ts
@@ -1,4 +1,4 @@
-import type { BaseEditor, Element, Node } from 'slate';
+import type { Element, Node } from 'slate';
 
 export enum ListType {
     ORDERED = 'ol',
@@ -24,5 +24,3 @@ export interface ListsSchema {
 
     createListItemTextNode(props?: Partial<Element>): Element;
 }
-
-export interface ListsEditor extends ListsSchema, BaseEditor {}

--- a/packages/slate-lists/src/withLists.test.tsx
+++ b/packages/slate-lists/src/withLists.test.tsx
@@ -14,12 +14,13 @@ import {
     UnorderedList,
     Untyped,
 } from './hyperscript';
+import { normalizeNode } from './normalizeNode';
 
 describe('withLists', () => {
     describe('normalizeListChildren', () => {
         it('should convert paragraph into list-item when it is a child of a list', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -57,7 +58,7 @@ describe('withLists', () => {
 
         it('should wrap list in list-item when it is a child of a list', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -103,7 +104,7 @@ describe('withLists', () => {
     describe('normalizeListItemChildren', () => {
         it('should lift up list-items when they are children of list-item', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -161,7 +162,7 @@ describe('withLists', () => {
 
         it('should ormalize paragraph children of list items', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <Paragraph>
@@ -203,7 +204,7 @@ describe('withLists', () => {
 
         it('should wrap extra list-item-text in list-item and lifts it up when it is a child of list-item', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -249,7 +250,7 @@ describe('withLists', () => {
 
         it('should wrap inline list-item children in list-item-text', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <Link href="https://example.com">
@@ -283,7 +284,7 @@ describe('withLists', () => {
 
         it('should wrap inline list-item children and sibling texts in list-item-text', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <Text>lorem</Text>
@@ -319,7 +320,7 @@ describe('withLists', () => {
 
         it('should add missing type attribute to block list-item children', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <Untyped>
@@ -351,7 +352,7 @@ describe('withLists', () => {
     describe('normalizeListItemTextChildren', () => {
         it('should unwrap block children of list-item-text elements', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -399,7 +400,7 @@ describe('withLists', () => {
     describe('normalizeOrphanListItem', () => {
         it('should convert orphan list-item into paragraph', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <ListItem>
                         <ListItemText>
                             <Text>lorem ipsum</Text>
@@ -433,7 +434,7 @@ describe('withLists', () => {
     describe('normalizeOrphanListItemText', () => {
         it('should convert orphan list-item-text into paragraph', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <ListItemText>
                         <Text>lorem ipsum</Text>
                     </ListItemText>
@@ -463,7 +464,7 @@ describe('withLists', () => {
     describe('normalizeOrphanNestedList', () => {
         it('should move the nested list when it does not have sibling list-item-text', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <UnorderedList>
@@ -497,7 +498,7 @@ describe('withLists', () => {
 
         it("should move items from nested list to previous list-item's nested list when it does not have sibling list-item-text", () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -565,7 +566,7 @@ describe('withLists', () => {
 
         it('should move nested list to previous list item when it does not have sibling list-item-text', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -613,7 +614,7 @@ describe('withLists', () => {
     describe('normalizeSiblingLists', () => {
         it('should merge sibling lists of same type', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <Paragraph>
                         <Text>lorem</Text>
                     </Paragraph>
@@ -661,7 +662,7 @@ describe('withLists', () => {
 
         it('should merge sibling lists of different types when they are nested lists', () => {
             const editor = (
-                <Editor>
+                <Editor normalizeNode={normalizeNode}>
                     <UnorderedList>
                         <ListItem>
                             <ListItemText>
@@ -721,7 +722,7 @@ describe('withLists', () => {
      */
     it('should correctly handle list-items with zero children', () => {
         const editor = (
-            <Editor>
+            <Editor normalizeNode={normalizeNode}>
                 <UnorderedList>
                     {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                     {/* @ts-ignore */}

--- a/packages/slate-lists/src/withLists.test.tsx
+++ b/packages/slate-lists/src/withLists.test.tsx
@@ -3,18 +3,17 @@
 import { Editor as Slate } from 'slate';
 
 import {
-    hyperscript,
     Editor,
-    OrderedList,
-    UnorderedList,
+    hyperscript,
+    Link,
     ListItem,
     ListItemText,
-    Text,
+    OrderedList,
     Paragraph,
-    Link,
+    Text,
+    UnorderedList,
     Untyped,
 } from './hyperscript';
-import type { ListsEditor } from './types';
 
 describe('withLists', () => {
     describe('normalizeListChildren', () => {
@@ -32,7 +31,7 @@ describe('withLists', () => {
                         </Paragraph>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -49,7 +48,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -74,7 +73,7 @@ describe('withLists', () => {
                         </UnorderedList>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -93,7 +92,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -126,7 +125,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -153,7 +152,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -178,7 +177,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -195,7 +194,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -219,7 +218,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -241,7 +240,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -259,7 +258,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -275,7 +274,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -295,7 +294,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -311,7 +310,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -329,7 +328,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -341,7 +340,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -372,7 +371,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -389,7 +388,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -412,7 +411,7 @@ describe('withLists', () => {
                         </ListItemText>
                     </ListItem>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -423,7 +422,7 @@ describe('withLists', () => {
                         <Text>dolor sit</Text>
                     </Paragraph>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -442,7 +441,7 @@ describe('withLists', () => {
                         <Text>dolor sit</Text>
                     </ListItemText>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -453,7 +452,7 @@ describe('withLists', () => {
                         <Text>dolor sit</Text>
                     </Paragraph>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -477,7 +476,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -489,7 +488,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -528,7 +527,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -557,7 +556,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -584,7 +583,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -603,7 +602,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -633,7 +632,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -653,7 +652,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -685,7 +684,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             const expected = (
                 <Editor>
@@ -709,7 +708,7 @@ describe('withLists', () => {
                         </ListItem>
                     </UnorderedList>
                 </Editor>
-            ) as unknown as ListsEditor;
+            ) as unknown as Slate;
 
             Slate.normalize(editor, { force: true });
 
@@ -732,7 +731,7 @@ describe('withLists', () => {
                     <ListItem></ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         const expected = (
             <Editor>
@@ -749,7 +748,7 @@ describe('withLists', () => {
                     </ListItem>
                 </UnorderedList>
             </Editor>
-        ) as unknown as ListsEditor;
+        ) as unknown as Slate;
 
         Slate.normalize(editor, { force: true });
 

--- a/packages/slate-lists/src/withLists.ts
+++ b/packages/slate-lists/src/withLists.ts
@@ -1,36 +1,15 @@
 import type { Editor } from 'slate';
 
-import { normalizeNode } from './normalizeNode';
-import type { ListsEditor, ListsSchema } from './types';
-
-interface Options {
-    normalizations?: boolean;
-}
+import * as Registry from './registry';
+import type { ListsSchema } from './types';
 
 /**
  * Enables normalizations that enforce schema constraints and recover from unsupported cases.
  */
-export function withLists(schema: ListsSchema, { normalizations = true }: Options = {}) {
-    return function <T extends Editor>(editor: T): T & ListsEditor {
-        const listsEditor: T & ListsEditor = Object.assign(editor, {
-            isConvertibleToListTextNode: schema.isConvertibleToListTextNode,
-            isDefaultTextNode: schema.isDefaultTextNode,
-            isListNode: schema.isListNode,
-            isListItemNode: schema.isListItemNode,
-            isListItemTextNode: schema.isListItemTextNode,
-            createDefaultTextNode: schema.createDefaultTextNode,
-            createListNode: schema.createListNode,
-            createListItemNode: schema.createListItemNode,
-            createListItemTextNode: schema.createListItemTextNode,
-        });
+export function withLists(schema: ListsSchema) {
+    return function <T extends Editor>(editor: T): T {
+        Registry.register(editor, schema);
 
-        if (normalizations) {
-            const parent = { normalizeNode: listsEditor.normalizeNode };
-            listsEditor.normalizeNode = (entry) => {
-                normalizeNode(editor, entry) || parent.normalizeNode(entry);
-            };
-        }
-
-        return listsEditor;
+        return editor;
     };
 }

--- a/packages/slate-lists/src/withLists.ts
+++ b/packages/slate-lists/src/withLists.ts
@@ -1,15 +1,12 @@
-import type { Editor } from 'slate';
+import type { ReactEditor } from 'slate-react';
 
-import * as Registry from './registry';
 import type { ListsSchema } from './types';
+import { withListsNormalization } from './withListsNormalization';
+import { withListsReact } from './withListsReact';
+import { withListsSchema } from './withListsSchema';
 
-/**
- * Enables normalizations that enforce schema constraints and recover from unsupported cases.
- */
 export function withLists(schema: ListsSchema) {
-    return function <T extends Editor>(editor: T): T {
-        Registry.register(editor, schema);
-
-        return editor;
+    return <T extends ReactEditor>(editor: T): T => {
+        return withListsReact(withListsNormalization(withListsSchema(schema)(editor)));
     };
 }

--- a/packages/slate-lists/src/withListsNormalization.ts
+++ b/packages/slate-lists/src/withListsNormalization.ts
@@ -1,0 +1,11 @@
+import type { Editor } from 'slate';
+
+import { normalizeNode } from './normalizeNode';
+
+export function withListsNormalization<T extends Editor>(editor: T): T {
+    const parent = { normalizeNode: editor.normalizeNode };
+    editor.normalizeNode = (entry, options) => {
+        return normalizeNode(editor, entry) || parent.normalizeNode(entry, options);
+    };
+    return editor;
+}

--- a/packages/slate-lists/src/withListsSchema.ts
+++ b/packages/slate-lists/src/withListsSchema.ts
@@ -1,0 +1,15 @@
+import type { Editor } from 'slate';
+
+import * as Registry from './registry';
+import type { ListsSchema } from './types';
+
+/**
+ * Enables normalizations that enforce schema constraints and recover from unsupported cases.
+ */
+export function withListsSchema(schema: ListsSchema) {
+    return function <T extends Editor>(editor: T): T {
+        Registry.register(editor, schema);
+
+        return editor;
+    };
+}


### PR DESCRIPTION
# :warning: BC Breaking changes

## Changed

- `withLists()` does now include `withListsReact()` -- no need to call `withListsReact()` separately
- `withLists()` no longer mutates the Editor instance -- thus there is no more `ListsEditor` interface extending Slate `Editor`
- `ListsEditor.*` namespace API hasn't changed, except `isListsEditor()` method is now `isListsSupported()` and is not a type guard anymore
- `ListsEditor` instance methods are now available in the `ListsEditor` namespace:
   - as proxy functions to `ListsSchema` 
     (e.g. `ListsEditor.isListNode(editor, node)`)
   - available via `ListsEditor.getListsSchema(editor).*` 
     (e.g. `Listseditor.getListsSchema(editor)?.isListNode(node)`)

## Added 

- `withListsSchema()` -- bind a `ListsSchema` object to an editor instance
- `withListsNormalization()` -- attach lists normalization to the editor instance (does mutate editor instance)
- `withListsReact()` -- unchanged

All three initializer functions above are now executed as part of the all-in-one `withLists()` initializer. You may, however, decide to only pick parts of it by manually invoking individual initializers from the above list instead of `withLists()`.

# Migration guide

- if you use `withLists()` to initialize the editor, remove any extra calls to `withListsReact()`, as it's already a part of 
- Replace `ListsEditor.isListsEditor()` usages with `ListsEditor.isListsEnabled()` 
- Drop any usages of the `ListsEditor` interface type and replace it with a generic `Editor` type
- Replace any `ListsEditor` _instance_ methods (e.g. `editor.isListNode(node)`) with their proxies in the `ListsEditor` namespace (e.g. `ListsEditor.isListNode(editor, node)`)



