### PR TITLE
[DEV-11412] Feature - Warn if video size options are not supported by the theme

### DIFF
--- a/packages/slate-editor/src/components/InfoText/InfoText.module.scss
+++ b/packages/slate-editor/src/components/InfoText/InfoText.module.scss
@@ -1,12 +1,8 @@
 @import "styles/variables";
 
-.info-text {
+.InfoText {
     font-size: $font-size-smaller;
     font-weight: 500;
     opacity: 0.5;
 }
 
-.icon {
-    width: 14px;
-    height: 14px;
-}

--- a/packages/slate-editor/src/components/InfoText/InfoText.module.scss
+++ b/packages/slate-editor/src/components/InfoText/InfoText.module.scss
@@ -5,4 +5,3 @@
     font-weight: 500;
     opacity: 0.5;
 }
-

--- a/packages/slate-editor/src/components/InfoText/InfoText.tsx
+++ b/packages/slate-editor/src/components/InfoText/InfoText.tsx
@@ -1,22 +1,64 @@
 import classNames from 'classnames';
-import * as React from 'react';
+import React from 'react';
+import type { ReactNode } from 'react';
 
-import { HStack } from '#components';
+import { Button, HStack } from '#components';
 import { Info } from '#icons';
 
 import styles from './InfoText.module.scss';
 
 interface Props {
     className?: string;
+    children?: ReactNode;
 }
 
