### PR TITLE
[DEV-11518] Feature - Render Tally embeds as web bookmarks in emails

### DIFF
--- a/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
+++ b/packages/slate-editor/src/extensions/embed/EmbedExtension.tsx
@@ -21,17 +21,19 @@ interface Parameters extends EmbedExtensionConfiguration {
 export const EXTENSION_ID = 'EmbedExtension';
 
 export interface EmbedExtensionConfiguration {
+    allowHtmlInjection?: boolean;
+    allowScreenshots?: boolean;
     fetchOembed: (url: OEmbedInfo['url']) => Promise<OEmbedInfo>;
     info?: InfoText.StructuredContent;
-    showAsScreenshot: boolean;
     withMenu?: boolean;
     withLayoutControls?: boolean;
 }
 
 export const EmbedExtension = ({
+    allowHtmlInjection,
+    allowScreenshots,
     availableWidth,
     info,
-    showAsScreenshot,
     withMenu = false,
     withLayoutControls = true,
 }: Parameters): Extension => ({
@@ -59,11 +61,12 @@ export const EmbedExtension = ({
             return (
                 <>
                     <EmbedElement
+                        allowHtmlInjection={allowHtmlInjection}
+                        allowScreenshots={allowScreenshots}
                         attributes={attributes}
                         availableWidth={availableWidth}
                         element={element}
                         info={info}
-                        showAsScreenshot={showAsScreenshot}
                         withMenu={withMenu}
                         withLayoutControls={withLayoutControls}
                     >

--- a/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
+++ b/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
@@ -96,15 +96,12 @@ export function EmbedElement({
 
                 if (element.oembed.type === 'link') {
                     return (
-                        <BookmarkCard.Container border layout="vertical">
-                            <BookmarkCard.Details
-                                href={element.url}
-                                layout="vertical"
-                                hasThumbnail={false}
-                            >
-                                <BookmarkCard.Provider showUrl url={element.url} />
-                            </BookmarkCard.Details>
-                        </BookmarkCard.Container>
+                        <BookmarkCard
+                            border
+                            layout="vertical"
+                            oembed={{ type: 'link', version: '1.0', url: element.url }}
+                            withThumbnail={false}
+                        />
                     );
                 }
 

--- a/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
+++ b/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
@@ -17,27 +17,28 @@ import styles from './EmbedElement.module.scss';
 import { EmbedMenu } from './EmbedMenu';
 
 interface Props extends RenderElementProps {
+    allowHtmlInjection?: boolean;
+    allowScreenshots?: boolean;
     availableWidth: number;
     info?: InfoText.StructuredContent;
     element: EmbedNode;
-    showAsScreenshot: boolean;
     withMenu: boolean;
     withLayoutControls: boolean;
 }
 
 export function EmbedElement({
+    allowHtmlInjection = false,
+    allowScreenshots = false,
     attributes,
     children,
     element,
     info,
-    showAsScreenshot,
     withMenu,
     withLayoutControls,
 }: Props) {
     const editor = useSlateStatic();
 
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
-    const isUsingScreenshots = showAsScreenshot && element.oembed.type !== 'link';
 
     const handleUpdate = useCallback(
         (patch: Partial<FormState>) => {
@@ -74,7 +75,27 @@ export function EmbedElement({
                     : undefined
             }
             renderReadOnlyFrame={function () {
-                if (isUsingScreenshots && element.oembed.screenshot_url) {
+                if (isInvalid) {
+                    return (
+                        <div className={styles.Error}>
+                            There was a problem loading the requested URL.
+                        </div>
+                    );
+                }
+
+                if (allowHtmlInjection && element.oembed.html) {
+                    return (
+                        <HtmlInjection
+                            className={classNames(styles.Content, {
+                                [styles.video]: element.oembed.type === 'video',
+                            })}
+                            html={element.oembed.html}
+                            onError={() => setIsInvalid(true)}
+                        />
+                    );
+                }
+
+                if (allowScreenshots && element.oembed.screenshot_url) {
                     return (
                         <ImageWithLoadingPlaceholder
                             src={element.oembed.screenshot_url}
@@ -86,32 +107,12 @@ export function EmbedElement({
                     );
                 }
 
-                if (isInvalid) {
-                    return (
-                        <div className={styles.Error}>
-                            There was a problem loading the requested URL.
-                        </div>
-                    );
-                }
-
-                if (element.oembed.type === 'link') {
-                    return (
-                        <BookmarkCard
-                            border
-                            layout="vertical"
-                            oembed={{ type: 'link', version: '1.0', url: element.url }}
-                            withThumbnail={false}
-                        />
-                    );
-                }
-
                 return (
-                    <HtmlInjection
-                        className={classNames(styles.Content, {
-                            [styles.video]: element.oembed.type === 'video',
-                        })}
-                        html={element.oembed.html ?? ''}
-                        onError={() => setIsInvalid(true)}
+                    <BookmarkCard
+                        border
+                        layout="vertical"
+                        oembed={element.oembed}
+                        withThumbnail={true}
                     />
                 );
             }}

--- a/packages/slate-editor/src/extensions/story-bookmark/components/StoryBookmarkElement/StoryBookmarkBlock.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/components/StoryBookmarkElement/StoryBookmarkBlock.tsx
@@ -3,7 +3,7 @@ import type { StoryBookmarkNode } from '@prezly/slate-types';
 import { StoryBookmarkLayout } from '@prezly/slate-types';
 import React, { useRef, useState, useMemo } from 'react';
 
-import { useResizeObserver, utils } from '#lib';
+import { useResizeObserver } from '#lib';
 
 import { BookmarkCard } from '#modules/components';
 
@@ -18,14 +18,9 @@ export function StoryBookmarkBlock({ story, element }: StoryBookmarkBlockProps) 
     const card = useRef<HTMLDivElement | null>(null);
     const [isSmallViewport, setSmallViewport] = useState(false);
 
-    const showThumbnail = element.show_thumbnail && story.oembed.thumbnail_url;
+    const showThumbnail = Boolean(element.show_thumbnail && story.oembed.thumbnail_url);
 
-    const isEmpty =
-        !showThumbnail &&
-        utils.isEmptyText(story.oembed.title) &&
-        utils.isEmptyText(story.oembed.description);
-
-    const actualLayout = useMemo(() => {
+    const autoLayout = useMemo(() => {
         if (!showThumbnail) {
             return StoryBookmarkLayout.HORIZONTAL;
         } else if (isSmallViewport) {
@@ -41,32 +36,13 @@ export function StoryBookmarkBlock({ story, element }: StoryBookmarkBlockProps) 
         });
     });
 
-    const hasThumbnail = Boolean(showThumbnail && story.oembed.thumbnail_url);
-
     return (
-        <BookmarkCard.Container border={false} layout={actualLayout} ref={card}>
-            {showThumbnail && story.oembed.thumbnail_url && (
-                <BookmarkCard.Thumbnail
-                    href={story.oembed.url}
-                    src={story.oembed.thumbnail_url}
-                    width={story.oembed.thumbnail_width}
-                    height={story.oembed.thumbnail_height}
-                />
-            )}
-            <BookmarkCard.Details
-                hasThumbnail={hasThumbnail}
-                layout={actualLayout}
-                href={story.oembed.url}
-                title={story.oembed.title}
-                description={story.oembed.description}
-            >
-                <BookmarkCard.Provider
-                    showUrl={isEmpty}
-                    url={story.oembed.url}
-                    providerName={story.oembed.provider_name}
-                    providerUrl={story.oembed.provider_url}
-                />
-            </BookmarkCard.Details>
-        </BookmarkCard.Container>
+        <BookmarkCard
+            border={false}
+            layout={autoLayout}
+            forwardRef={card}
+            withThumbnail={showThumbnail}
+            oembed={story.oembed}
+        />
     );
 }

--- a/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkElement.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkElement.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
 import { EditorBlock } from '#components';
-import { useResizeObserver, utils } from '#lib';
+import { useResizeObserver } from '#lib';
 
 import { BookmarkCard } from '#modules/components';
 
@@ -30,10 +30,8 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({
 
     const { url, oembed, layout } = element;
     const showThumbnail = element.show_thumbnail && oembed.thumbnail_url;
-    const isEmpty =
-        !showThumbnail && utils.isEmptyText(oembed.title) && utils.isEmptyText(oembed.description);
 
-    const actualLayout = !showThumbnail
+    const autoLayout = !showThumbnail
         ? BookmarkCardLayout.HORIZONTAL
         : isSmallViewport
         ? BookmarkCardLayout.VERTICAL
@@ -61,30 +59,14 @@ export const WebBookmarkElement: FunctionComponent<Props> = ({
             // We have to render children or Slate will fail when trying to find the node.
             renderAboveFrame={children}
             renderReadOnlyFrame={() => (
-                <BookmarkCard.Container border={false} layout={actualLayout} ref={card}>
-                    {showThumbnail && oembed.thumbnail_url && (
-                        <BookmarkCard.Thumbnail
-                            href={url}
-                            src={oembed.thumbnail_url}
-                            width={oembed.thumbnail_width}
-                            height={oembed.thumbnail_height}
-                        />
-                    )}
-                    <BookmarkCard.Details
-                        hasThumbnail={Boolean(showThumbnail && oembed.thumbnail_url)}
-                        layout={actualLayout}
-                        href={url}
-                        title={oembed.title}
-                        description={oembed.description}
-                    >
-                        <BookmarkCard.Provider
-                            showUrl={isEmpty}
-                            url={oembed.url}
-                            providerName={oembed.provider_name}
-                            providerUrl={oembed.provider_url}
-                        />
-                    </BookmarkCard.Details>
-                </BookmarkCard.Container>
+                <BookmarkCard
+                    border={false}
+                    layout={autoLayout}
+                    forwardRef={card}
+                    oembed={oembed}
+                    url={url}
+                    withThumbnail={Boolean(element.show_thumbnail)}
+                />
             )}
             rounded
             void

--- a/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.stories.tsx
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.stories.tsx
@@ -1,15 +1,15 @@
+import type { OEmbedInfo } from '@prezly/sdk';
 import * as React from 'react';
 
-import * as BookmarkCard from './index';
+import { BookmarkCard } from './BookmarkCard';
 
 export default {
     title: 'Modules/Components/BookmarkCard',
-    argTypes: {
-        showUrl: { control: 'boolean' },
-    },
 };
 
-const info = {
+const info: OEmbedInfo = {
+    type: 'link',
+    version: '1.0',
     url: 'https://www.prezly.com/index',
     title: 'PR Software for better, faster PR',
     description:
@@ -21,72 +21,31 @@ const info = {
     thumbnail_height: 500,
 };
 
-export function Horizontal(props: { showUrl: boolean }) {
+export function Horizontal() {
     return (
         <div style={{ width: 680 }}>
-            <BookmarkCard.Container border layout="horizontal">
-                <BookmarkCard.Thumbnail
-                    href={info.url}
-                    src={info.thumbnail_url}
-                    width={info.thumbnail_width}
-                    height={info.thumbnail_height}
-                />
-                <BookmarkCard.Details
-                    href={info.url}
-                    title={info.title}
-                    description={info.description}
-                    layout="horizontal"
-                    hasThumbnail
-                >
-                    <BookmarkCard.Provider
-                        showUrl={props.showUrl}
-                        url={info.url}
-                        providerName={info.provider_name}
-                    />
-                </BookmarkCard.Details>
-            </BookmarkCard.Container>
+            <BookmarkCard layout="horizontal" oembed={info} withThumbnail />
         </div>
     );
 }
 
-export function Vertical(props: { showUrl: boolean }) {
+export function Vertical() {
     return (
         <div style={{ width: 680 }}>
-            <BookmarkCard.Container border layout="vertical">
-                <BookmarkCard.Thumbnail
-                    href={info.url}
-                    src={info.thumbnail_url}
-                    width={info.thumbnail_width}
-                    height={info.thumbnail_height}
-                />
-                <BookmarkCard.Details
-                    href={info.url}
-                    title={info.title}
-                    description={info.description}
-                    layout="vertical"
-                    hasThumbnail
-                >
-                    <BookmarkCard.Provider
-                        showUrl={props.showUrl}
-                        url={info.url}
-                        providerName={info.provider_name}
-                    />
-                </BookmarkCard.Details>
-            </BookmarkCard.Container>
+            <BookmarkCard layout="vertical" oembed={info} withThumbnail />
         </div>
     );
 }
 
 export function Minimal() {
-    const url =
-        'https://www.facebook.com/PrezlyPR/posts/pfbid0zinDzc7t9pLwkEtdVAbcZgoeZ792csmyVGgUgz2eFB1fjz3yoYbuvbenXPJSN4tDl?__cft__[0]=AZUWtBN4H5i0AnIfCYHAwa3J0rXPydGcCaAJ4R9IvZCdTWLp_dbPZ3lNcVFKMONxsPfV3CATYts4iXNLvNU0dvsMJskip5faSIg35v-gFL8CMGCCE_SD2kLtjmFFvbx2RyJ3rw-sREgFrp9NheKji-SzfhQMR0UNzICq2e18tYJ3p_tRWGS-3Z-u5X7gA89Ox1U&__tn__=%2CO%2CP-R';
+    const oembed: OEmbedInfo = {
+        type: 'link',
+        version: '1.0',
+        url: 'https://www.facebook.com/PrezlyPR/posts/pfbid0zinDzc7t9pLwkEtdVAbcZgoeZ792csmyVGgUgz2eFB1fjz3yoYbuvbenXPJSN4tDl?__cft__[0]=AZUWtBN4H5i0AnIfCYHAwa3J0rXPydGcCaAJ4R9IvZCdTWLp_dbPZ3lNcVFKMONxsPfV3CATYts4iXNLvNU0dvsMJskip5faSIg35v-gFL8CMGCCE_SD2kLtjmFFvbx2RyJ3rw-sREgFrp9NheKji-SzfhQMR0UNzICq2e18tYJ3p_tRWGS-3Z-u5X7gA89Ox1U&__tn__=%2CO%2CP-R',
+    };
     return (
         <div style={{ width: 680 }}>
-            <BookmarkCard.Container border layout="vertical">
-                <BookmarkCard.Details href={url} layout="vertical" hasThumbnail={false}>
-                    <BookmarkCard.Provider showUrl url={url} />
-                </BookmarkCard.Details>
-            </BookmarkCard.Container>
+            <BookmarkCard border layout="vertical" withThumbnail={false} oembed={oembed} />
         </div>
     );
 }

--- a/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.tsx
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/BookmarkCard.tsx
@@ -1,0 +1,58 @@
+import type { OEmbedInfo } from '@prezly/sdk';
+import React, { type Ref } from 'react';
+
+import { utils } from '#lib';
+
+import { Container } from './Container';
+import { Details } from './Details';
+import { Provider } from './Provider';
+import { Thumbnail } from './Thumbnail';
+
+export function BookmarkCard({
+    border = true,
+    layout,
+    forwardRef,
+    oembed,
+    url = oembed.url,
+    withThumbnail,
+}: BookmarkCard.Props) {
+    const isEmpty =
+        !withThumbnail && utils.isEmptyText(oembed.title) && utils.isEmptyText(oembed.description);
+    return (
+        <Container border={border} layout={layout} forwardRef={forwardRef}>
+            {withThumbnail && oembed.thumbnail_url && (
+                <Thumbnail
+                    href={url}
+                    src={oembed.thumbnail_url}
+                    width={oembed.thumbnail_width}
+                    height={oembed.thumbnail_height}
+                />
+            )}
+            <Details
+                hasThumbnail={Boolean(withThumbnail && oembed.thumbnail_url)}
+                layout={layout}
+                href={url}
+                title={oembed.title}
+                description={oembed.description}
+            >
+                <Provider
+                    showUrl={isEmpty}
+                    url={url}
+                    providerName={oembed.provider_name}
+                    providerUrl={oembed.provider_url}
+                />
+            </Details>
+        </Container>
+    );
+}
+
+export namespace BookmarkCard {
+    export interface Props {
+        border?: boolean;
+        forwardRef?: Ref<HTMLDivElement>;
+        layout: 'vertical' | 'horizontal';
+        oembed: OEmbedInfo;
+        url?: string;
+        withThumbnail: boolean;
+    }
+}

--- a/packages/slate-editor/src/modules/components/BookmarkCard/Container.tsx
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/Container.tsx
@@ -1,31 +1,27 @@
 import classNames from 'classnames';
-import type { PropsWithChildren } from 'react';
-import React from 'react';
+import type { Ref } from 'react';
+import React, { type ReactNode } from 'react';
 
 import styles from './BookmarkCard.module.scss';
 
-type ContainerLayout = 'vertical' | 'horizontal';
-
-interface ContainerProps {
-    border?: boolean;
-    layout: ContainerLayout;
+interface Props {
+    border: boolean;
+    children: ReactNode;
+    forwardRef?: Ref<HTMLDivElement>;
+    layout: 'vertical' | 'horizontal';
 }
 
-export const Container = React.forwardRef<HTMLDivElement, PropsWithChildren<ContainerProps>>(
-    ({ border = true, layout, children }, ref) => {
-        return (
-            <div
-                className={classNames(styles.container, {
-                    [styles.border]: border,
-                    [styles.vertical]: layout === 'vertical',
-                    [styles.horizontal]: layout === 'horizontal',
-                })}
-                ref={ref}
-            >
-                {children}
-            </div>
-        );
-    },
-);
-
-Container.displayName = 'Container';
+export function Container({ border = true, layout, children, forwardRef }: Props) {
+    return (
+        <div
+            className={classNames(styles.container, {
+                [styles.border]: border,
+                [styles.vertical]: layout === 'vertical',
+                [styles.horizontal]: layout === 'horizontal',
+            })}
+            ref={forwardRef}
+        >
+            {children}
+        </div>
+    );
+}

--- a/packages/slate-editor/src/modules/components/BookmarkCard/index.ts
+++ b/packages/slate-editor/src/modules/components/BookmarkCard/index.ts
@@ -1,4 +1,1 @@
-export * from './Container';
-export * from './Details';
-export * from './Provider';
-export * from './Thumbnail';
+export { BookmarkCard } from './BookmarkCard';

--- a/packages/slate-editor/src/modules/components/index.ts
+++ b/packages/slate-editor/src/modules/components/index.ts
@@ -1,4 +1,4 @@
-export * as BookmarkCard from './BookmarkCard';
+export { BookmarkCard } from './BookmarkCard';
 export * as FloatingContainer from './FloatingContainer';
 export * from './FloatingSnippetInput';
 export { InlineContactForm } from './InlineContactForm';

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -38,7 +38,8 @@ export function getAllExtensions() {
             withDivider: true,
             withEmbeds: {
                 fetchOembed,
-                showAsScreenshot: false,
+                allowHtmlInjection: true,
+                allowScreenshots: false,
             },
             withFloatingAddMenu: true,
             withGalleries: {},


### PR DESCRIPTION
The main change here is restructuring the Embed element rendering to fallback to the Bookmark presentation. This happens when both iframe HTML and Screenshot presentations are either disabled or not possible.

The rest of changes are refactoring to simplify the reuse of Bookmark presentation