### PR TITLE
[CARE-4614] Fix - Use proper fill for gallery bookmarks

### DIFF
--- a/packages/slate-editor/src/extensions/floating-add-menu/components/Dropdown.module.scss
+++ b/packages/slate-editor/src/extensions/floating-add-menu/components/Dropdown.module.scss
@@ -90,6 +90,7 @@
 
         &[data-action="add_image"],
         &[data-action="add_gallery"],
+        &[data-action="add_gallery_bookmark"],
         &[data-action="add_video"],
         &[data-action="add_attachment"],
         &[data-action="add_embed"],


### PR DESCRIPTION
![Screenshot 2024-07-08 at 18 44 04](https://github.com/prezly/slate/assets/4209081/f2228642-967d-43d6-8a66-5a2ac1ca5e2b)
