### PR TITLE
[CARE-3589] Drop React v16 and v17 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        react-version: [ 16.14.0, 17, 18 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,14 +18,6 @@ jobs:
         with:
           node: ${{ matrix.node-version }}
           pnpm: "8.4.0"
-
-      - name: Set React ${{ matrix.react-version }}
-        uses: prezly/pnpm-overrides-action@v1
-        with:
-          '@types/react':     "${{ matrix.react-version }}"
-          '@types/react-dom': "${{ startsWith(matrix.react-version, '16.') && '16.9.9' || matrix.react-version }}"
-          'react':            "${{ matrix.react-version }}"
-          'react-dom':        "${{ matrix.react-version }}"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        react-version: [ 16.14.0, 17, 18 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,14 +18,6 @@ jobs:
         with:
           node: ${{ matrix.node-version }}
           pnpm: "8.4.0"
-
-      - name: Set React ${{ matrix.react-version }}
-        uses: prezly/pnpm-overrides-action@v1
-        with:
-          '@types/react':     "${{ matrix.react-version }}"
-          '@types/react-dom': "${{ startsWith(matrix.react-version, '16.') && '16.9.9' || matrix.react-version }}"
-          'react':            "${{ matrix.react-version }}"
-          'react-dom':        "${{ matrix.react-version }}"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile --strict-peer-dependencies --ignore-pnpmfile --prod

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        react-version: [ 16.14.0, 17, 18 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,14 +18,6 @@ jobs:
         with:
           node: ${{ matrix.node-version }}
           pnpm: "8.4.0"
-
-      - name: Set React ${{ matrix.react-version }}
-        uses: prezly/pnpm-overrides-action@v1
-        with:
-          '@types/react':     "${{ matrix.react-version }}"
-          '@types/react-dom': "${{ startsWith(matrix.react-version, '16.') && '16.9.9' || matrix.react-version }}"
-          'react':            "${{ matrix.react-version }}"
-          'react-dom':        "${{ matrix.react-version }}"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        react-version: [ 16.14.0, 17, 18 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,14 +18,6 @@ jobs:
         with:
           node: ${{ matrix.node-version }}
           pnpm: "8.4.0"
-
-      - name: Set React ${{ matrix.react-version }}
-        uses: prezly/pnpm-overrides-action@v1
-        with:
-          '@types/react':     "${{ matrix.react-version }}"
-          '@types/react-dom': "${{ startsWith(matrix.react-version, '16.') && '16.9.9' || matrix.react-version }}"
-          'react':            "${{ matrix.react-version }}"
-          'react-dom':        "${{ matrix.react-version }}"
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -20,11 +20,6 @@
         "lint": "pnpm --recursive lint",
         "lint:fix": "pnpm --recursive lint --fix",
         "test": "turbo run test",
-        "test:matrix": "pnpm test:react16 && pnpm test:react17 && pnpm test:react18",
-        "test:react16": "REACT_VERSION=16 pnpm test:react",
-        "test:react17": "REACT_VERSION=17 pnpm test:react",
-        "test:react18": "REACT_VERSION=18 pnpm test:react",
-        "test:react": "pnpm install --no-lockfile -w react@$REACT_VERSION react-dom@$REACT_VERSION @types/react@$REACT_VERSION @types/react-dom@$REACT_VERSION && pnpm clean:build && pnpm build && pnpm test",
         "clean": "pnpm clean:build && pnpm clean:node_modules",
         "clean:build": "rimraf *.tsbuildinfo && rimraf node_modules/.cache/ && pnpm --recursive run clean:build",
         "clean:node_modules": "rimraf node_modules/ pnpm-lock.yaml package-lock.json && pnpm --recursive run clean:node_modules",
@@ -41,10 +36,10 @@
         "pnpm": ">= 8.4.0"
     },
     "dependencies": {
-        "@types/react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "@types/react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "slate": "^0.94.1",
         "slate-history": "^0.93.0",
         "slate-react": "^0.97.0"

--- a/packages/slate-commons/package.json
+++ b/packages/slate-commons/package.json
@@ -42,7 +42,7 @@
         "clean:build": "rimraf build/ *.tsbuildinfo"
     },
     "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
         "slate": "^0.94.1",
         "slate-history": "^0.93.0",
         "slate-react": "^0.97.0"

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -89,8 +89,8 @@
         "validator": "^13.5.2"
     },
     "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "slate": "^0.94.1",
         "slate-history": "^0.93.0",
         "slate-react": "^0.97.0"

--- a/packages/slate-lists/package.json
+++ b/packages/slate-lists/package.json
@@ -42,7 +42,7 @@
         "clean:build": "rimraf build/ *.tsbuildinfo"
     },
     "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
         "slate": "^0.94.1",
         "slate-react": "^0.97.0"
     },

--- a/packages/slate-tables/package.json
+++ b/packages/slate-tables/package.json
@@ -42,7 +42,7 @@
         "clean:build": "rimraf build/ *.tsbuildinfo"
     },
     "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
         "slate": "^0.94.1",
         "slate-react": "^0.97.0"
     },


### PR DESCRIPTION
I don't think we use older React versions anywhere. Right?