### PR TITLE
[CARE-4306] Update outdated dependencies with security issues

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
     "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-    "useWorkspaces": true,
     "version": "0.102.0"
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@babel/register": "^7.23.7",
-        "@dr.pogodin/babel-preset-svgr": "^1.3.1",
+        "@dr.pogodin/babel-preset-svgr": "^1.8.0",
         "@manypkg/get-packages": "^2.1.0",
         "@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0",
         "@types/chai": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -129,5 +129,10 @@
             "slate-hyperscript",
             "slate-react"
         ]
+    },
+    "pnpm": {
+        "overrides": {
+            "glob-parent@<5.1.2": ">=5.1.2"
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -104,11 +104,11 @@
         "sinon": "^15.0.4",
         "slate-hyperscript": "^0.100.0",
         "ts-node": "^10.9.1",
-        "ts-plugin-scss-modules": "^0.1.2",
         "tsc-fancy": "^1.1.2",
         "tsconfig-paths": "^4.2.0",
         "turbo": "^1.9.3",
         "typescript": "^5.3.3",
+        "typescript-plugin-css-modules": "^5.0.2",
         "vinyl": "^2.2.1"
     },
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
         "slate-react": "^0.101.5"
     },
     "devDependencies": {
-        "@babel/cli": "^7.21.5",
-        "@babel/core": "^7.18.5",
-        "@babel/preset-env": "^7.21.5",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.21.5",
-        "@babel/register": "^7.21.0",
+        "@babel/cli": "^7.23.9",
+        "@babel/core": "^7.23.9",
+        "@babel/preset-env": "^7.23.9",
+        "@babel/preset-react": "^7.23.3",
+        "@babel/preset-typescript": "^7.23.3",
+        "@babel/register": "^7.23.7",
         "@dr.pogodin/babel-preset-svgr": "^1.3.1",
         "@manypkg/get-packages": "^2.1.0",
         "@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "gulp-use": "^0.0.4",
         "ignore-styles": "^5.0.1",
         "jsdom": "^22.0.0",
-        "lerna": "^6.6.2",
+        "lerna": "^8.0.2",
         "mocha": "^10.2.0",
         "mocha-expect-snapshot": "^7.0.0",
         "open-cli": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "mocha": "^10.2.0",
         "mocha-expect-snapshot": "^7.0.0",
         "open-cli": "^7.2.0",
-        "postcss": "^8.4.1",
+        "postcss": "^8.4.33",
         "postcss-modules": "^4.3.0",
         "prettier": "^2.8.8",
         "rimraf": "^3.0.2",

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -86,7 +86,7 @@
         "social-links": "^1.10.0",
         "striptags": "^3.2.0",
         "uuid": "^8.3.0",
-        "validator": "^13.5.2"
+        "validator": "^13.11.0"
     },
     "peerDependencies": {
         "react": "^18.2.0",
@@ -105,6 +105,6 @@
         "@types/react-portal": "^4.0.2",
         "@types/react-router-dom": "=5.1.2",
         "@types/uuid": "^8.3.0",
-        "@types/validator": "^13.1.3"
+        "@types/validator": "^13.11.8"
     }
 }

--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -71,7 +71,7 @@
         "combine-reducers": "^1.0.0",
         "is-hotkey": "^0.2.0",
         "json-stable-stringify": "^1.0.1",
-        "moment": "^2.29.1",
+        "moment": "^2.30.1",
         "popper-max-size-modifier": "^0.2.0",
         "rangefix": "^0.2.9",
         "react-bootstrap": "=0.32.4",

--- a/packages/slate-editor/tsconfig.json
+++ b/packages/slate-editor/tsconfig.json
@@ -16,11 +16,7 @@
         },
         "plugins": [
             {
-                "name": "ts-plugin-scss-modules",
-                // @see https://www.npmjs.com/package/ts-plugin-scss-modules#user-content-options
-                "options": {
-                    "classnameTransform": "asIs",
-                },
+                "name": "typescript-plugin-css-modules"
             },
         ]
     },


### PR DESCRIPTION
Also updated the `lerna` package with the latest one and replaced oudated `ts-plugin-scss-modules` with `typescript-plugin-css-modules`.