### PR TITLE
[CARE-4612] Fix - Hide embed option if it's not available

### DIFF
--- a/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkMenu.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkMenu.tsx
@@ -58,7 +58,7 @@ function getPresentationOptions(element: BookmarkNode): OptionsGroupOption<Prese
             value: 'link',
             label: 'Link',
         },
-    ];
+    ].filter(({ disabled }) => !disabled) as OptionsGroupOption<Presentation>[];
 }
 
 export const WebBookmarkMenu: FunctionComponent<Props> = ({


### PR DESCRIPTION
If it's not possible to change to an embed, we hide the option instead of disabling it.

![Screenshot 2024-07-15 at 19 05 38](https://github.com/user-attachments/assets/a1c61874-5eb7-432f-87d4-edd6b2b067c6)
