### PR TITLE
[CARE-5260] Fix - Ensure vertical videos are centered

### DIFF
--- a/packages/slate-editor/src/extensions/video/components/VideoElement.module.scss
+++ b/packages/slate-editor/src/extensions/video/components/VideoElement.module.scss
@@ -47,3 +47,10 @@
         fill: $indigo-500;
     }
 }
+
+.HtmlInjection {
+    > *:only-child {
+        margin-left: auto;
+        margin-right: auto;
+    }
+}

--- a/packages/slate-editor/src/extensions/video/components/VideoElement.tsx
+++ b/packages/slate-editor/src/extensions/video/components/VideoElement.tsx
@@ -93,6 +93,7 @@ export function VideoElement({
                     oembed.html &&
                     mode === 'iframe' ? (
                         <HtmlInjection
+                            className={styles.HtmlInjection}
                             html={oembed.html}
                             onError={() => setHtmlEmbeddedWithErrors(true)}
                         />


### PR DESCRIPTION
Content Renderer Related Changes: https://github.com/prezly/content-renderer-react-js/pull/85

| Before | After |
|--------|--------|
| ![image](https://github.com/prezly/slate/assets/67554982/7a2c18ed-45b3-4c33-9986-6ddf6c6c8436) | ![Screenshot 2024-06-25 121822](https://github.com/prezly/slate/assets/67554982/7e82282c-89fa-4b5a-9b6f-f83c079b1094) | 




