### PR TITLE
Mark new paragraph delimiter as void

### DIFF
--- a/packages/slate-editor/src/components/NewParagraphDelimiter/NewParagraphDelimiter.tsx
+++ b/packages/slate-editor/src/components/NewParagraphDelimiter/NewParagraphDelimiter.tsx
@@ -38,6 +38,7 @@ export function NewParagraphDelimiter(props: Props) {
 
     return (
         <div
+            data-slate-void={true}
             data-new-paragraph-delimiter={true}
             data-new-paragraph-delimiter-position={position}
             className={classNames(styles.NewParagraphDelimiter, {


### PR DESCRIPTION
This took me a while to figure out but the problem was that new paragraph delimiter has `contenteditable="false"` so Slate was executing [this compatibility code](https://github.com/ianstormtaylor/slate/blob/5838e36229750863bfe3b499632dd3d92594bbe5/packages/slate-react/src/plugin/react-editor.ts#L982-L984) in Chrome, treating the element like a non-void, but it is in reality a void element.