### PR TITLE
[CARE-4611] Feature - Tweak various element menus

### DIFF
--- a/packages/slate-editor/src/components/Button/Button.module.scss
+++ b/packages/slate-editor/src/components/Button/Button.module.scss
@@ -10,16 +10,12 @@
     cursor: pointer;
     text-decoration: none;
     font-weight: 600;
-    font-size: $font-size-smaller;
+    font-size: $font-size-small;
     color: inherit;
     box-sizing: border-box;
     margin: 0;
     border: $border-size solid transparent;
     padding: $spacing-1 - $border-size;
-
-    &--clear-faded {
-        opacity: 0.5;
-    }
 
     &:not(&.disabled, &:disabled) {
         &:hover,
@@ -130,8 +126,23 @@
         border-radius: 6px;
     }
 
-    &--noPadding {
+    &--tiny {
         padding: 0;
+        font-size: $font-size-smaller;
+
+        .icon-wrapper {
+            width: $spacing-1-5;
+            height: $spacing-1-5;
+        }
+    }
+
+    &--small {
+        padding: $spacing-half $spacing-1;
+
+        .icon-wrapper {
+            width: $spacing-1-5;
+            height: $spacing-1-5;
+        }
     }
 }
 
@@ -140,8 +151,8 @@
 }
 
 .icon-wrapper {
-    width: $spacing-1-5;
-    height: $spacing-1-5;
+    width: $spacing-2;
+    height: $spacing-2;
     color: inherit;
     opacity: 0.8;
 }

