### PR TITLE
[DEV-11536] Revert the disabled size controls for specific embeds

### DIFF
--- a/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
+++ b/packages/slate-editor/src/extensions/embed/components/EmbedElement.tsx
@@ -1,4 +1,3 @@
-import type { OEmbedInfo } from '@prezly/sdk';
 import classNames from 'classnames';
 import React, { useCallback, useState } from 'react';
 import type { RenderElementProps } from 'slate-react';
@@ -80,11 +79,7 @@ export function EmbedElement({
                               onRemove={handleRemove}
                               url={element.url}
                               value={{ layout: element.layout }}
-                              withLayoutControls={
-                                  withLayoutControls && isFixedSizeEmbed(element.oembed)
-                                      ? 'disabled'
-                                      : withLayoutControls
-                              }
+                              withLayoutControls={withLayoutControls}
                               withConversionOptions={withConversionOptions}
                           />
                       )
@@ -136,24 +131,4 @@ export function EmbedElement({
             void
         />
     );
-}
-
-/**
- * @see DEV-11536
- */
-function isFixedSizeEmbed(oembed: OEmbedInfo) {
-    return (
-        oembed.type === 'rich' &&
-        startsWith(oembed.url, [
-            'https://instagram.com/',
-            'https://pin.it/',
-            'https://twitter.com/',
-            'https://www.tiktok.com/',
-            'https://x.com/',
-        ])
-    );
-}
-
-function startsWith(haystack: string, needles: string[]): boolean {
-    return needles.some((needle) => haystack.startsWith(needle));
 }

--- a/packages/slate-editor/src/extensions/embed/components/EmbedMenu.tsx
+++ b/packages/slate-editor/src/extensions/embed/components/EmbedMenu.tsx
@@ -28,7 +28,7 @@ interface Props {
     onClose: () => void;
     onRemove: () => void;
     value: FormState;
-    withLayoutControls: boolean | 'disabled';
+    withLayoutControls: boolean;
     withConversionOptions: boolean;
 }
 
@@ -113,7 +113,6 @@ export function EmbedMenu({
             {withLayoutControls && (
                 <Toolbox.Section caption="Size">
                     <OptionsGroup
-                        disabled={withLayoutControls === 'disabled'}
                         name="layout"
                         options={LAYOUT_OPTIONS}
                         selectedValue={value.layout}


### PR DESCRIPTION
This reverts #495 

See https://linear.app/prezly/issue/DEV-11536/qa-should-certain-embeds-not-have-resize-controls-if-they-are-always#comment-581fb499 for explanation.