### PR TITLE
[CARE-2178] Fix - Provide invalidateSuggestions prop to SearchInputPlaceholder

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/components/SearchInputPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/components/SearchInputPlaceholderElement.tsx
@@ -55,6 +55,7 @@ export function SearchInputPlaceholderElement<T>({
     removable,
     // Input
     getSuggestions,
+    invalidateSuggestions,
     renderEmpty,
     renderSuggestion,
     renderSuggestions,
@@ -123,6 +124,7 @@ export function SearchInputPlaceholderElement<T>({
                     <SearchInputPlaceholder<T>
                         // Customization
                         getSuggestions={getSuggestions}
+                        invalidateSuggestions={invalidateSuggestions}
                         renderAddon={renderAddon}
                         renderEmpty={
                             renderEmpty &&


### PR DESCRIPTION
`invalidateSuggestions` was never passed to the `SearchInputPlaceholder` so the callbacks were never triggered.