### PR TITLE
[DEV-11546] Add oEmbed-rerouting to Video placeholders too

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -338,6 +338,9 @@ export function PlaceholdersExtension({
                         fetchOembed={withVideoPlaceholders.fetchOembed}
                         format={format}
                         removable={removable}
+                        withImagePlaceholders={Boolean(withImagePlaceholders)}
+                        withVideoPlaceholders={Boolean(withVideoPlaceholders)}
+                        withWebBookmarkPlaceholders={Boolean(withWebBookmarkPlaceholders)}
                     >
                         {children}
                     </VideoPlaceholderElement>


### PR DESCRIPTION
The problem with DEV-11546 was that the TikToks URLs are not `video`-type embeds, but a regular rich app iframe.

That's why the Video placeholder did not handle them, not recognizing as a video.