### PR TITLE
[DEV-12552] Feature - Show pencil next to the caption & truncate if needed

### DIFF
--- a/packages/slate-editor/src/extensions/galleries/components/Gallery/GalleryTile.module.scss
+++ b/packages/slate-editor/src/extensions/galleries/components/Gallery/GalleryTile.module.scss
@@ -1,3 +1,4 @@
+@import "styles/helpers";
 @import "styles/variables";
 
 .GalleryTile {
@@ -82,6 +83,7 @@
 
         .Input {
             width: 100%;
+            padding: 0;
             appearance: none;
             color: $white;
             background: none;
@@ -95,6 +97,43 @@
                 color: $white;
                 font-style: italic;
                 font-weight: 300;
+            }
+        }
+
+        .Button {
+            max-width: 100%;
+            margin: 0;
+            padding: 0;
+            border: none;
+            font-size: 13px;
+            font-weight: 500;
+            line-height: 1.2;
+            overflow: hidden;
+
+            &,
+            &:hover,
+            &:focus {
+                color: $white !important;
+                background: none !important;
+            }
+
+            &.empty {
+                font-style: italic;
+                font-weight: 300;
+            }
+
+            > div {
+                overflow: hidden;
+            }
+
+            span {
+                @include ellipsis;
+
+                opacity: 1;
+            }
+
+            svg {
+                flex-shrink: 0;
             }
         }
     }


### PR DESCRIPTION
- caption is rendered as a ghost button by default, with pencil and truncation
- when clicked, button changes into an input with the same styling to allow editing
- introduced intermediary state for caption as using the caption prop directly causes the input to rerender on every update, causing a bug that moves the caret to the end of the input

<img width="911" alt="Screenshot 2024-02-28 at 11 56 56" src="https://github.com/prezly/slate/assets/4209081/6075abf1-815e-4748-8b5f-8a12da5bbe57">
