### PR TITLE
[CARE-5666] Fix - Use overflow: auto in tables

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
@@ -103,6 +103,10 @@
         z-index: $editor-block-overlay-z-index - 1;
     }
 
+    &.overflowAuto {
+        overflow: auto;
+    }
+
     &.overflowHidden {
         overflow: hidden;
     }

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.module.scss
@@ -103,18 +103,6 @@
         z-index: $editor-block-overlay-z-index - 1;
     }
 
-    &.overflowAuto {
-        overflow: auto;
-    }
-
-    &.overflowHidden {
-        overflow: hidden;
-    }
-
-    &.overflowVisible {
-        overflow: visible;
-    }
-
     &.editable {
         white-space: pre-wrap;
     }

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -53,7 +53,7 @@ export interface Props
     layout?: `${Layout}`;
     loading?: boolean;
     menuPlacement?: PopperOptionsContextType['placement'];
-    overflow?: 'visible' | 'hidden';
+    overflow?: 'visible' | 'hidden' | 'auto';
     overlay?: OverlayMode;
     renderAboveFrame?: ((props: RenderProps) => ReactNode) | ReactNode;
     renderBelowFrame?: ((props: RenderProps) => ReactNode) | ReactNode;
@@ -203,6 +203,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                         [styles.border]: border,
                         [styles.editable]: Boolean(renderEditableFrame),
                         [styles.hasError]: hasError,
+                        [styles.overflowAuto]: overflow === 'auto',
                         [styles.overflowHidden]: overflow === 'hidden',
                         [styles.overflowVisible]: overflow === 'visible',
                         [styles.selected]: isSelected,

--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -203,14 +203,12 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                         [styles.border]: border,
                         [styles.editable]: Boolean(renderEditableFrame),
                         [styles.hasError]: hasError,
-                        [styles.overflowAuto]: overflow === 'auto',
-                        [styles.overflowHidden]: overflow === 'hidden',
-                        [styles.overflowVisible]: overflow === 'visible',
                         [styles.selected]: isSelected,
                     })}
                     onClick={handleFrameClick}
                     onMouseEnter={() => setIsHovered(true)}
                     onMouseLeave={() => setIsHovered(false)}
+                    style={{ overflow }}
                 >
                     {renderInjectionPoint(renderEditableFrame ?? renderReadOnlyFrame, renderProps)}
                 </div>

--- a/packages/slate-editor/src/extensions/tables/components/elements/TableElement.tsx
+++ b/packages/slate-editor/src/extensions/tables/components/elements/TableElement.tsx
@@ -19,6 +19,7 @@ export function TableElement({ attributes, element, children }: Props) {
         <EditorBlock
             {...attributes} // contains `ref`
             element={element}
+            overflow="auto"
             overlay={false}
             renderMenu={() => <TableMenu element={element} />}
             renderEditableFrame={() => {


### PR DESCRIPTION
Previously the table element was using `overflow: hidden`, now it will use `overflow: auto` showing a scrollbar if needed.

![Screenshot 2024-07-08 at 17 46 54](https://github.com/prezly/slate/assets/4209081/930b9887-6035-4d8a-8bdf-2b7fb5390a38)

