### PR TITLE
[CARE-5345] Fix - Always set the `text-align` property on paragraph

### DIFF
--- a/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
@@ -1,6 +1,6 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
-import type { Alignment} from '@prezly/slate-types';
+import type { Alignment } from '@prezly/slate-types';
 import { PARAGRAPH_NODE_TYPE, isParagraphNode } from '@prezly/slate-types';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
@@ -36,7 +36,11 @@ export const ParagraphsExtension = ({ defaultAlignment }: Parameters): Extension
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isParagraphNode(element)) {
             return (
-                <ParagraphElement attributes={attributes} defaultAlignment={defaultAlignment} element={element}>
+                <ParagraphElement
+                    attributes={attributes}
+                    defaultAlignment={defaultAlignment}
+                    element={element}
+                >
                     {children}
                 </ParagraphElement>
             );

--- a/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/ParagraphsExtension.tsx
@@ -1,5 +1,6 @@
 import type { Extension } from '@prezly/slate-commons';
 import { createDeserializeElement } from '@prezly/slate-commons';
+import type { Alignment} from '@prezly/slate-types';
 import { PARAGRAPH_NODE_TYPE, isParagraphNode } from '@prezly/slate-types';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
@@ -15,7 +16,11 @@ import {
 
 export const EXTENSION_ID = 'ParagraphsExtension';
 
-export const ParagraphsExtension = (): Extension => ({
+interface Parameters {
+    defaultAlignment: Alignment;
+}
+
+export const ParagraphsExtension = ({ defaultAlignment }: Parameters): Extension => ({
     id: EXTENSION_ID,
     deserialize: {
         element: composeElementDeserializer({
@@ -31,7 +36,7 @@ export const ParagraphsExtension = (): Extension => ({
     renderElement: ({ attributes, children, element }: RenderElementProps) => {
         if (isParagraphNode(element)) {
             return (
-                <ParagraphElement attributes={attributes} element={element}>
+                <ParagraphElement attributes={attributes} defaultAlignment={defaultAlignment} element={element}>
                     {children}
                 </ParagraphElement>
             );

--- a/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
@@ -1,4 +1,4 @@
-import { Alignment} from '@prezly/slate-types';
+import { Alignment } from '@prezly/slate-types';
 import { type ParagraphNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
@@ -13,7 +13,14 @@ interface Props extends HTMLAttributes<HTMLParagraphElement> {
     element: ParagraphNode;
 }
 
-export function ParagraphElement({ attributes, children, className, defaultAlignment, element, ...props }: Props) {
+export function ParagraphElement({
+    attributes,
+    children,
+    className,
+    defaultAlignment,
+    element,
+    ...props
+}: Props) {
     const align = element.align || defaultAlignment;
 
     return (

--- a/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
@@ -1,4 +1,5 @@
-import { Alignment, type ParagraphNode } from '@prezly/slate-types';
+import type { Alignment} from '@prezly/slate-types';
+import { type ParagraphNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
@@ -8,11 +9,12 @@ import styles from './ParagraphElement.module.scss';
 
 interface Props extends HTMLAttributes<HTMLParagraphElement> {
     attributes?: RenderElementProps['attributes'];
+    defaultAlignment: Alignment;
     element: ParagraphNode;
 }
 
-export function ParagraphElement({ attributes, children, className, element, ...props }: Props) {
-    const align = element.align || Alignment.LEFT;
+export function ParagraphElement({ attributes, children, className, defaultAlignment, element, ...props }: Props) {
+    const align = element.align || defaultAlignment;
 
     return (
         <p

--- a/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
@@ -1,4 +1,4 @@
-import type { ParagraphNode } from '@prezly/slate-types';
+import { Alignment, type ParagraphNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
@@ -12,12 +12,14 @@ interface Props extends HTMLAttributes<HTMLParagraphElement> {
 }
 
 export function ParagraphElement({ attributes, children, className, element, ...props }: Props) {
+    const align = element.align || Alignment.LEFT;
+
     return (
         <p
             {...attributes}
             {...props}
             className={classNames(styles.ParagraphElement, className)}
-            style={{ textAlign: element.align }}
+            style={{ textAlign: align }}
         >
             {children}
         </p>

--- a/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
+++ b/packages/slate-editor/src/extensions/paragraphs/components/ParagraphElement.tsx
@@ -1,4 +1,4 @@
-import type { Alignment} from '@prezly/slate-types';
+import { Alignment} from '@prezly/slate-types';
 import { type ParagraphNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
@@ -21,9 +21,21 @@ export function ParagraphElement({ attributes, children, className, defaultAlign
             {...attributes}
             {...props}
             className={classNames(styles.ParagraphElement, className)}
-            style={{ textAlign: align }}
+            style={{ textAlign: getTextAlign(align) }}
         >
             {children}
         </p>
     );
+}
+
+function getTextAlign(align: Alignment) {
+    if (align === Alignment.CENTER) {
+        return 'center';
+    }
+
+    if (align === Alignment.RIGHT) {
+        return 'end';
+    }
+
+    return 'start';
 }

--- a/packages/slate-editor/src/extensions/paragraphs/test-utils.ts
+++ b/packages/slate-editor/src/extensions/paragraphs/test-utils.ts
@@ -1,10 +1,11 @@
 import { withNormalization } from '@prezly/slate-commons';
+import { Alignment } from '@prezly/slate-types';
 import type { Editor } from 'slate';
 
 import { ParagraphsExtension } from './ParagraphsExtension';
 
 function getExtensions() {
-    return [ParagraphsExtension()];
+    return [ParagraphsExtension({ defaultAlignment: Alignment.LEFT })];
 }
 
 export function createParagraphsEditor(input: JSX.Element) {

--- a/packages/slate-editor/src/modules/editor/Editor.tsx
+++ b/packages/slate-editor/src/modules/editor/Editor.tsx
@@ -143,6 +143,7 @@ export const Editor = forwardRef<EditorRef, EditorProps>((props, forwardedRef) =
 
     const extensions = Array.from(
         getEnabledExtensions({
+            align,
             availableWidth,
             onFloatingAddMenuToggle,
             withAllowedBlocks,

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -1,5 +1,6 @@
 import { EditorCommands, type Extension } from '@prezly/slate-commons';
 import { TablesEditor } from '@prezly/slate-tables';
+import type { Alignment} from '@prezly/slate-types';
 import { CalloutNode, isImageNode, isQuoteNode } from '@prezly/slate-types';
 import { Node } from 'slate';
 
@@ -59,6 +60,7 @@ import {
 import type { EditorProps } from './types';
 
 type Parameters = {
+    align: Alignment;
     availableWidth: number;
     onFloatingAddMenuToggle: (show: boolean, trigger: 'input' | 'hotkey') => void;
 } & Pick<
@@ -96,6 +98,7 @@ type Parameters = {
 
 export function* getEnabledExtensions(parameters: Parameters): Generator<Extension> {
     const {
+        align,
         availableWidth,
         onFloatingAddMenuToggle,
         withAllowedBlocks,
@@ -143,7 +146,7 @@ export function* getEnabledExtensions(parameters: Parameters): Generator<Extensi
     yield DecorateSelectionExtension({ decorate: false });
 
     yield FlashNodesExtension();
-    yield ParagraphsExtension();
+    yield ParagraphsExtension({ defaultAlignment: align });
     yield SoftBreakExtension();
     yield InsertBlockHotkeyExtension({
         createDefaultElement: createParagraph,

--- a/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
+++ b/packages/slate-editor/src/modules/editor/getEnabledExtensions.ts
@@ -1,6 +1,6 @@
 import { EditorCommands, type Extension } from '@prezly/slate-commons';
 import { TablesEditor } from '@prezly/slate-tables';
-import type { Alignment} from '@prezly/slate-types';
+import type { Alignment } from '@prezly/slate-types';
 import { CalloutNode, isImageNode, isQuoteNode } from '@prezly/slate-types';
 import { Node } from 'slate';
 

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -1,4 +1,5 @@
 import { Events } from '@prezly/events';
+import { Alignment } from '@prezly/slate-types';
 import { noop } from '@technically/lodash';
 import type { Editor } from 'slate';
 
@@ -16,6 +17,7 @@ export function getAllExtensions() {
     const fetchOembed = createDelayedResolve(oembedInfo);
     return Array.from(
         getEnabledExtensions({
+            align: Alignment.LEFT,
             availableWidth: 1000,
             onFloatingAddMenuToggle: noop,
             withAllowedBlocks: {


### PR DESCRIPTION
Previously, if default alignment was applied to the paragraph (in our case `left`), it would not render the `text-align: left` style property.

This caused a bug in the tables, more specifically table header cell, which by default aligns the text to the center.

The solution is to explicitly render the `text-align` style property even if default alignment is used.