### PR TITLE
[CARE-1853] Fix - Pasting into title subtitle

### DIFF
--- a/packages/slate-commons/src/commands/index.ts
+++ b/packages/slate-commons/src/commands/index.ts
@@ -11,6 +11,7 @@ export { getPrevChars } from './getPrevChars';
 export { hasVoidElements } from './hasVoidElements';
 export { insertEmptyParagraph } from './insertEmptyParagraph';
 export { insertNodes } from './insertNodes';
+export { isAtEmptyBlock } from './isAtEmptyBlock';
 export { isBlock } from './isBlock';
 export { isBlockActive } from './isBlockActive';
 export { isCursorInEmptyParagraph } from './isCursorInEmptyParagraph';

--- a/packages/slate-commons/src/commands/insertNodes.test.tsx
+++ b/packages/slate-commons/src/commands/insertNodes.test.tsx
@@ -7,7 +7,7 @@ import { hyperscript } from '../hyperscript';
 import { insertNodes } from './insertNodes';
 
 describe('insertNodes', () => {
-    it('Does nothing when there is no selection', () => {
+    it('should do nothing when there is no selection', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -30,7 +30,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Does nothing when there are no nodes to insert', () => {
+    it('should do nothing when there are no nodes to insert', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -59,7 +59,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts a new block element', () => {
+    it('should insert a new block element', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -98,7 +98,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts a new block element with extra paragraph after', () => {
+    it('should insert a new block element with extra paragraph after', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -140,7 +140,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts a new block element with extra paragraph after unless there already is one', () => {
+    it('should insert a new block element with extra paragraph after unless there already is one', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -185,7 +185,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts inline nodes into the current block until encountering a block node', () => {
+    it('should insert inline nodes into the current block until encountering a block node', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -233,7 +233,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts a new block element and removes an empty paragraph', () => {
+    it('should insert a new block element and removes an empty paragraph', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -268,7 +268,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts inline nodes into the current empty paragraph until encountering a block node', () => {
+    it('should insert inline nodes into the current empty paragraph until encountering a block node', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -316,7 +316,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts inline nodes into a new paragraph if void node is focused', () => {
+    it('should insert inline nodes into a new paragraph if void node is focused', () => {
         const editor = (
             <editor>
                 <h:divider>
@@ -360,7 +360,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts text nodes into a new paragraph after void node', () => {
+    it('should insert text nodes into a new paragraph after void node', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -398,7 +398,7 @@ describe('insertNodes', () => {
         expect(editor.selection).toEqual(expected.selection);
     });
 
-    it('Inserts text nodes after inline void node', () => {
+    it('should insert text nodes after inline void node', () => {
         const editor = (
             <editor>
                 <h:paragraph>
@@ -438,6 +438,41 @@ describe('insertNodes', () => {
                     <h:text></h:text>
                 </h:mention>,
                 <h:text bold>{' dolor'}</h:text>,
+            ]),
+        );
+
+        expect(editor.children).toEqual(expected.children);
+        expect(editor.selection).toEqual(expected.selection);
+    });
+
+    it('should replace target block if it is empty', () => {
+        const editor = (
+            <editor>
+                <h:blockquote>
+                    <h:text>
+                        <cursor />
+                    </h:text>
+                </h:blockquote>
+            </editor>
+        ) as unknown as Editor;
+
+        const expected = (
+            <editor>
+                <h:heading-1>
+                    <h:text>
+                        Hello world
+                        <cursor />
+                    </h:text>
+                </h:heading-1>
+            </editor>
+        ) as unknown as Editor;
+
+        insertNodes(
+            editor,
+            nodes([
+                <h:heading-1>
+                    <h:text>Hello world</h:text>
+                </h:heading-1>,
             ]),
         );
 

--- a/packages/slate-commons/src/commands/isAtEmptyBlock.ts
+++ b/packages/slate-commons/src/commands/isAtEmptyBlock.ts
@@ -1,0 +1,35 @@
+import { Editor, Element } from 'slate';
+import { Range } from 'slate';
+
+import { isNodeEmpty } from './isNodeEmpty';
+
+interface Options {
+    trim?: boolean;
+}
+
+/**
+ * Check if the selection is pointing to an empty non-void block element.
+ */
+export function isAtEmptyBlock(
+    editor: Editor,
+    at: Range | null = editor.selection,
+    options?: Options,
+): boolean {
+    if (!at) {
+        return false;
+    }
+
+    if (Range.isExpanded(at)) {
+        return false;
+    }
+
+    const entry = Editor.node(editor, at, { depth: 1 });
+    if (!entry) {
+        return false;
+    }
+
+    const [node] = entry;
+    return (
+        Element.isElement(node) && editor.isBlock(node) && isNodeEmpty(editor, node, options?.trim)
+    );
+}

--- a/packages/slate-commons/src/hyperscript.ts
+++ b/packages/slate-commons/src/hyperscript.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import {
-    LINK_NODE_TYPE,
-    PARAGRAPH_NODE_TYPE,
     DIVIDER_NODE_TYPE,
     HEADING_1_NODE_TYPE,
     HEADING_2_NODE_TYPE,
+    LINK_NODE_TYPE,
     MENTION_NODE_TYPE,
+    PARAGRAPH_NODE_TYPE,
+    QUOTE_NODE_TYPE,
 } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 import type { Editor } from 'slate';
@@ -95,6 +96,9 @@ declare global {
             'h:paragraph': {
                 children?: ReactNode;
             };
+            'h:blockquote': {
+                children?: ReactNode;
+            };
             // it could have been any other block element
             'h:heading-1': {
                 children?: ReactNode;
@@ -118,6 +122,7 @@ export const hyperscript = createHyperscript({
         'h:paragraph': { type: PARAGRAPH_NODE_TYPE },
         'h:heading-1': { type: HEADING_1_NODE_TYPE },
         'h:heading-2': { type: HEADING_2_NODE_TYPE },
+        'h:blockquote': { type: QUOTE_NODE_TYPE },
     },
     creators: {
         'h:text': createText,

--- a/packages/slate-editor/src/modules/editor/Editor.test.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.test.tsx
@@ -15,646 +15,692 @@ function readTestFile(filepath: string): string {
     return fs.readFileSync(path.resolve(__dirname, '__tests__', filepath), 'utf-8');
 }
 
-describe('Editor - deleteForward - selection maintenance', () => {
-    it('should focus the list after the paragraph when using deleteForward (Del key) ', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-                <h-ul>
-                    <h-li>
-                        <h-li-text>
-                            <h-text>lorem ipsum</h-text>
-                        </h-li-text>
-                    </h-li>
-                </h-ul>
-            </editor>,
-        );
+describe('Editor', () => {
+    describe('deleteForward()', () => {
+        it('should focus the list after the paragraph when using deleteForward (Del key) ', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                    <h-ul>
+                        <h-li>
+                            <h-li-text>
+                                <h-text>lorem ipsum</h-text>
+                            </h-li-text>
+                        </h-li>
+                    </h-ul>
+                </editor>,
+            );
 
-        const expected = (
-            <editor>
-                <h-ul>
-                    <h-li>
-                        <h-li-text>
-                            <h-text>
-                                <cursor />
-                                lorem ipsum
-                            </h-text>
-                        </h-li-text>
-                    </h-li>
-                </h-ul>
-            </editor>
-        ) as unknown as Editor;
+            const expected = (
+                <editor>
+                    <h-ul>
+                        <h-li>
+                            <h-li-text>
+                                <h-text>
+                                    <cursor />
+                                    lorem ipsum
+                                </h-text>
+                            </h-li-text>
+                        </h-li>
+                    </h-ul>
+                </editor>
+            ) as unknown as Editor;
 
-        editor.deleteForward('character'); // equivalent to pressing delete (fn+backspace on macs)
+            editor.deleteForward('character'); // equivalent to pressing delete (fn+backspace on macs)
 
-        expect(() => {
-            // In other extensions we modify the behavior of `deleteForward`, which in the past
-            // caused the editor to be left with an invalid selection (pointing to non-leaf nodes).
-            // Calling `Editor.marks` afterwards would throw an error:
-            // "Cannot get the leaf node at path [${path}] because it refers to a non-leaf node: ${node}"
-            // see: https://app.clubhouse.io/prezly/story/19544/editor-crashes-when-pressing-del-in-an-empty-paragraph-before-a-list
-            Editor.marks(editor);
-        }).not.toThrow();
+            expect(() => {
+                // In other extensions we modify the behavior of `deleteForward`, which in the past
+                // caused the editor to be left with an invalid selection (pointing to non-leaf nodes).
+                // Calling `Editor.marks` afterwards would throw an error:
+                // "Cannot get the leaf node at path [${path}] because it refers to a non-leaf node: ${node}"
+                // see: https://app.clubhouse.io/prezly/story/19544/editor-crashes-when-pressing-del-in-an-empty-paragraph-before-a-list
+                Editor.marks(editor);
+            }).not.toThrow();
 
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
-});
-
-describe('Editor - inserting block nodes after lists', () => {
-    it('Insterts block node after a list node (and not within the list)', () => {
-        const editor = createEditor(
-            <editor>
-                <h-ul>
-                    <h-li>
-                        <h-li-text>
-                            <h-text>lorem ipsum</h-text>
-                        </h-li-text>
-                    </h-li>
-                </h-ul>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = (
-            <editor>
-                <h-ul>
-                    <h-li>
-                        <h-li-text>
-                            <h-text>lorem ipsum</h-text>
-                        </h-li-text>
-                    </h-li>
-                </h-ul>
-                <h-divider>
-                    <h-text />
-                </h-divider>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
-
-        insertDivider(editor);
-
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
-});
-
-describe('Editor - pasting', () => {
-    it('Deserializes Google Docs reference document', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/google-docs-reference-document.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/google-docs-reference-document.html'),
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
         });
-
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
     });
 
-    it('Deserializes Microsoft Word reference document', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
+    describe('Insertion', () => {
+        it('should insert block node after a list node (and not within the list)', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-ul>
+                        <h-li>
+                            <h-li-text>
+                                <h-text>lorem ipsum</h-text>
+                            </h-li-text>
+                        </h-li>
+                    </h-ul>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-        const expected = readTestFile('expected/docx-reference-document.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/docx-reference-document.html'),
-            'text/rtf': readTestFile('input/docx-reference-document.rtf'),
+            const expected = (
+                <editor>
+                    <h-ul>
+                        <h-li>
+                            <h-li-text>
+                                <h-text>lorem ipsum</h-text>
+                            </h-li-text>
+                        </h-li>
+                    </h-ul>
+                    <h-divider>
+                        <h-text />
+                    </h-divider>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
+
+            insertDivider(editor);
+
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
         });
-
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
     });
 
-    it('Does not merge sibling divs into p', function () {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
+    describe('Pasting', () => {
+        it('should deserialize Google Docs reference document', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/divs.html'),
-        });
+            const expected = readTestFile('expected/google-docs-reference-document.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/google-docs-reference-document.html'),
+            });
 
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toMatchSnapshot();
-    });
-
-    it('Deserializes paragraph nested in quote', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/paragraph-in-quote.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/paragraph-in-quote.html'),
-        });
-
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toEqual(JSON.parse(expected));
-    });
-
-    it('Deserializes image nested in paragraph', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/image-in-paragraph.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/image-in-paragraph.html'),
-        });
-
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
-
-    it('Deserializes image nested in h1', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/image-in-h1.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/image-in-h1.html'),
-        });
-
-        editor.insertData(dataTransfer);
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
-
-    it('Deserializes list without throwing an error (normalizations count limit)', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/list-normalization-1.html'),
-        });
-
-        expect(() => {
             editor.insertData(dataTransfer);
-        }).not.toThrow();
-    });
 
-    it('Deserializes custom Slack line-breaks', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/slack-line-breaks.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/slack-line-breaks.html'),
+            expect(editor.children).toMatchObject(JSON.parse(expected));
         });
 
-        editor.insertData(dataTransfer);
+        it('should deserialize Microsoft Word reference document', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
+            const expected = readTestFile('expected/docx-reference-document.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/docx-reference-document.html'),
+                'text/rtf': readTestFile('input/docx-reference-document.rtf'),
+            });
 
-    it('Inserts nodes with list nested in a paragraph', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
+            editor.insertData(dataTransfer);
 
-        const input = readTestFile('input/list-normalization-2.json');
-        const expected = readTestFile('expected/list-normalization-2.json');
-
-        EditorCommands.insertNodes(editor, JSON.parse(input));
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
-
-    /**
-     * @see CARE-1320
-     */
-    it('should handle pasting nodes with empty children array', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const input = readTestFile('input/list-normalization-3.json');
-        const expected = readTestFile('expected/list-normalization-3.json');
-
-        EditorCommands.insertNodes(editor, JSON.parse(input), { mode: 'highest' });
-
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
-
-    /**
-     * @see CARE-1320
-     */
-    it('should handle nodes with empty children array', () => {
-        const editor = createEditor(
-            <editor>
-                <h-ol>
-                    <h-li></h-li>
-                </h-ol>
-            </editor>,
-        );
-
-        Editor.normalize(editor, { force: true });
-
-        expect(editor.children).toMatchObject([
-            {
-                type: 'numbered-list',
-                children: [
-                    {
-                        type: 'list-item',
-                        children: [
-                            {
-                                type: 'list-item-text',
-                                children: [{ text: '' }],
-                            },
-                        ],
-                    },
-                ],
-            },
-        ]);
-    });
-
-    it('Deserializes marks from style attributes', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
-
-        const expected = readTestFile('expected/marks-in-style.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/marks-in-style.html'),
+            expect(editor.children).toMatchObject(JSON.parse(expected));
         });
 
-        editor.insertData(dataTransfer);
+        it('should not merge sibling divs into p', function () {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-        expect(editor.children).toMatchObject(JSON.parse(expected));
-    });
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/divs.html'),
+            });
 
-    it('Deserializes plaintext copied from PDF', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
+            editor.insertData(dataTransfer);
 
-        const expected = readTestFile('expected/pdf-plaintext.json');
-        const dataTransfer = createDataTransfer({
-            'text/html': readTestFile('input/pdf-plaintext.html'),
-            'text/plain': readTestFile('input/pdf-plaintext.txt'),
+            expect(editor.children).toMatchSnapshot();
         });
 
-        editor.insertData(dataTransfer);
+        it('should deserialize paragraph nested in quote', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-        expect(editor.children).toMatchObject(JSON.parse(expected));
+            const expected = readTestFile('expected/paragraph-in-quote.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/paragraph-in-quote.html'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toEqual(JSON.parse(expected));
+        });
+
+        it('should deserialize image nested in paragraph', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = readTestFile('expected/image-in-paragraph.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/image-in-paragraph.html'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        it('should deserialize image nested in h1', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = readTestFile('expected/image-in-h1.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/image-in-h1.html'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        it('should deserialize list without throwing an error (normalizations count limit)', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/list-normalization-1.html'),
+            });
+
+            expect(() => {
+                editor.insertData(dataTransfer);
+            }).not.toThrow();
+        });
+
+        it('should deserialize custom Slack line-breaks', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = readTestFile('expected/slack-line-breaks.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/slack-line-breaks.html'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        it('should insert nodes with list nested in a paragraph', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const input = readTestFile('input/list-normalization-2.json');
+            const expected = readTestFile('expected/list-normalization-2.json');
+
+            EditorCommands.insertNodes(editor, JSON.parse(input));
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        /**
+         * @see CARE-1320
+         */
+        it('should handle pasting nodes with empty children array', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const input = readTestFile('input/list-normalization-3.json');
+            const expected = readTestFile('expected/list-normalization-3.json');
+
+            EditorCommands.insertNodes(editor, JSON.parse(input), { mode: 'highest' });
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        /**
+         * @see CARE-1320
+         */
+        it('should handle nodes with empty children array', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-ol>
+                        <h-li></h-li>
+                    </h-ol>
+                </editor>,
+            );
+
+            Editor.normalize(editor, { force: true });
+
+            expect(editor.children).toMatchObject([
+                {
+                    type: 'numbered-list',
+                    children: [
+                        {
+                            type: 'list-item',
+                            children: [
+                                {
+                                    type: 'list-item-text',
+                                    children: [{ text: '' }],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+        });
+
+        it('should deserialize marks from style attributes', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = readTestFile('expected/marks-in-style.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/marks-in-style.html'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        it('should deserialize plaintext copied from PDF', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = readTestFile('expected/pdf-plaintext.json');
+            const dataTransfer = createDataTransfer({
+                'text/html': readTestFile('input/pdf-plaintext.html'),
+                'text/plain': readTestFile('input/pdf-plaintext.txt'),
+            });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        it('should preserve target block formatting when pasting a single text block', () => {
+            const HTML = '<h1>Hello world</h1>';
+
+            const editor = createEditor(
+                <editor>
+                    <h:blockquote>
+                        <h:text>
+                            <cursor />
+                        </h:text>
+                    </h:blockquote>
+                </editor>,
+            );
+
+            const dataTransfer = createDataTransfer({ 'text/html': HTML });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchSnapshot();
+        });
+
+        it('should preserve source blocks formatting when pasting multiple text blocks', () => {
+            const HTML = `
+                 <h1>Hello world</h1>
+                 <h2>This is it, a subtitle.</h2>
+                 <p>How do you like it?</p>
+            `;
+
+            const editor = createEditor(
+                <editor>
+                    <h:blockquote>
+                        <h:text>
+                            <cursor />
+                        </h:text>
+                    </h:blockquote>
+                </editor>,
+            );
+
+            const dataTransfer = createDataTransfer({ 'text/html': HTML });
+
+            editor.insertData(dataTransfer);
+
+            expect(editor.children).toMatchSnapshot();
+        });
     });
-});
 
-describe('Editor - withRootElements', () => {
-    it('Lifts up nested paragraphs', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
+    describe('withRootElements', () => {
+        it('should lift up nested paragraphs', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                        <h-p>
+                            <h-text>nested paragraph - text before</h-text>
+                            <h-p>
+                                <h-text>deeply nested paragraph</h-text>
+                            </h-p>
+                            <h-text>nested paragraph - text after</h-text>
+                        </h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
                     <h-p>
                         <h-text>nested paragraph - text before</h-text>
-                        <h-p>
-                            <h-text>deeply nested paragraph</h-text>
-                        </h-p>
+                    </h-p>
+                    <h-p>
+                        <h-text>deeply nested paragraph</h-text>
+                    </h-p>
+                    <h-p>
                         <h-text>nested paragraph - text after</h-text>
                     </h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>,
-        );
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>nested paragraph - text before</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>deeply nested paragraph</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>nested paragraph - text after</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            Editor.normalize(editor, { force: true });
 
-        Editor.normalize(editor, { force: true });
-
-        expect(editor.children).toEqual(expected.children);
+            expect(editor.children).toEqual(expected.children);
+        });
     });
-});
+    //
+    describe('Voids', () => {
+        it('should properly remove text from trailing paragraph', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-divider>
+                        <h-text>
+                            <anchor />
+                        </h-text>
+                    </h-divider>
+                    <h-p>
+                        <h-text>
+                            text <focus />
+                            after
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
 
-describe('Editor - voids behaviour', () => {
-    it('Properly removes text from trailing paragraph', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-divider>
-                    <h-text>
-                        <anchor />
-                    </h-text>
-                </h-divider>
-                <h-p>
-                    <h-text>
-                        text <focus />
-                        after
-                    </h-text>
-                </h-p>
-            </editor>,
-        );
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                            after
+                        </h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                        after
-                    </h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            editor.deleteFragment();
 
-        editor.deleteFragment();
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
+        });
 
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
+        it('should properly remove text from leading paragraph', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            text <anchor />
+                            before
+                        </h-text>
+                    </h-p>
+                    <h-divider>
+                        <h-text>
+                            <focus />
+                        </h-text>
+                    </h-divider>
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>,
+            );
 
-    it('Properly removes text from leading paragraph', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>
-                        text <anchor />
-                        before
-                    </h-text>
-                </h-p>
-                <h-divider>
-                    <h-text>
-                        <focus />
-                    </h-text>
-                </h-divider>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>,
-        );
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>
+                            text <cursor />
+                        </h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>
-                        text <cursor />
-                    </h-text>
-                </h-p>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            editor.deleteFragment();
 
-        editor.deleteFragment();
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
+        });
 
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
+        it('should properly remove 2 consecutive void blocks after a paragraph', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-divider>
+                        <h-text>
+                            <anchor />
+                        </h-text>
+                    </h-divider>
+                    <h-divider>
+                        <h-text>
+                            <focus />
+                        </h-text>
+                    </h-divider>
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>,
+            );
 
-    it('Properly removes 2 consecutive void blocks after a paragraph', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-divider>
-                    <h-text>
-                        <anchor />
-                    </h-text>
-                </h-divider>
-                <h-divider>
-                    <h-text>
-                        <focus />
-                    </h-text>
-                </h-divider>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>,
-        );
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                            text after
+                        </h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                        text after
-                    </h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            editor.deleteFragment();
 
-        editor.deleteFragment();
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
+        });
 
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
+        it('should properly remove 2 consecutive void blocks after 2 paragraphs', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>text before 1</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>text before 2</h-text>
+                    </h-p>
+                    <h-divider>
+                        <h-text>
+                            <anchor />
+                        </h-text>
+                    </h-divider>
+                    <h-divider>
+                        <h-text>
+                            <focus />
+                        </h-text>
+                    </h-divider>
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>,
+            );
 
-    it('Properly removes 2 consecutive void blocks after 2 paragraphs', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>text before 1</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>text before 2</h-text>
-                </h-p>
-                <h-divider>
-                    <h-text>
-                        <anchor />
-                    </h-text>
-                </h-divider>
-                <h-divider>
-                    <h-text>
-                        <focus />
-                    </h-text>
-                </h-divider>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>,
-        );
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>text before 1</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>text before 2</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                            text after
+                        </h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>text before 1</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>text before 2</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                        text after
-                    </h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            editor.deleteFragment();
 
-        editor.deleteFragment();
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
+        });
 
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
-    });
+        it('should properly remove 4 consecutive void blocks', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-divider>
+                        <h-text>
+                            <anchor />
+                        </h-text>
+                    </h-divider>
+                    <h-divider>
+                        <h-text />
+                    </h-divider>
+                    <h-divider>
+                        <h-text />
+                    </h-divider>
+                    <h-divider>
+                        <h-text>
+                            <focus />
+                        </h-text>
+                    </h-divider>
+                    <h-p>
+                        <h-text>text after</h-text>
+                    </h-p>
+                </editor>,
+            );
 
-    it('Properly removes 4 consecutive void blocks', () => {
-        const editor = createEditor(
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-divider>
-                    <h-text>
-                        <anchor />
-                    </h-text>
-                </h-divider>
-                <h-divider>
-                    <h-text />
-                </h-divider>
-                <h-divider>
-                    <h-text />
-                </h-divider>
-                <h-divider>
-                    <h-text>
-                        <focus />
-                    </h-text>
-                </h-divider>
-                <h-p>
-                    <h-text>text after</h-text>
-                </h-p>
-            </editor>,
-        );
+            const expected = (
+                <editor>
+                    <h-p>
+                        <h-text>text before</h-text>
+                    </h-p>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                            text after
+                        </h-text>
+                    </h-p>
+                </editor>
+            ) as unknown as Editor;
 
-        const expected = (
-            <editor>
-                <h-p>
-                    <h-text>text before</h-text>
-                </h-p>
-                <h-p>
-                    <h-text>
-                        <cursor />
-                        text after
-                    </h-text>
-                </h-p>
-            </editor>
-        ) as unknown as Editor;
+            editor.deleteFragment();
 
-        editor.deleteFragment();
-
-        expect(editor.children).toEqual(expected.children);
-        expect(editor.selection).toEqual(expected.selection);
+            expect(editor.children).toEqual(expected.children);
+            expect(editor.selection).toEqual(expected.selection);
+        });
     });
 });

--- a/packages/slate-editor/src/modules/editor/__snapshots__/Editor.test.tsx.snap
+++ b/packages/slate-editor/src/modules/editor/__snapshots__/Editor.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Editor - pasting Does not merge sibling divs into p 1`] = `
+exports[`Editor Pasting should not merge sibling divs into p 1`] = `
 [
   {
     "children": [
@@ -379,6 +379,56 @@ exports[`Editor - pasting Does not merge sibling divs into p 1`] = `
       },
     ],
     "type": "paragraph",
+  },
+]
+`;
+
+exports[`Editor Pasting should preserve source blocks formatting when pasting multiple text blocks 1`] = `
+[
+  {
+    "children": [
+      {
+        "text": "Hello world",
+      },
+    ],
+    "type": "heading-one",
+  },
+  {
+    "children": [
+      {
+        "text": "This is it, a subtitle.",
+      },
+    ],
+    "type": "heading-two",
+  },
+  {
+    "children": [
+      {
+        "text": "How do you like it?",
+      },
+    ],
+    "type": "paragraph",
+  },
+  {
+    "children": [
+      {
+        "text": "",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`Editor Pasting should preserve target block formatting when pasting a single text block 1`] = `
+[
+  {
+    "children": [
+      {
+        "text": "Hello world",
+      },
+    ],
+    "type": "block-quote",
   },
 ]
 `;

--- a/packages/slate-editor/src/modules/editor/__tests__/expected/image-in-h1.json
+++ b/packages/slate-editor/src/modules/editor/__tests__/expected/image-in-h1.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "heading-one",
+        "type": "paragraph",
         "children": [
             {
                 "text": "lorem "
@@ -16,7 +16,7 @@
         "type": "loader"
     },
     {
-        "type": "heading-one",
+        "type": "paragraph",
         "children": [
             {
                 "text": " ipsum"

--- a/packages/slate-editor/src/modules/editor/__tests__/expected/marks-in-style.json
+++ b/packages/slate-editor/src/modules/editor/__tests__/expected/marks-in-style.json
@@ -25,13 +25,5 @@
                 "superscript": true
             }
         ]
-    },
-    {
-        "type": "paragraph",
-        "children": [
-            {
-                "text": ""
-            }
-        ]
     }
 ]

--- a/packages/slate-editor/src/modules/editor/hyperscript.ts
+++ b/packages/slate-editor/src/modules/editor/hyperscript.ts
@@ -7,6 +7,7 @@ import {
     LIST_ITEM_TEXT_NODE_TYPE,
     NUMBERED_LIST_NODE_TYPE,
     PARAGRAPH_NODE_TYPE,
+    QUOTE_NODE_TYPE,
 } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
 import { createHyperscript, createText } from 'slate-hyperscript';
@@ -32,6 +33,12 @@ declare global {
             'h-ul': {
                 children?: ReactNode;
             };
+            'h:blockquote': {
+                children?: ReactNode;
+            };
+            'h:text': {
+                children?: ReactNode;
+            };
         }
     }
 }
@@ -44,8 +51,10 @@ export const hyperscript = createHyperscript({
         'h-ul': { type: BULLETED_LIST_NODE_TYPE },
         'h-li': { type: LIST_ITEM_NODE_TYPE },
         'h-li-text': { type: LIST_ITEM_TEXT_NODE_TYPE },
+        'h:blockquote': { type: QUOTE_NODE_TYPE },
     },
     creators: {
         'h-text': createText,
+        'h:text': createText,
     },
 });

--- a/packages/slate-editor/src/modules/editor/plugins/withDeserializeHtml/withDeserializeHtml.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withDeserializeHtml/withDeserializeHtml.ts
@@ -4,6 +4,7 @@ import { cleanDocx } from '@prezly/docx-cleaner';
 import type { Extension } from '@prezly/slate-commons';
 import { EditorCommands } from '@prezly/slate-commons';
 import type { Editor } from 'slate';
+import { Element } from 'slate';
 
 import { createDataTransfer } from '#lib';
 
@@ -61,7 +62,18 @@ export function withDeserializeHtml(
 
                 // If there are no "nodes" then there is no interesting "text/html" in clipboard.
                 // Pass through to default "insertData" so that "text/plain" is used if available.
-                if (nodes.length > 0) {
+                if (
+                    nodes.length === 1 &&
+                    Element.isElement(nodes[0]) &&
+                    editor.isBlock(nodes[0]) &&
+                    !editor.isRichBlock(nodes[0])
+                ) {
+                    EditorCommands.insertNodes(editor, nodes[0].children, {
+                        ensureEmptyParagraphAfter: true,
+                        mode: 'highest',
+                    });
+                    return;
+                } else if (nodes.length > 0) {
                     EditorCommands.insertNodes(editor, nodes, {
                         ensureEmptyParagraphAfter: true,
                         mode: 'highest',

--- a/packages/slate-editor/src/modules/editor/plugins/withDeserializeHtml/withDeserializeHtml.ts
+++ b/packages/slate-editor/src/modules/editor/plugins/withDeserializeHtml/withDeserializeHtml.ts
@@ -3,7 +3,7 @@
 import { cleanDocx } from '@prezly/docx-cleaner';
 import type { Extension } from '@prezly/slate-commons';
 import { EditorCommands } from '@prezly/slate-commons';
-import type { Editor } from 'slate';
+import type { Editor, Node } from 'slate';
 import { Element } from 'slate';
 
 import { createDataTransfer } from '#lib';
@@ -60,26 +60,30 @@ export function withDeserializeHtml(
                 const extensions = getExtensions();
                 const nodes = deserializeHtml(extensions, cleanHtml, handleError);
 
-                // If there are no "nodes" then there is no interesting "text/html" in clipboard.
-                // Pass through to default "insertData" so that "text/plain" is used if available.
-                if (
-                    nodes.length === 1 &&
-                    Element.isElement(nodes[0]) &&
-                    editor.isBlock(nodes[0]) &&
-                    !editor.isRichBlock(nodes[0])
-                ) {
-                    EditorCommands.insertNodes(editor, nodes[0].children, {
-                        ensureEmptyParagraphAfter: true,
-                        mode: 'highest',
-                    });
-                    return;
-                } else if (nodes.length > 0) {
-                    EditorCommands.insertNodes(editor, nodes, {
+                if (nodes.length === 0) {
+                    // If there are no "nodes" then there is no interesting "text/html" in clipboard.
+                    // Pass through to default "insertData" so that "text/plain" is used if available.
+                    return insertData(data);
+                }
+
+                const singleTextBlockInserted = checkSingleTextBlockInserted(editor, nodes);
+
+                if (singleTextBlockInserted) {
+                    // If it's a single block inserted, inherit block formatting from the destination
+                    // location, instead of overwriting it with the pasted block style.
+                    // @see CARE-1853
+                    EditorCommands.insertNodes(editor, singleTextBlockInserted.children, {
                         ensureEmptyParagraphAfter: true,
                         mode: 'highest',
                     });
                     return;
                 }
+
+                EditorCommands.insertNodes(editor, nodes, {
+                    ensureEmptyParagraphAfter: true,
+                    mode: 'highest',
+                });
+                return;
             }
 
             insertData(data);
@@ -87,4 +91,18 @@ export function withDeserializeHtml(
 
         return editor;
     };
+}
+
+function checkSingleTextBlockInserted(editor: Editor, nodes: Node[]): Element | undefined {
+    const [node] = nodes;
+
+    if (
+        nodes.length === 1 &&
+        Element.isElement(node) &&
+        editor.isBlock(node) &&
+        !editor.isRichBlock(node)
+    ) {
+        return node;
+    }
+    return undefined;
 }


### PR DESCRIPTION
- [Tweak HTML-pasting behaviour](https://github.com/prezly/slate/commit/2c5cafbabb082a42d6462357480f1a70237c2e4b)

  To only inherit copied elements block formatting when there are 2+ elements, otherwise we only paste inner contents, preserving the target element block formatting. For example:

  - When pasted h1 into a blockquote -- the blockquote will have the h1 contents, but will remain a blockquote.
  - When pasted h1 + h2 + paragraph -- the pasted content will replace the blockquote and force the pasted elements block formatting (h1 + h2 + paragraph)

  This seems to be better matching what's expected intuitively.

- [Tweak](https://github.com/prezly/slate/commit/a62f77329ecaa56eb38bb77c5e949d449c5336a5) [insertNodes](https://github.com/prezly/slate/commit/a62f77329ecaa56eb38bb77c5e949d449c5336a5) [to remove any empty block upon pasting](https://github.com/prezly/slate/commit/a62f77329ecaa56eb38bb77c5e949d449c5336a5)

  Previously, it was only replacing (i.e. removing after insertion) the target element if it was an empty *paragraph*. Now it does so for any empty block element: heading, paragraph, blockquote, etc.