### PR TITLE
[CARE-1965] Fix - Infinite list structure normalization loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "babel-plugin-module-resolver": "^5.0.0",
         "babel-plugin-transform-remove-imports": "^1.7.0",
         "branch-pipe": "^1.0.1",
+        "canvas": "^2.11.2",
         "concurrently": "^6.4.0",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",

--- a/packages/slate-editor/src/modules/editor/Editor.test.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.test.tsx
@@ -322,6 +322,30 @@ describe('Editor', () => {
         });
 
         /**
+         * @see CARE-1965
+         */
+        it('should normalize list-items directly nested into another list-item', () => {
+            const editor = createEditor(
+                <editor>
+                    <h-p>
+                        <h-text>
+                            <cursor />
+                        </h-text>
+                    </h-p>
+                </editor>,
+            );
+
+            const input = readTestFile('input/list-normalization-4.json');
+            const expected = readTestFile('expected/list-normalization-4.json');
+
+            editor.children = JSON.parse(input).children;
+
+            Editor.normalize(editor, { force: true });
+
+            expect(editor.children).toMatchObject(JSON.parse(expected));
+        });
+
+        /**
          * @see CARE-1320
          */
         it('should handle nodes with empty children array', () => {

--- a/packages/slate-editor/src/modules/editor/__tests__/expected/list-normalization-4.json
+++ b/packages/slate-editor/src/modules/editor/__tests__/expected/list-normalization-4.json
@@ -1,0 +1,18 @@
+[
+    {
+        "type": "paragraph",
+        "children": [
+            {
+                "text": "Hello"
+            }
+        ]
+    },
+    {
+        "type": "paragraph",
+        "children": [
+            {
+                "text": ""
+            }
+        ]
+    }
+]

--- a/packages/slate-editor/src/modules/editor/__tests__/input/list-normalization-4.json
+++ b/packages/slate-editor/src/modules/editor/__tests__/input/list-normalization-4.json
@@ -1,0 +1,32 @@
+{
+    "type": "document",
+    "children": [
+        {
+            "type": "list-item",
+            "children": [
+                {
+                    "type": "list-item-text",
+                    "children": [
+                        {
+                            "text": "Hello"
+                        }
+                    ]
+                },
+                {
+                    "type": "list-item",
+                    "children": [
+                        {
+                            "type": "list-item-text",
+                            "children": [
+                                {
+                                    "text": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "version": "0.50"
+}

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -4,6 +4,7 @@ import type { Editor } from 'slate';
 
 import type { EditorEventMap } from '#modules/events';
 import { withEvents } from '#modules/events';
+import { hierarchySchema, withNodesHierarchy } from '#modules/nodes-hierarchy';
 import { coverage, createDelayedResolve, oembedInfo } from '#modules/tests';
 
 import { createEditor as createBaseEditor } from './createEditor';
@@ -102,5 +103,8 @@ export function getAllExtensions() {
 }
 
 export function createEditor(input: JSX.Element) {
-    return createBaseEditor(input as unknown as Editor, getAllExtensions, [withEvents(events)]);
+    return createBaseEditor(input as unknown as Editor, getAllExtensions, [
+        withEvents(events),
+        withNodesHierarchy(hierarchySchema),
+    ]);
 }

--- a/packages/slate-lists/src/lib/index.ts
+++ b/packages/slate-lists/src/lib/index.ts
@@ -10,6 +10,8 @@ export { getParentListItem } from './getParentListItem';
 export { getPrevSibling } from './getPrevSibling';
 export { isAtStartOfListItem } from './isAtStartOfListItem';
 export { isAtEmptyListItem } from './isAtEmptyListItem';
+export { isContainingTextNodes } from './isContainingTextNodes';
+export { isElementOrEditor } from './isElementOrEditor';
 export { isInList } from './isInList';
 export { isListItemContainingText } from './isListItemContainingText';
 export { pickSubtreesRoots } from './pickSubtreesRoots';

--- a/packages/slate-lists/src/lib/isContainingTextNodes.ts
+++ b/packages/slate-lists/src/lib/isContainingTextNodes.ts
@@ -1,0 +1,6 @@
+import type { Element } from 'slate';
+import { Text } from 'slate';
+
+export function isContainingTextNodes(element: Element): boolean {
+    return element.children.some(Text.isText);
+}

--- a/packages/slate-lists/src/lib/isElementOrEditor.ts
+++ b/packages/slate-lists/src/lib/isElementOrEditor.ts
@@ -1,0 +1,8 @@
+import type { Editor, Element, Node } from 'slate';
+
+/**
+ * The Slate's `Element.isElement()` is explicitly excluding `Editor`.
+ */
+export function isElementOrEditor(node: Node): node is Element | Editor {
+    return 'children' in node;
+}

--- a/packages/slate-lists/src/normalizations/normalizeListItemChildren.ts
+++ b/packages/slate-lists/src/normalizations/normalizeListItemChildren.ts
@@ -18,9 +18,7 @@ export function normalizeListItemChildren(
 
     const children = Array.from(Node.children(editor, path));
 
-    for (let childIndex = 0; childIndex < children.length; ++childIndex) {
-        const [childNode, childPath] = children[childIndex];
-
+    for (const [childIndex, [childNode, childPath]] of children.entries()) {
         if (Text.isText(childNode) || editor.isInline(childNode)) {
             const listItemText = schema.createListItemTextNode({
                 children: [childNode],

--- a/packages/slate-lists/src/normalizations/normalizeSiblingLists.ts
+++ b/packages/slate-lists/src/normalizations/normalizeSiblingLists.ts
@@ -22,9 +22,9 @@ export function normalizeSiblingLists(
     const [, path] = entry;
     const nextSibling = getNextSibling(editor, path);
 
-    if (!nextSibling) {
-        return false;
+    if (nextSibling) {
+        return mergeListWithPreviousSiblingList(editor, schema, nextSibling);
     }
 
-    return mergeListWithPreviousSiblingList(editor, schema, nextSibling);
+    return false;
 }


### PR DESCRIPTION
The problem was in `normalizeOrphanListItem` / `normalizeOrphanListItemText` -- one was applying a fix, and the other one was reverting it back. 