### PR TITLE
Refactor - Remove `canvas` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
         "babel-plugin-module-resolver": "^5.0.0",
         "babel-plugin-transform-remove-imports": "^1.7.0",
         "branch-pipe": "^1.0.1",
-        "canvas": "^2.11.2",
         "concurrently": "^6.4.0",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
It is not used anywhere, and `pnpm clean` followed by `pnpm install` works as expected without it, so it shouldn't be a peer dependency of another package AFAIK.