### PR TITLE
[CARE-4942] Upgrade @prezly/sdk package

### DIFF
--- a/packages/slate-editor/package.json
+++ b/packages/slate-editor/package.json
@@ -58,7 +58,7 @@
         "@prezly/events": "^2.0.3",
         "@prezly/linear-partition": "^1.0.3",
         "@prezly/progress-promise": "^2.0.1",
-        "@prezly/sdk": "^20.0.0",
+        "@prezly/sdk": "^21.0.0",
         "@prezly/slate-commons": "workspace:*",
         "@prezly/slate-lists": "workspace:*",
         "@prezly/slate-tables": "workspace:*",

--- a/packages/slate-types/package.json
+++ b/packages/slate-types/package.json
@@ -44,7 +44,7 @@
         "slate": "^0.101.5"
     },
     "dependencies": {
-        "@prezly/sdk": "^20.0.0",
+        "@prezly/sdk": "^21.0.0",
         "@prezly/uploads": "^0.3.2",
         "is-plain-object": "^5.0.0"
     },


### PR DESCRIPTION
See https://github.com/prezly/javascript-sdk/releases/tag/v21.0.0