### PR TITLE
[CARE-1853] Upgrade - Slate

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
         "@types/react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.91.4",
-        "slate-history": "^0.86.0",
-        "slate-react": "^0.91.7"
+        "slate": "^0.94.1",
+        "slate-history": "^0.93.0",
+        "slate-react": "^0.97.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.21.5",

--- a/packages/slate-commons/package.json
+++ b/packages/slate-commons/package.json
@@ -43,9 +43,9 @@
     },
     "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.91.4",
-        "slate-history": "^0.86.0",
-        "slate-react": "^0.91.7"
+        "slate": "^0.94.1",
+        "slate-history": "^0.93.0",
+        "slate-react": "^0.97.0"
     },
     "dependencies": {
         "@prezly/slate-types": "workspace:*",

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -91,9 +91,9 @@
     "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.91.4",
-        "slate-history": "^0.86.0",
-        "slate-react": "^0.91.7"
+        "slate": "^0.94.1",
+        "slate-history": "^0.93.0",
+        "slate-react": "^0.97.0"
     },
     "devDependencies": {
         "@babel/core": "^7.18.5",

--- a/packages/slate-editor/src/extensions/loader/components/LoaderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/loader/components/LoaderElement.stories.tsx
@@ -27,7 +27,7 @@ export default {
     title: 'Extensions/Loaders/Loader',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[]}>
+            <Slate editor={editor} initialValue={[]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/components/InputPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/components/InputPlaceholderElement.stories.tsx
@@ -31,7 +31,7 @@ export default {
     title: 'Extensions/Placeholders/components/InputPlaceholderElement',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/components/PlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/components/PlaceholderElement.stories.tsx
@@ -30,7 +30,7 @@ export default {
     title: 'Extensions/Placeholders/components/PlaceholderElement',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680, boxSizing: 'border-box' }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/AttachmentPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/AttachmentPlaceholderElement.stories.tsx
@@ -28,7 +28,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680, boxSizing: 'border-box' }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.stories.tsx
@@ -68,7 +68,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680, height: 400 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/EmbedPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/EmbedPlaceholderElement.stories.tsx
@@ -33,7 +33,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryPlaceholderElement.stories.tsx
@@ -28,7 +28,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/ImagePlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ImagePlaceholderElement.stories.tsx
@@ -28,7 +28,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/MediaPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/MediaPlaceholderElement.stories.tsx
@@ -28,7 +28,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/SocialPostPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/SocialPostPlaceholderElement.stories.tsx
@@ -33,7 +33,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/VideoPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/VideoPlaceholderElement.stories.tsx
@@ -33,7 +33,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/extensions/placeholders/elements/WebBookmarkPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/WebBookmarkPlaceholderElement.stories.tsx
@@ -33,7 +33,7 @@ export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
         (Story: React.ComponentType) => (
-            <Slate editor={editor} value={[placeholder]}>
+            <Slate editor={editor} initialValue={[placeholder]}>
                 <div style={{ width: 680 }}>
                     <Story />
                 </div>

--- a/packages/slate-editor/src/modules/editor/Editor.module.scss
+++ b/packages/slate-editor/src/modules/editor/Editor.module.scss
@@ -11,6 +11,8 @@
         color: $editor-selection-color;
     }
 
+    outline: none !important;
+
     > [data-slate-block] {
         &:first-child {
             margin-top: 0;

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -501,7 +501,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
                         variables.onChange(editor);
                         userMentions.onChange(editor);
                     }}
-                    value={getInitialValue()}
+                    initialValue={getInitialValue()}
                 >
                     <InitialNormalization />
                     <EditableWithExtensions

--- a/packages/slate-lists/package.json
+++ b/packages/slate-lists/package.json
@@ -43,8 +43,8 @@
     },
     "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.91.4",
-        "slate-react": "^0.91.7"
+        "slate": "^0.94.1",
+        "slate-react": "^0.97.0"
     },
     "dependencies": {
         "is-hotkey": "^0.2.0",

--- a/packages/slate-tables/package.json
+++ b/packages/slate-tables/package.json
@@ -43,8 +43,8 @@
     },
     "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "slate": "^0.91.4",
-        "slate-react": "^0.91.7"
+        "slate": "^0.94.1",
+        "slate-react": "^0.97.0"
     },
     "dependencies": {
         "@prezly/slate-commons": "workspace:*",

--- a/packages/slate-types/package.json
+++ b/packages/slate-types/package.json
@@ -41,7 +41,7 @@
         "clean:build": "rimraf build/ *.tsbuildinfo"
     },
     "peerDependencies": {
-        "slate": "^0.91.4"
+        "slate": "^0.94.1"
     },
     "dependencies": {
         "@prezly/sdk": "^13.0.0 || ^14.0.0",


### PR DESCRIPTION
- Bump `slate` dependencies to their latest versions
- [Disable unwanted focus ring around the editable area](https://github.com/prezly/slate/commit/a42b182c875e4fe0e53d40cec68d4b3b65246b65) -- fix a regression caused by the upgrade