--- a/packages/slate-editor/src/components/Button/Button.module.scss
+++ b/packages/slate-editor/src/components/Button/Button.module.scss
@@ -137,7 +137,7 @@
     }
 
     &--small {
-        padding: $spacing-half $spacing-1;
+        padding: $spacing-half;
 
         .icon-wrapper {
             width: $spacing-1-5;

--- a/packages/slate-editor/src/components/Button/Button.stories.tsx
+++ b/packages/slate-editor/src/components/Button/Button.stories.tsx
@@ -80,10 +80,6 @@ export function Variants() {
             </div>
 
             <div>
-                <Button variant="clear-faded">Clear-faded Round</Button>
-            </div>
-
-            <div>
                 <Button variant="underlined">Underlined</Button>
             </div>
         </VStack>

--- a/packages/slate-editor/src/components/Button/Button.tsx
+++ b/packages/slate-editor/src/components/Button/Button.tsx
@@ -6,13 +6,13 @@ import { HStack } from '#components';
 import styles from './Button.module.scss';
 
 interface ButtonBaseProps {
-    variant?: 'primary' | 'secondary' | 'clear' | 'clear-faded' | 'underlined';
+    variant?: 'primary' | 'secondary' | 'clear' | 'underlined';
     icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
     iconPosition?: 'left' | 'right';
     fullWidth?: boolean;
     round?: boolean;
-    noPadding?: boolean;
     disabled?: boolean;
+    size?: 'tiny' | 'small' | 'medium';
 }
 
 interface AsButtonProps extends ButtonBaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -32,9 +32,9 @@ export function Button({
     fullWidth,
     type,
     round,
-    noPadding,
     disabled,
     children,
+    size,
     ...attributes
 }: React.PropsWithChildren<ButtonProps>) {
     const Component = type === 'link' ? 'a' : 'button';
@@ -54,14 +54,14 @@ export function Button({
                   }
                 : attributes.onClick,
             className: classNames(attributes.className, styles.button, {
-                [styles['button--clear']]: variant === 'clear' || variant === 'clear-faded',
-                [styles['button--clear-faded']]: variant === 'clear-faded',
+                [styles['button--clear']]: variant === 'clear',
                 [styles['button--primary']]: variant === 'primary',
                 [styles['button--secondary']]: variant === 'secondary',
                 [styles['button--underlined']]: variant === 'underlined',
                 [styles['button--full-width']]: fullWidth,
                 [styles['button--round']]: round,
-                [styles['button--noPadding']]: noPadding,
+                [styles['button--tiny']]: size === 'tiny',
+                [styles['button--small']]: size === 'small',
                 [styles['disabled']]: disabled,
             }),
             type: type !== 'link' ? type : undefined,

--- a/packages/slate-editor/src/components/Toolbox/Caption.tsx
+++ b/packages/slate-editor/src/components/Toolbox/Caption.tsx
@@ -1,7 +1,21 @@
+import classNames from 'classnames';
 import * as React from 'react';
 
 import styles from './Toolbox.module.scss';
 
-export function Caption(props: React.PropsWithChildren<Record<string, unknown>>) {
-    return <span className={styles.caption}>{props.children}</span>;
+type Props = {
+    children: React.ReactNode;
+    withFullOpacity?: boolean;
+};
+
+export function Caption({ children, withFullOpacity = false }: Props) {
+    return (
+        <span
+            className={classNames(styles.caption, {
+                [styles['caption--full-opacity']]: withFullOpacity,
+            })}
+        >
+            {children}
+        </span>
+    );
 }

--- a/packages/slate-editor/src/components/Toolbox/Header.tsx
+++ b/packages/slate-editor/src/components/Toolbox/Header.tsx
@@ -17,7 +17,13 @@ export function Header(props: React.PropsWithChildren<HeaderProps>) {
             <Caption withFullOpacity>{props.children}</Caption>
 
             {props.withCloseButton && (
-                <Button variant="clear" icon={Cross} onClick={props.onCloseClick} round />
+                <Button
+                    variant="clear"
+                    icon={Cross}
+                    onClick={props.onCloseClick}
+                    round
+                    size="small"
+                />
             )}
         </div>
     );

--- a/packages/slate-editor/src/components/Toolbox/Header.tsx
+++ b/packages/slate-editor/src/components/Toolbox/Header.tsx
@@ -14,7 +14,7 @@ interface HeaderProps {
 export function Header(props: React.PropsWithChildren<HeaderProps>) {
     return (
         <div className={styles.header}>
-            <Caption>{props.children}</Caption>
+            <Caption withFullOpacity>{props.children}</Caption>
 
             {props.withCloseButton && (
                 <Button variant="clear" icon={Cross} onClick={props.onCloseClick} round />

--- a/packages/slate-editor/src/components/Toolbox/Toolbox.module.scss
+++ b/packages/slate-editor/src/components/Toolbox/Toolbox.module.scss
@@ -5,6 +5,10 @@
     font-size: $font-size-small;
     font-weight: 600;
     opacity: 0.9;
+
+    &--full-opacity {
+        opacity: 1;
+    }
 }
 
 .header {
@@ -12,8 +16,7 @@
     justify-content: space-between;
     align-items: center;
     overflow: hidden;
-    padding: $spacing-1-5 $spacing-1;
-    padding-left: $spacing-2;
+    padding: $spacing-2;
     color: $white;
 }
 

--- a/packages/slate-editor/src/components/Toolbox/Toolbox.stories.tsx
+++ b/packages/slate-editor/src/components/Toolbox/Toolbox.stories.tsx
@@ -87,8 +87,8 @@ export function WebBookmark() {
                 </Toolbox.Section>
 
                 <Toolbox.Footer>
-                    <Button variant="clear-faded" icon={Delete} fullWidth>
-                        Remove web bookmark
+                    <Button variant="clear" icon={Delete} fullWidth>
+                        Remove
                     </Button>
                 </Toolbox.Footer>
             </Toolbox.Panel>
@@ -263,8 +263,8 @@ export function GallerySettings() {
                 </Toolbox.Section>
 
                 <Toolbox.Footer>
-                    <Button variant="clear-faded" icon={Delete} fullWidth>
-                        Remove gallery
+                    <Button variant="clear" icon={Delete} fullWidth>
+                        Remove
                     </Button>
                 </Toolbox.Footer>
             </Toolbox.Panel>
@@ -295,8 +295,8 @@ export function AttachmentSettings() {
                 </Toolbox.Section>
 
                 <Toolbox.Footer>
-                    <Button variant="clear-faded" icon={Delete} fullWidth>
-                        Remove attachment
+                    <Button variant="clear" icon={Delete} fullWidth>
+                        Remove
                     </Button>
                 </Toolbox.Footer>
             </Toolbox.Panel>
@@ -370,8 +370,8 @@ export function CoverageCard() {
                 </Toolbox.Section>
 
                 <Toolbox.Footer>
-                    <Button variant="clear-faded" icon={Delete} fullWidth>
-                        Remove web bookmark
+                    <Button variant="clear" icon={Delete} fullWidth>
+                        Remove
                     </Button>
                 </Toolbox.Footer>
             </Toolbox.Panel>
@@ -477,8 +477,8 @@ export function ImageSettings() {
                 </Toolbox.Section>
 
                 <Toolbox.Footer>
-                    <Button variant="clear-faded" icon={Delete} fullWidth>
-                        Remove image
+                    <Button variant="clear" icon={Delete} fullWidth>
+                        Remove
                     </Button>
                 </Toolbox.Footer>
             </Toolbox.Panel>

--- a/packages/slate-editor/src/extensions/embed/components/EmbedMenu.tsx
+++ b/packages/slate-editor/src/extensions/embed/components/EmbedMenu.tsx
@@ -90,20 +90,6 @@ export function EmbedMenu({
         <>
             <Toolbox.Header>Embed settings</Toolbox.Header>
 
-            <Toolbox.Section noPadding>
-                <Button
-                    type="link"
-                    href={url}
-                    target="_blank"
-                    rel="noreferrer"
-                    icon={ExternalLink}
-                    iconPosition="right"
-                    fullWidth
-                >
-                    View
-                </Button>
-            </Toolbox.Section>
-
             {info.length > 0 && (
                 <Toolbox.Section>
                     <InfoText.Structured className={styles.Info}>{info}</InfoText.Structured>
@@ -135,9 +121,23 @@ export function EmbedMenu({
                 </Toolbox.Section>
             )}
 
+            <Toolbox.Section noPadding>
+                <Button
+                    type="link"
+                    href={url}
+                    target="_blank"
+                    rel="noreferrer"
+                    icon={ExternalLink}
+                    iconPosition="right"
+                    fullWidth
+                >
+                    View embed
+                </Button>
+            </Toolbox.Section>
+
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={onRemove}>
-                    Remove embed
+                <Button variant="clear" icon={Delete} fullWidth onClick={onRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/extensions/file-attachment/components/FileAttachmentMenu.tsx
+++ b/packages/slate-editor/src/extensions/file-attachment/components/FileAttachmentMenu.tsx
@@ -81,6 +81,7 @@ export function FileAttachmentMenu({ element, onEdited, onRemoved }: Props) {
                         variant="primary"
                         fullWidth
                         round
+                        size="small"
                         onClick={handleUpdate}
                         disabled={!isFilenameValid}
                     >
@@ -90,8 +91,8 @@ export function FileAttachmentMenu({ element, onEdited, onRemoved }: Props) {
             </Toolbox.Section>
 
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={handleRemove}>
-                    Remove attachment
+                <Button variant="clear" icon={Delete} fullWidth onClick={handleRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </Toolbox.Panel>

--- a/packages/slate-editor/src/extensions/galleries/components/GalleryMenu.tsx
+++ b/packages/slate-editor/src/extensions/galleries/components/GalleryMenu.tsx
@@ -3,7 +3,7 @@ import { GalleryImageSize, GalleryLayout, GalleryPadding } from '@prezly/slate-t
 import React from 'react';
 
 import type { OptionsGroupOption } from '#components';
-import { Button, ButtonGroup, InfoText, OptionsGroup, Toolbox } from '#components';
+import { Button, ButtonGroup, OptionsGroup, Toolbox } from '#components';
 import {
     Add,
     Delete,
@@ -109,12 +109,6 @@ export function GalleryMenu({
                 </ButtonGroup>
             </Toolbox.Section>
 
-            <Toolbox.Section>
-                <InfoText>
-                    Reorder, delete, crop and set image captions in the main image grid.
-                </InfoText>
-            </Toolbox.Section>
-
             {withLayoutOptions && (
                 <Toolbox.Section caption="Gallery width">
                     <OptionsGroup<GalleryLayout>
@@ -146,8 +140,8 @@ export function GalleryMenu({
             </Toolbox.Section>
 
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={onDelete}>
-                    Remove gallery
+                <Button variant="clear" icon={Delete} fullWidth onClick={onDelete}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/extensions/image/components/ImageMenu.tsx
+++ b/packages/slate-editor/src/extensions/image/components/ImageMenu.tsx
@@ -162,7 +162,7 @@ export function ImageMenu({
             </Toolbox.Section>
 
             {withLayoutOptions && (
-                <Toolbox.Section caption="Image size">
+                <Toolbox.Section caption="Size">
                     <OptionsGroup
                         name="layout"
                         options={IMAGE_LAYOUT_OPTIONS}
@@ -177,7 +177,7 @@ export function ImageMenu({
             )}
 
             {withSizeOptions && (
-                <Toolbox.Section caption="Image size">
+                <Toolbox.Section caption="Size">
                     <OptionsGroup
                         name="width"
                         options={getAvailableSizeOptions(withSizeOptions)}
@@ -190,7 +190,7 @@ export function ImageMenu({
             )}
 
             {withAlignmentOptions && (
-                <Toolbox.Section caption="Image alignment" paddingBottom="3">
+                <Toolbox.Section caption="Alignment" paddingBottom="3">
                     <OptionsGroup
                         disabled={value.layout !== ImageLayout.CONTAINED}
                         name="align"
@@ -231,8 +231,8 @@ export function ImageMenu({
             </Toolbox.Section>
 
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={onRemove}>
-                    Remove image
+                <Button variant="clear" icon={Delete} fullWidth onClick={onRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/extensions/inline-contacts/components/InlineContactMenu.tsx
+++ b/packages/slate-editor/src/extensions/inline-contacts/components/InlineContactMenu.tsx
@@ -37,8 +37,8 @@ function EditButton(props: { onClick: () => void }) {
 
 function RemoveButton(props: { onClick: () => void }) {
     return (
-        <Button variant="clear-faded" icon={Delete} fullWidth onClick={props.onClick}>
-            Remove contact
+        <Button variant="clear" icon={Delete} fullWidth onClick={props.onClick}>
+            Remove
         </Button>
     );
 }

--- a/packages/slate-editor/src/extensions/press-contacts/components/PressContactMenu.tsx
+++ b/packages/slate-editor/src/extensions/press-contacts/components/PressContactMenu.tsx
@@ -61,7 +61,7 @@ export function PressContactMenu({ element, onChangeLayout, onRemove, onToggleAv
 
 function RemoveButton(props: { onClick: () => void }) {
     return (
-        <Button variant="clear-faded" icon={Delete} fullWidth onClick={props.onClick}>
+        <Button variant="clear" icon={Delete} fullWidth onClick={props.onClick}>
             Remove
         </Button>
     );

--- a/packages/slate-editor/src/extensions/story-bookmark/components/StoryBookmarkMenu.tsx
+++ b/packages/slate-editor/src/extensions/story-bookmark/components/StoryBookmarkMenu.tsx
@@ -54,39 +54,6 @@ export function StoryBookmarkMenu({
         <>
             <Toolbox.Header>Story bookmark settings</Toolbox.Header>
 
-            <Toolbox.Section noPadding>
-                <ButtonGroup>
-                    {[
-                        <Button
-                            type="link"
-                            key="edit"
-                            variant="clear"
-                            icon={ExternalLink}
-                            iconPosition="right"
-                            fullWidth
-                            target="_blank"
-                            disabled={!editUrl}
-                            href={editUrl ?? 'javascript:void(0)'}
-                        >
-                            Edit
-                        </Button>,
-                        <Button
-                            type="link"
-                            key="preview"
-                            variant="clear"
-                            icon={ExternalLink}
-                            iconPosition="right"
-                            fullWidth
-                            target="_blank"
-                            disabled={!previewUrl}
-                            href={previewUrl ?? 'javascript:void(0)'}
-                        >
-                            Preview
-                        </Button>,
-                    ]}
-                </ButtonGroup>
-            </Toolbox.Section>
-
             <Toolbox.Section caption="Preview image">
                 <Toggle
                     name="show_preview"
@@ -121,9 +88,42 @@ export function StoryBookmarkMenu({
                 </VStack>
             </Toolbox.Section>
 
+            <Toolbox.Section noPadding>
+                <ButtonGroup>
+                    {[
+                        <Button
+                            type="link"
+                            key="edit"
+                            variant="clear"
+                            icon={ExternalLink}
+                            iconPosition="right"
+                            fullWidth
+                            target="_blank"
+                            disabled={!editUrl}
+                            href={editUrl ?? 'javascript:void(0)'}
+                        >
+                            Edit story
+                        </Button>,
+                        <Button
+                            type="link"
+                            key="preview"
+                            variant="clear"
+                            icon={ExternalLink}
+                            iconPosition="right"
+                            fullWidth
+                            target="_blank"
+                            disabled={!previewUrl}
+                            href={previewUrl ?? 'javascript:void(0)'}
+                        >
+                            View story
+                        </Button>,
+                    ]}
+                </ButtonGroup>
+            </Toolbox.Section>
+
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={onRemove}>
-                    Remove Story bookmark
+                <Button variant="clear" icon={Delete} fullWidth onClick={onRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
+++ b/packages/slate-editor/src/extensions/tables/components/TableMenu.tsx
@@ -54,7 +54,7 @@ export function TableMenu({ element }: Props) {
                         variant="primary"
                         fullWidth
                         round
-                        noPadding
+                        size="tiny"
                         onClick={() => {
                             TablesEditor.insertRowAbove(editor);
                             EventsEditor.dispatchEvent(editor, 'table-insert-row-above');
@@ -67,7 +67,7 @@ export function TableMenu({ element }: Props) {
                         variant="primary"
                         fullWidth
                         round
-                        noPadding
+                        size="tiny"
                         onClick={() => {
                             TablesEditor.insertRowBelow(editor);
                             EventsEditor.dispatchEvent(editor, 'table-insert-row-below');
@@ -79,6 +79,7 @@ export function TableMenu({ element }: Props) {
                         icon={Delete}
                         variant="primary"
                         round
+                        size="small"
                         onClick={() => {
                             TablesEditor.removeRow(editor);
                             EventsEditor.dispatchEvent(editor, 'table-remove-row');
@@ -94,7 +95,7 @@ export function TableMenu({ element }: Props) {
                         variant="primary"
                         fullWidth
                         round
-                        noPadding
+                        size="tiny"
                         onClick={() => {
                             TablesEditor.insertColumnLeft(editor);
                             EventsEditor.dispatchEvent(editor, 'table-insert-column-left');
@@ -107,7 +108,7 @@ export function TableMenu({ element }: Props) {
                         variant="primary"
                         fullWidth
                         round
-                        noPadding
+                        size="tiny"
                         onClick={() => {
                             TablesEditor.insertColumnRight(editor);
                             EventsEditor.dispatchEvent(editor, 'table-insert-column-right');
@@ -119,6 +120,7 @@ export function TableMenu({ element }: Props) {
                         icon={Delete}
                         variant="primary"
                         round
+                        size="small"
                         onClick={() => {
                             TablesEditor.removeColumn(editor);
                             EventsEditor.dispatchEvent(editor, 'table-remove-column');
@@ -129,7 +131,7 @@ export function TableMenu({ element }: Props) {
 
             <Toolbox.Footer>
                 <Button
-                    variant="clear-faded"
+                    variant="clear"
                     icon={Delete}
                     fullWidth
                     onClick={() => {
@@ -137,7 +139,7 @@ export function TableMenu({ element }: Props) {
                         EventsEditor.dispatchEvent(editor, 'table-remove');
                     }}
                 >
-                    Remove table
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </Toolbox.Panel>

--- a/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
+++ b/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
@@ -142,8 +142,8 @@ export function VideoMenu({
             )}
 
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onClick={onRemove}>
-                    Remove video
+                <Button variant="clear" icon={Delete} fullWidth onClick={onRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
+++ b/packages/slate-editor/src/extensions/video/components/VideoMenu.tsx
@@ -94,22 +94,6 @@ export function VideoMenu({
         <>
             <Toolbox.Header>Video settings</Toolbox.Header>
 
-            {!isSelfHosted && (
-                <Toolbox.Section noPadding>
-                    <Button
-                        type="link"
-                        href={url}
-                        target="_blank"
-                        rel="noreferrer"
-                        icon={ExternalLink}
-                        iconPosition="right"
-                        fullWidth
-                    >
-                        Go to video
-                    </Button>
-                </Toolbox.Section>
-            )}
-
             {info.length > 0 && (
                 <Toolbox.Section>
                     <InfoText.Structured className={styles.Info}>{info}</InfoText.Structured>
@@ -138,6 +122,22 @@ export function VideoMenu({
                         onChange={onConvert}
                         variant="pills"
                     />
+                </Toolbox.Section>
+            )}
+
+            {!isSelfHosted && (
+                <Toolbox.Section noPadding>
+                    <Button
+                        type="link"
+                        href={url}
+                        target="_blank"
+                        rel="noreferrer"
+                        icon={ExternalLink}
+                        iconPosition="right"
+                        fullWidth
+                    >
+                        View video
+                    </Button>
                 </Toolbox.Section>
             )}
 

--- a/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkMenu.tsx
+++ b/packages/slate-editor/src/extensions/web-bookmark/components/WebBookmarkMenu.tsx
@@ -91,20 +91,6 @@ export const WebBookmarkMenu: FunctionComponent<Props> = ({
         <>
             <Toolbox.Header>Web bookmark settings</Toolbox.Header>
 
-            <Toolbox.Section noPadding>
-                <Button
-                    type="link"
-                    href={element.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    icon={ExternalLink}
-                    iconPosition="right"
-                    fullWidth
-                >
-                    View
-                </Button>
-            </Toolbox.Section>
-
             <Toolbox.Section caption="Preview image">
                 <Toggle
                     disabled={!element.oembed.thumbnail_url}
@@ -150,9 +136,23 @@ export const WebBookmarkMenu: FunctionComponent<Props> = ({
                 </Toolbox.Section>
             )}
 
+            <Toolbox.Section noPadding>
+                <Button
+                    type="link"
+                    href={element.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    icon={ExternalLink}
+                    iconPosition="right"
+                    fullWidth
+                >
+                    View website
+                </Button>
+            </Toolbox.Section>
+
             <Toolbox.Footer>
-                <Button variant="clear-faded" icon={Delete} fullWidth onMouseDown={handleRemove}>
-                    Remove web bookmark
+                <Button variant="clear" icon={Delete} fullWidth onMouseDown={handleRemove}>
+                    Remove
                 </Button>
             </Toolbox.Footer>
         </>

--- a/packages/slate-editor/src/modules/rich-formatting-menu/LinkMenu.tsx
+++ b/packages/slate-editor/src/modules/rich-formatting-menu/LinkMenu.tsx
@@ -115,7 +115,7 @@ export function LinkMenu({
             </form>
             <Toolbox.Footer>
                 <Button
-                    variant="clear-faded"
+                    variant="clear"
                     icon={Delete}
                     fullWidth
                     disabled={!canUnlink}


### PR DESCRIPTION
- toolbox header now uses full opacity
- default (medium) button size changed to 14 px
  - introduced "small" and "tiny" sizes
  - removed `noPadding` variant
- "Remove X" changed to simply "Remove"
- various edit/view links shuffled to the bottom, above the "Remove" button