-export function InfoText(props: React.PropsWithChildren<Props>) {
+export function InfoText({ className, children }: Props) {
     return (
-        <div className={classNames(styles['info-text'], props.className)}>
+        <div className={classNames(styles.InfoText, className)}>
             <HStack spacing="1">
                 <Info height={14} />
-                <span>{props.children}</span>
+                <span>{children}</span>
             </HStack>
         </div>
+    );
+}
+
+export namespace InfoText {
+    export type Text = string;
+    export type Link = { text: Text; href: string };
+    export type Button = { text: Text; onClick: () => void };
+    export type StructuredContent = Array<Text | Link | Button>;
+
+    export function Structured(props: Omit<Props, 'children'> & { children: StructuredContent }) {
+        const { children, ...rest } = props;
+        return (
+            <InfoText {...rest}>
+                {children.map((child, idx) => (
+                    <Child key={idx}>{child}</Child>
+                ))}
+            </InfoText>
+        );
+    }
+}
+
+function Child(props: { children: InfoText.Text | InfoText.Link | InfoText.Button }) {
+    const content = props.children;
+
+    if (typeof content === 'string') {
+        return <>{content}</>;
+    }
+
+    if ('href' in content) {
+        return (
+            <Button href={content.href} type="link" variant="underlined">
+                {content.text}
+            </Button>
+        );
+    }
+
+    return (
+        <Button onClick={content.onClick} variant="underlined">
+            {content.text}
+        </Button>
     );
 }

--- a/packages/slate-editor/src/extensions/button-block/ButtonBlockExtension.tsx
+++ b/packages/slate-editor/src/extensions/button-block/ButtonBlockExtension.tsx
@@ -2,6 +2,8 @@ import { createDeserializeElement, type Extension } from '@prezly/slate-commons'
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
+import type { InfoText } from '#components';
+
 import { composeElementDeserializer } from '#modules/html-deserialization';
 
 import { ButtonBlockNode } from './ButtonBlockNode';
@@ -16,7 +18,7 @@ export const EXTENSION_ID = 'ButtonBlockExtension';
 
 export interface ButtonBlockExtensionConfiguration {
     withNewTabOption?: boolean;
-    info?: Array<string | { text: string; href: string } | { text: string; onClick: () => void }>;
+    info?: InfoText.StructuredContent;
 }
 
 export function ButtonBlockExtension({

--- a/packages/slate-editor/src/extensions/button-block/components/ButtonBlockElement.tsx
+++ b/packages/slate-editor/src/extensions/button-block/components/ButtonBlockElement.tsx
@@ -2,6 +2,7 @@ import type * as Popper from '@popperjs/core';
 import React, { useCallback } from 'react';
 import { useSlateStatic, type RenderElementProps } from 'slate-react';
 
+import type { InfoText } from '#components';
 import { EditorBlock } from '#components';
 
 import { EventsEditor } from '#modules/events';
@@ -15,7 +16,7 @@ import { ButtonMenu, type FormState } from './ButtonBlockMenu';
 interface Props extends RenderElementProps {
     element: ButtonBlockNode;
     withNewTabOption: boolean;
-    info?: Array<string | { text: string; href: string } | { text: string; onClick: () => void }>;
+    info?: InfoText.StructuredContent;
 }
 
 const PLACEMENT: Record<ButtonBlockNode['layout'], Popper.Placement> = {

--- a/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.module.scss
+++ b/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.module.scss
@@ -1,6 +1,6 @@
 @import "styles/variables";
 
-.icon {
+.Icon {
     fill: $white;
 
     &.active {
@@ -8,6 +8,6 @@
     }
 }
 
-.info {
+.Info {
     opacity: 1;
 }

--- a/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
+++ b/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
@@ -66,7 +66,7 @@ const BUTTON_LAYOUT_OPTIONS: OptionsGroupOption<ButtonBlockNode.Layout>[] = [
         value: ButtonBlockNode.Layout.LEFT,
         label: 'Left',
         icon: ({ isActive }) => (
-            <ButtonLayoutLeft className={classNames(styles.icon, { [styles.active]: isActive })} />
+            <ButtonLayoutLeft className={classNames(styles.Icon, { [styles.active]: isActive })} />
         ),
     },
     {

--- a/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
+++ b/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
@@ -47,7 +47,7 @@ interface Props {
     onReposition: () => void;
     value: FormState;
     withNewTabOption: boolean;
-    info?: Array<string | { text: string; href: string } | { text: string; onClick: () => void }>;
+    info?: InfoText.StructuredContent;
 }
 
 const BUTTON_MENU_VARIANT_OPTIONS: OptionsGroupOption<ButtonBlockNode.Variant>[] = [
@@ -93,28 +93,6 @@ const BUTTON_LAYOUT_OPTIONS: OptionsGroupOption<ButtonBlockNode.Layout>[] = [
         ),
     },
 ];
-
-function renderInfoText(
-    value: string | { text: string; href: string } | { text: string; onClick: () => void },
-) {
-    if (typeof value === 'string') {
-        return <span>{value}</span>;
-    }
-
-    if ('href' in value) {
-        return (
-            <Button href={value.href} type="link" variant="underlined">
-                {value.text}
-            </Button>
-        );
-    }
-
-    return (
-        <Button onClick={value.onClick} variant="underlined">
-            {value.text}
-        </Button>
-    );
-}
 
 export function ButtonMenu({
     info = [],
@@ -163,7 +141,7 @@ export function ButtonMenu({
 
             {info.length > 0 && (
                 <Toolbox.Section>
-                    <InfoText className={styles.info}>{info.map(renderInfoText)}</InfoText>
+                    <InfoText.Structured className={styles.info}>{info}</InfoText.Structured>
                 </Toolbox.Section>
             )}
 

--- a/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
+++ b/packages/slate-editor/src/extensions/button-block/components/ButtonBlockMenu.tsx
@@ -74,7 +74,7 @@ const BUTTON_LAYOUT_OPTIONS: OptionsGroupOption<ButtonBlockNode.Layout>[] = [
         label: 'Center',
         icon: ({ isActive }) => (
             <ButtonLayoutCenter
-                className={classNames(styles.icon, { [styles.active]: isActive })}
+                className={classNames(styles.Icon, { [styles.active]: isActive })}
             />
         ),
     },
@@ -82,14 +82,14 @@ const BUTTON_LAYOUT_OPTIONS: OptionsGroupOption<ButtonBlockNode.Layout>[] = [
         value: ButtonBlockNode.Layout.RIGHT,
         label: 'Right',
         icon: ({ isActive }) => (
-            <ButtonLayoutRight className={classNames(styles.icon, { [styles.active]: isActive })} />
+            <ButtonLayoutRight className={classNames(styles.Icon, { [styles.active]: isActive })} />
         ),
     },
     {
         value: ButtonBlockNode.Layout.WIDE,
         label: 'Wide',
         icon: ({ isActive }) => (
-            <ButtonLayoutWide className={classNames(styles.icon, { [styles.active]: isActive })} />
+            <ButtonLayoutWide className={classNames(styles.Icon, { [styles.active]: isActive })} />
         ),
     },
 ];
@@ -141,7 +141,7 @@ export function ButtonMenu({
 
             {info.length > 0 && (
                 <Toolbox.Section>
-                    <InfoText.Structured className={styles.info}>{info}</InfoText.Structured>
+                    <InfoText.Structured className={styles.Info}>{info}</InfoText.Structured>
                 </Toolbox.Section>
             )}
 

--- a/packages/slate-editor/src/extensions/video/VideoExtension.tsx
+++ b/packages/slate-editor/src/extensions/video/VideoExtension.tsx
@@ -5,6 +5,8 @@ import { VideoNode } from '@prezly/slate-types';
 import { isEqual } from '@technically/lodash';
 import React from 'react';
 
+import type { InfoText } from '#components';
+
 import { composeElementDeserializer } from '#modules/html-deserialization';
 
 import { VideoElement } from './components';
@@ -12,6 +14,7 @@ import { normalizeRedundantVideoAttributes, parseSerializedElement } from './lib
 
 export interface VideoExtensionParameters {
     fetchOembed: (url: OEmbedInfo['url']) => Promise<OEmbedInfo>;
+    info?: InfoText.StructuredContent;
     mode?: 'iframe' | 'thumbnail';
     withMenu?: boolean;
     withLayoutControls?: boolean;
@@ -20,6 +23,7 @@ export interface VideoExtensionParameters {
 export const EXTENSION_ID = 'VideoExtension';
 
 export function VideoExtension({
+    info,
     mode = 'thumbnail',
     withMenu = false,
     withLayoutControls = true,
@@ -44,6 +48,7 @@ export function VideoExtension({
             if (VideoNode.isVideoNode(element)) {
                 return (
                     <VideoElement
+                        info={info}
                         attributes={attributes}
                         element={element}
                         mode={mode}

--- a/packages/slate-editor/src/extensions/video/components/VideoElement.tsx
+++ b/packages/slate-editor/src/extensions/video/components/VideoElement.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useState } from 'react';
 import type { RenderElementProps } from 'slate-react';
 import { useSlateStatic } from 'slate-react';
 
+import type { InfoText } from '#components';
 import { EditorBlock, HtmlInjection } from '#components';
 import { PlayButton } from '#icons';
 
@@ -13,6 +14,7 @@ import styles from './VideoElement.module.scss';
 import { type FormState, VideoMenu } from './VideoMenu';
 
 interface Props extends RenderElementProps {
+    info?: InfoText.StructuredContent;
     element: VideoNode;
     mode: 'iframe' | 'thumbnail';
     withMenu: boolean;
@@ -23,6 +25,7 @@ export function VideoElement({
     attributes,
     children,
     element,
+    info,
     mode,
     withMenu,
     withLayoutControls,
@@ -54,6 +57,7 @@ export function VideoElement({
                 withMenu
                     ? ({ onClose }) => (
                           <VideoMenu
+                              info={info}
                               onChange={handleUpdate}
                               onClose={onClose}
                               onRemove={handleRemove}

--- a/packages/slate-editor/src/extensions/video/components/VideoMenu.module.scss
+++ b/packages/slate-editor/src/extensions/video/components/VideoMenu.module.scss
@@ -1,9 +1,13 @@
 @import "styles/variables";
 
-.icon {
+.Icon {
     fill: white;
 
     &.active {
         fill: $yellow-300;
     }
+}
+
+.Info {
+    opacity: 1;
 }

--- a/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
+++ b/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import type { OptionsGroupOption } from '#components';
-import { Button, OptionsGroup, Toolbox } from '#components';
+import { Button, InfoText, OptionsGroup, Toolbox } from '#components';
 import {
     Delete,
     ExternalLink,
@@ -19,6 +19,7 @@ export interface FormState {
 }
 
 interface Props {
+    info?: InfoText.StructuredContent;
     url: VideoNode['url'];
     onChange: (props: Partial<FormState>) => void;
     onClose: () => void;
@@ -33,7 +34,7 @@ const VIDEO_LAYOUT_OPTIONS: OptionsGroupOption<VideoNode.Layout>[] = [
         label: 'Contained',
         icon: ({ isActive }) => (
             <ImageLayoutContained
-                className={classNames(styles.icon, { [styles.active]: isActive })}
+                className={classNames(styles.Icon, { [styles.active]: isActive })}
             />
         ),
     },
@@ -42,7 +43,7 @@ const VIDEO_LAYOUT_OPTIONS: OptionsGroupOption<VideoNode.Layout>[] = [
         label: 'Expanded',
         icon: ({ isActive }) => (
             <ImageLayoutExpanded
-                className={classNames(styles.icon, { [styles.active]: isActive })}
+                className={classNames(styles.Icon, { [styles.active]: isActive })}
             />
         ),
     },
@@ -51,13 +52,21 @@ const VIDEO_LAYOUT_OPTIONS: OptionsGroupOption<VideoNode.Layout>[] = [
         label: 'Full width',
         icon: ({ isActive }) => (
             <ImageLayoutFullWidth
-                className={classNames(styles.icon, { [styles.active]: isActive })}
+                className={classNames(styles.Icon, { [styles.active]: isActive })}
             />
         ),
     },
 ];
 
-export function VideoMenu({ url, onChange, onClose, onRemove, value, withLayoutControls }: Props) {
+export function VideoMenu({
+    info = [],
+    url,
+    onChange,
+    onClose,
+    onRemove,
+    value,
+    withLayoutControls,
+}: Props) {
     const isSelfHosted =
         url.startsWith('https://cdn.uc.assets.prezly.com/') ||
         url.startsWith('https://ucarecdn.com/');
@@ -81,6 +90,12 @@ export function VideoMenu({ url, onChange, onClose, onRemove, value, withLayoutC
                     >
                         Go to video
                     </Button>
+                </Toolbox.Section>
+            )}
+
+            {info.length > 0 && (
+                <Toolbox.Section>
+                    <InfoText.Structured className={styles.Info}>{info}</InfoText.Structured>
                 </Toolbox.Section>
             )}
 


### PR DESCRIPTION
- Refactor `InfoText` and its structure content support into shared reusable code
- Use `InfoText` for VideoMenu the same way we use it for ButtonBlock menu (#460)