### PR TITLE
[DEV-13254] Implement settings menu for variables with optional fallback

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/getMenuPopperModifiers.ts
+++ b/packages/slate-editor/src/components/EditorBlock/getMenuPopperModifiers.ts
@@ -71,6 +71,7 @@ export function getMenuPopperModifiers(
             enabled: true,
             options: {
                 padding: 19,
+                ...modifiers?.arrow,
             },
         } satisfies Partial<ArrowModifier>,
         {

--- a/packages/slate-editor/src/components/EditorBlock/index.ts
+++ b/packages/slate-editor/src/components/EditorBlock/index.ts
@@ -1,3 +1,4 @@
 export { CloseButton } from './CloseButton';
 export { EditorBlock } from './EditorBlock';
+export { Menu } from './Menu';
 export { ResizableEditorBlock } from './ResizableEditorBlock';

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -15,17 +15,28 @@
         .DropdownToggle {
             border-radius: $border-radius-base;
 
+            &[data-headlessui-state="open"] {
+                border-bottom-left-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+
             &.enabled,
             &.enabled:hover {
                 color: $black;
                 background-color: $white;
             }
+
+            &.enabled .Caret {
+                color: $black;
+            }
         }
 
         .DropdownMenu {
             width: 100%;
-            background-color: $white;
             margin: 0;
+            background-color: $white;
+            border-top: 1px solid $grey-200;
+            box-shadow: none;
         }
 
         .MenuItem {

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -35,7 +35,7 @@
             width: 100%;
             margin: 0;
             background-color: $white;
-            border-top: 1px solid $grey-200;
+            border: 1px solid $grey-200;
             box-shadow: none;
         }
 

--- a/packages/slate-editor/src/components/Menu/Dropdown.module.scss
+++ b/packages/slate-editor/src/components/Menu/Dropdown.module.scss
@@ -11,6 +11,41 @@
         width: 180px;
     }
 
+    &.light {
+        .DropdownToggle {
+            border-radius: $border-radius-base;
+
+            &.enabled,
+            &.enabled:hover {
+                color: $black;
+                background-color: $white;
+            }
+        }
+
+        .DropdownMenu {
+            width: 100%;
+            background-color: $white;
+            margin: 0;
+        }
+
+        .MenuItem {
+            color: $black;
+
+            &.selected,
+            &.active {
+                color: $black;
+
+                &::before {
+                    background-color: $grey-200;
+                }
+            }
+
+            &.active:not(.selected) {
+                color: $black;
+            }
+        }
+    }
+
     &:last-child {
         border-right: none;
     }
@@ -83,6 +118,7 @@
         background-color: $toolbar-dark-theme-bg;
         border-radius: 0 0 $toolbar-dark-theme-border-radius $toolbar-dark-theme-border-radius;
         box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.11), inset 0 1px 0 $toolbar-dark-theme-border-color;
+        z-index: 2;
     }
 
     .MenuItem {

--- a/packages/slate-editor/src/components/Menu/Dropdown.tsx
+++ b/packages/slate-editor/src/components/Menu/Dropdown.tsx
@@ -21,6 +21,7 @@ export namespace Dropdown {
         disabled?: boolean;
         renderOption?: ComponentType<{ option: Option<Value>; selected: boolean }>;
         value?: Value;
+        variant?: 'dark' | 'light';
         className?: string;
     }
 }
@@ -32,6 +33,7 @@ export function Dropdown<Value extends string = string>({
     disabled = false,
     renderOption = PlainLabel,
     value,
+    variant = 'dark',
     ...props
 }: Dropdown.Props<Value>): ReturnType<FunctionComponent<Dropdown.Props<Value>>> {
     const RenderOption = renderOption;
@@ -50,6 +52,7 @@ export function Dropdown<Value extends string = string>({
         <Listbox
             className={classNames(styles.Dropdown, className, {
                 [styles.enabled]: !disabled,
+                [styles.light]: variant === 'light',
             })}
             as="div"
             {...props}

--- a/packages/slate-editor/src/components/Toolbox/Caption.tsx
+++ b/packages/slate-editor/src/components/Toolbox/Caption.tsx
@@ -5,13 +5,14 @@ import styles from './Toolbox.module.scss';
 
 type Props = {
     children: React.ReactNode;
+    className?: string;
     withFullOpacity?: boolean;
 };
 
-export function Caption({ children, withFullOpacity = false }: Props) {
+export function Caption({ children, className, withFullOpacity = false }: Props) {
     return (
         <span
-            className={classNames(styles.caption, {
+            className={classNames(styles.caption, className, {
                 [styles['caption--full-opacity']]: withFullOpacity,
             })}
         >

--- a/packages/slate-editor/src/extensions/mentions/lib/insertMention.test.tsx
+++ b/packages/slate-editor/src/extensions/mentions/lib/insertMention.test.tsx
@@ -37,7 +37,7 @@ describe('insertMention', () => {
             </editor>
         ) as unknown as Editor;
 
-        insertMention(editor, createPlaceholderMentionElement(placeholderKey));
+        insertMention(editor, createPlaceholderMentionElement(placeholderKey), true);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -71,7 +71,7 @@ describe('insertMention', () => {
             </editor>
         ) as unknown as Editor;
 
-        insertMention(editor, createPlaceholderMentionElement(placeholderKey));
+        insertMention(editor, createPlaceholderMentionElement(placeholderKey), true);
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-editor/src/extensions/mentions/lib/insertMention.test.tsx
+++ b/packages/slate-editor/src/extensions/mentions/lib/insertMention.test.tsx
@@ -37,7 +37,7 @@ describe('insertMention', () => {
             </editor>
         ) as unknown as Editor;
 
-        insertMention(editor, createPlaceholderMentionElement(placeholderKey), true);
+        insertMention(editor, createPlaceholderMentionElement(placeholderKey));
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);
@@ -71,7 +71,7 @@ describe('insertMention', () => {
             </editor>
         ) as unknown as Editor;
 
-        insertMention(editor, createPlaceholderMentionElement(placeholderKey), true);
+        insertMention(editor, createPlaceholderMentionElement(placeholderKey));
 
         expect(editor.children).toEqual(expected.children);
         expect(editor.selection).toEqual(expected.selection);

--- a/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
+++ b/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
@@ -6,7 +6,7 @@ import type { MentionElementType } from '../types';
 export function insertMention(
     editor: Editor,
     element: MentionElementType,
-    moveCursorAfterInsert: boolean,
+    moveCursorAfterInsert = true,
 ) {
     Transforms.insertNodes(editor, element);
 

--- a/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
+++ b/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
@@ -3,7 +3,10 @@ import { Transforms } from 'slate';
 
 import type { MentionElementType } from '../types';
 
-export function insertMention(editor: Editor, element: MentionElementType) {
+export function insertMention(editor: Editor, element: MentionElementType, moveCursorAfterInsert: boolean) {
     Transforms.insertNodes(editor, element);
-    Transforms.move(editor, { distance: 1, unit: 'offset' });
+
+    if (moveCursorAfterInsert) {
+        Transforms.move(editor, { distance: 1, unit: 'offset' });
+    }
 }

--- a/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
+++ b/packages/slate-editor/src/extensions/mentions/lib/insertMention.ts
@@ -3,7 +3,11 @@ import { Transforms } from 'slate';
 
 import type { MentionElementType } from '../types';
 
-export function insertMention(editor: Editor, element: MentionElementType, moveCursorAfterInsert: boolean) {
+export function insertMention(
+    editor: Editor,
+    element: MentionElementType,
+    moveCursorAfterInsert: boolean,
+) {
     Transforms.insertNodes(editor, element);
 
     if (moveCursorAfterInsert) {

--- a/packages/slate-editor/src/extensions/mentions/useMentions.ts
+++ b/packages/slate-editor/src/extensions/mentions/useMentions.ts
@@ -11,6 +11,7 @@ import type { MentionElementType, Option } from './types';
 interface Parameters<V> {
     createMentionElement: (option: Option<V>) => MentionElementType;
     isEnabled?: (target: Range | null) => boolean;
+    moveCursorAfterInsert?: boolean;
     options: Option<V>[];
     trigger: string;
 }
@@ -28,6 +29,7 @@ export interface Mentions<V> {
 export function useMentions<V>({
     createMentionElement,
     isEnabled = stubTrue,
+    moveCursorAfterInsert = true,
     options,
     trigger,
 }: Parameters<V>): Mentions<V> {
@@ -44,7 +46,7 @@ export function useMentions<V>({
             if (target) {
                 Transforms.select(editor, target);
                 const mentionElement = createMentionElement(option);
-                insertMention(editor, mentionElement);
+                insertMention(editor, mentionElement, moveCursorAfterInsert);
                 setTarget(null);
             }
         },

--- a/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
@@ -8,8 +8,8 @@
      *
      * Also, it's not possible to drag a node when it's selectable.
      *
-     * see: https://app.clubhouse.io/prezly/story/19824/weird-selection-after-editing-an-attachment-or-image-or-gallery
-     * see: https://app.clubhouse.io/prezly/story/20456/error-cannot-resolve-a-dom-node-from-slate-node-text
+     * see: https://github.com/prezly/clubhouse-archive/blob/master/archive/stories/19824.md
+     * see: https://github.com/prezly/clubhouse-archive/blob/master/archive/stories/20456.md
      */
     user-select: none;
 

--- a/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
@@ -31,3 +31,19 @@
 .Dropdown {
     width: 100% !important;
 }
+
+.Caption {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .Icon {
+        display: flex;
+        align-items: center;
+
+        > svg {
+            width: 16px;
+            height: 16px;
+        }
+    }
+}

--- a/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
@@ -1,0 +1,33 @@
+@import "styles/helpers";
+@import "styles/variables";
+
+.VariableElement {
+    /*
+     * Selection in Slate 0.50+ does not work as expected if a void block is selectable.
+     * It could lead to an error when Slate is resolving the node which crashes the editor.
+     *
+     * Also, it's not possible to drag a node when it's selectable.
+     *
+     * see: https://app.clubhouse.io/prezly/story/19824/weird-selection-after-editing-an-attachment-or-image-or-gallery
+     * see: https://app.clubhouse.io/prezly/story/20456/error-cannot-resolve-a-dom-node-from-slate-node-text
+     */
+    user-select: none;
+
+    padding: 0 2px;
+    background-color: $legacy-alert-info-bg;
+    border: 1px solid $legacy-alert-info-border;
+    border-radius: 3px;
+    color: darken($legacy-alert-info-text, 5%);
+
+    &:hover {
+        color: #004492;
+    }
+
+    &.selected {
+        border-color: #004492;
+    }
+}
+
+.Dropdown {
+    width: 100% !important;
+}

--- a/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.module.scss
@@ -27,23 +27,3 @@
         border-color: #004492;
     }
 }
-
-.Dropdown {
-    width: 100% !important;
-}
-
-.Caption {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
-    .Icon {
-        display: flex;
-        align-items: center;
-
-        > svg {
-            width: 16px;
-            height: 16px;
-        }
-    }
-}

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -43,6 +43,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
 
     function handleSave() {
         updateVariable(editor, { fallback: fallback !== '' ? fallback : null });
+        handleCloseMenu();
     }
 
     function handleRemove() {

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -7,6 +7,8 @@ import { useSelected, useSlateStatic } from 'slate-react';
 import { Button, Input, Menu as BaseMenu, Toolbox, VStack } from '#components';
 import { Delete } from '#icons';
 
+import { usePopperOptionsContext } from '#modules/popper-options-context';
+
 import { Menu } from '../../components/EditorBlock';
 
 import { removeVariable, updateVariable } from './transforms';
@@ -21,6 +23,7 @@ interface Props extends RenderElementProps {
 export function VariableElement({ attributes, children, element, variables }: Props) {
     const selected = useSelected();
     const editor = useSlateStatic();
+    const popperOptions = usePopperOptionsContext();
 
     const [fallback, setFallback] = useState<string>(element.fallback ?? '');
     const [container, setContainer] = useState<HTMLSpanElement | null>(null);
@@ -64,7 +67,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
         <>
             {selected && isOnlyVariableSelected && container && (
                 <Menu
-                    popperOptions={{ modifiers: { arrow: { padding: 0 } } }}
+                    popperOptions={{ ...popperOptions, modifiers: { arrow: { padding: 0 } } }}
                     reference={container}
                 >
                     <Toolbox.Header>Variable settings</Toolbox.Header>

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -71,7 +71,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                     reference={container}
                 >
                     <Toolbox.Header onCloseClick={handleCloseMenu} withCloseButton>
-                        Dynamic field settings
+                        Variable settings
                     </Toolbox.Header>
                     <Toolbox.Section>
                         <VStack spacing="2">

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -1,19 +1,12 @@
 import { isVariableNode, type VariableNode } from '@prezly/slate-types';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { RenderElementProps } from 'slate-react';
 import { useSelected, useSlateStatic } from 'slate-react';
 
-import { Button, Input, Menu as BaseMenu, Toolbox, VStack, TooltipV2 } from '#components';
-import { Delete, Info } from '#icons';
-
-import { usePopperOptionsContext } from '#modules/popper-options-context';
-
-import { Menu } from '../../components/EditorBlock';
-
-import { removeVariable, updateVariable } from './transforms';
 import type { Variable } from './types';
 import styles from './VariableElement.module.scss';
+import { VariableMenu } from './VariableMenu';
 
 interface Props extends RenderElementProps {
     element: VariableNode;
@@ -23,128 +16,18 @@ interface Props extends RenderElementProps {
 export function VariableElement({ attributes, children, element, variables }: Props) {
     const selected = useSelected();
     const editor = useSlateStatic();
-    const popperOptions = usePopperOptionsContext();
 
-    const [fallback, setFallback] = useState<string>(element.fallback ?? '');
     const [container, setContainer] = useState<HTMLSpanElement | null>(null);
 
+    const variable = variables.find(({ key }) => key === element.key);
     const selectedNodes = Array.from(editor.nodes({ mode: 'lowest' }));
     const isOnlyVariableSelected =
         selectedNodes.length === 1 && selectedNodes.every(([node]) => isVariableNode(node));
 
-    const options = variables.map((variable) => ({
-        value: variable.key,
-        label: variable.text,
-        withFallback: variable.withFallback,
-    }));
-    const option = options.find(({ value }) => value === element.key);
-
-    function handleChangeType(newType: string) {
-        updateVariable(editor, { key: newType });
-    }
-
-    function handleSave() {
-        updateVariable(editor, { fallback: fallback !== '' ? fallback : null });
-    }
-
-    function handleRemove() {
-        removeVariable(editor);
-    }
-
-    useEffect(() => {
-        if (selected) {
-            setFallback(element.fallback ?? '');
-        }
-    }, [selected]);
-
-    useEffect(() => {
-        if (!option?.withFallback) {
-            updateVariable(editor, { fallback: null });
-        }
-    }, [option?.withFallback]);
-
     return (
         <>
             {selected && isOnlyVariableSelected && container && (
-                <Menu
-                    popperOptions={{ ...popperOptions, modifiers: { arrow: { padding: 0 } } }}
-                    reference={container}
-                >
-                    <Toolbox.Header>Variable settings</Toolbox.Header>
-                    {options.length > 1 && (
-                        <Toolbox.Section>
-                            <VStack spacing="2">
-                                <Toolbox.Caption>Type</Toolbox.Caption>
-                                <BaseMenu.Dropdown
-                                    className={styles.Dropdown}
-                                    onChange={handleChangeType}
-                                    options={options}
-                                    value={element.key}
-                                    variant="light"
-                                />
-                            </VStack>
-                        </Toolbox.Section>
-                    )}
-                    {option?.withFallback && (
-                        <form
-                            onSubmit={(event) => {
-                                event.preventDefault();
-                                handleSave();
-                            }}
-                        >
-                            <Toolbox.Section>
-                                <VStack spacing="2">
-                                    <Toolbox.Caption className={styles.Caption}>
-                                        Fallback
-                                        <TooltipV2.Tooltip
-                                            tooltip={`This text will be used if '${option.label}' is not available.`}
-                                        >
-                                            {({
-                                                ariaAttributes,
-                                                onHide,
-                                                onShow,
-                                                setReferenceElement,
-                                            }) => (
-                                                <span
-                                                    {...ariaAttributes}
-                                                    ref={setReferenceElement}
-                                                    onFocus={onShow}
-                                                    onBlur={onHide}
-                                                    onMouseEnter={onShow}
-                                                    onMouseLeave={onHide}
-                                                    className={styles.Icon}
-                                                >
-                                                    <Info />
-                                                </span>
-                                            )}
-                                        </TooltipV2.Tooltip>
-                                    </Toolbox.Caption>
-                                    <Input
-                                        name="fallback"
-                                        value={fallback}
-                                        onChange={setFallback}
-                                        placeholder="Define your fallback"
-                                    />
-                                    <Button
-                                        disabled={fallback === element.fallback}
-                                        variant="primary"
-                                        type="submit"
-                                        size="small"
-                                        fullWidth
-                                        round
-                                    >
-                                        Save
-                                    </Button>
-                                </VStack>
-                            </Toolbox.Section>
-                        </form>
-                    )}
-                    <Toolbox.Footer>
-                        <Button variant="clear" icon={Delete} fullWidth onClick={handleRemove}>
-                            Remove
-                        </Button>
-                    </Toolbox.Footer>
-                </Menu>
+                <VariableMenu container={container} element={element} variables={variables} />
             )}
             <span
                 {...attributes}
@@ -156,7 +39,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                     attributes.ref(ref);
                 }}
             >
-                {option?.label}
+                {variable?.text}
                 {element.fallback && ` or "${element.fallback}"`}
                 {children}
             </span>

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -71,18 +71,20 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                     reference={container}
                 >
                     <Toolbox.Header>Variable settings</Toolbox.Header>
-                    <Toolbox.Section>
-                        <VStack spacing="2">
-                            <Toolbox.Caption>Type</Toolbox.Caption>
-                            <BaseMenu.Dropdown
-                                className={styles.Dropdown}
-                                onChange={handleChangeType}
-                                options={options}
-                                value={element.key}
-                                variant="light"
-                            />
-                        </VStack>
-                    </Toolbox.Section>
+                    {options.length > 1 && (
+                        <Toolbox.Section>
+                            <VStack spacing="2">
+                                <Toolbox.Caption>Type</Toolbox.Caption>
+                                <BaseMenu.Dropdown
+                                    className={styles.Dropdown}
+                                    onChange={handleChangeType}
+                                    options={options}
+                                    value={element.key}
+                                    variant="light"
+                                />
+                            </VStack>
+                        </Toolbox.Section>
+                    )}
                     {option?.withFallback && (
                         <form
                             onSubmit={(event) => {

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -55,7 +55,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
             setMenuOpen(true);
             setFallback(element.fallback ?? '');
         }
-    }, [selected, element.fallback]);
+    }, [selected]);
 
     useEffect(() => {
         if (!option?.withFallback) {

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -1,6 +1,6 @@
 import { isVariableNode, type VariableNode } from '@prezly/slate-types';
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { RenderElementProps } from 'slate-react';
 import { useSelected, useSlateStatic } from 'slate-react';
 
@@ -17,6 +17,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
     const selected = useSelected();
     const editor = useSlateStatic();
 
+    const [isMenuOpen, setMenuOpen] = useState(false);
     const [container, setContainer] = useState<HTMLSpanElement | null>(null);
 
     const variable = variables.find(({ key }) => key === element.key);
@@ -24,16 +25,28 @@ export function VariableElement({ attributes, children, element, variables }: Pr
     const isOnlyVariableSelected =
         selectedNodes.length === 1 && selectedNodes.every(([node]) => isVariableNode(node));
 
+    useEffect(() => {
+        if (selected) {
+            setMenuOpen(true);
+        }
+    }, [selected]);
+
     return (
         <>
-            {selected && isOnlyVariableSelected && container && (
-                <VariableMenu container={container} element={element} variables={variables} />
+            {selected && isOnlyVariableSelected && container && isMenuOpen && (
+                <VariableMenu
+                    container={container}
+                    element={element}
+                    onClose={() => setMenuOpen(false)}
+                    variables={variables}
+                />
             )}
             <span
                 {...attributes}
                 className={classNames(styles.VariableElement, {
                     [styles.selected]: selected,
                 })}
+                onClick={() => setMenuOpen(true)}
                 ref={(ref) => {
                     setContainer(ref);
                     attributes.ref(ref);

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -1,0 +1,125 @@
+import type { VariableNode } from '@prezly/slate-types';
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+import type { RenderElementProps } from 'slate-react';
+import { useSelected, useSlateStatic } from 'slate-react';
+
+import { Button, Input, Menu as BaseMenu, Toolbox, VStack } from '#components';
+import { Delete } from '#icons';
+
+import { Menu } from '../../components/EditorBlock';
+
+import { removeVariable, updateVariable } from './transforms';
+import type { Variable } from './types';
+import styles from './VariableElement.module.scss';
+
+interface Props extends RenderElementProps {
+    element: VariableNode;
+    variables: Variable[];
+}
+
+export function VariableElement({ attributes, children, element, variables }: Props) {
+    const selected = useSelected();
+    const editor = useSlateStatic();
+
+    const [isMenuOpen, setMenuOpen] = useState(false);
+    const [fallback, setFallback] = useState<string>(element.fallback ?? '');
+    const [container, setContainer] = useState<HTMLSpanElement | null>(null);
+
+    const options = variables.map((variable) => ({
+        value: variable.key,
+        label: variable.text,
+        withFallback: variable.withFallback
+    }));
+    const option = options.find(({ value }) => value === element.key);
+
+    function handleCloseMenu() {
+        setMenuOpen(false);
+    }
+
+    function handleChangeType(newType: string) {
+        updateVariable(editor, { key: newType });
+    }
+
+    function handleSave() {
+        updateVariable(editor, { fallback: fallback !== '' ? fallback : null });
+    }
+
+    function handleRemove() {
+        removeVariable(editor);
+    }
+
+    useEffect(() => {
+        if (selected) {
+            setMenuOpen(true);
+            setFallback(element.fallback ?? '');
+        }
+    }, [selected, element.fallback]);
+
+    useEffect(() => {
+        if (!option?.withFallback) {
+            updateVariable(editor, { fallback: null });
+        }
+    }, [option?.withFallback]);
+
+    return (
+        <>
+            {selected && container && isMenuOpen && (
+                <Menu popperOptions={{ modifiers: { arrow: { padding: 0 } } }} reference={container}>
+                    <Toolbox.Header onCloseClick={handleCloseMenu} withCloseButton>Dynamic field settings</Toolbox.Header>
+                    <Toolbox.Section>
+                        <VStack spacing="2">
+                            <Toolbox.Caption>Type</Toolbox.Caption>
+                            <BaseMenu.Dropdown
+                                className={styles.Dropdown}
+                                onChange={handleChangeType}
+                                options={options}
+                                value={element.key}
+                                variant="light"
+                            />
+                        </VStack>
+                    </Toolbox.Section>
+                    {option?.withFallback && (
+                        <form
+                            onSubmit={(event) => {
+                                event.preventDefault();
+                                handleSave();
+                            }}
+                        >
+                            <Toolbox.Section>
+                                <VStack spacing="2">
+                                    <Toolbox.Caption>Fallback</Toolbox.Caption>
+                                    <Input
+                                        name="fallback"
+                                        value={fallback}
+                                        onChange={setFallback}
+                                        placeholder="Define your fallback"
+                                    />
+                                    <Button variant="primary" type="submit" size="small" fullWidth round>
+                                        Save
+                                    </Button>
+                                </VStack>
+                            </Toolbox.Section>
+                        </form>
+                    )}
+                    <Toolbox.Footer>
+                        <Button variant="clear" icon={Delete} fullWidth onClick={handleRemove}>
+                            Remove
+                        </Button>
+                    </Toolbox.Footer>
+                </Menu>
+            )}
+            <span
+                {...attributes}
+                className={classNames(styles.VariableElement, {
+                    [styles.selected]: selected,
+                })}
+                contentEditable={false}
+                ref={setContainer}
+            >
+                {option?.label}{element.fallback && ` or "${element.fallback}"`}
+                {children}
+            </span>
+        </>
+    );
+}

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -29,7 +29,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
     const options = variables.map((variable) => ({
         value: variable.key,
         label: variable.text,
-        withFallback: variable.withFallback
+        withFallback: variable.withFallback,
     }));
     const option = options.find(({ value }) => value === element.key);
 
@@ -65,8 +65,13 @@ export function VariableElement({ attributes, children, element, variables }: Pr
     return (
         <>
             {selected && container && isMenuOpen && (
-                <Menu popperOptions={{ modifiers: { arrow: { padding: 0 } } }} reference={container}>
-                    <Toolbox.Header onCloseClick={handleCloseMenu} withCloseButton>Dynamic field settings</Toolbox.Header>
+                <Menu
+                    popperOptions={{ modifiers: { arrow: { padding: 0 } } }}
+                    reference={container}
+                >
+                    <Toolbox.Header onCloseClick={handleCloseMenu} withCloseButton>
+                        Dynamic field settings
+                    </Toolbox.Header>
                     <Toolbox.Section>
                         <VStack spacing="2">
                             <Toolbox.Caption>Type</Toolbox.Caption>
@@ -95,7 +100,13 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                                         onChange={setFallback}
                                         placeholder="Define your fallback"
                                     />
-                                    <Button variant="primary" type="submit" size="small" fullWidth round>
+                                    <Button
+                                        variant="primary"
+                                        type="submit"
+                                        size="small"
+                                        fullWidth
+                                        round
+                                    >
                                         Save
                                     </Button>
                                 </VStack>
@@ -117,7 +128,8 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                 contentEditable={false}
                 ref={setContainer}
             >
-                {option?.label}{element.fallback && ` or "${element.fallback}"`}
+                {option?.label}
+                {element.fallback && ` or "${element.fallback}"`}
                 {children}
             </span>
         </>

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -126,8 +126,10 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                 className={classNames(styles.VariableElement, {
                     [styles.selected]: selected,
                 })}
-                contentEditable={false}
-                ref={setContainer}
+                ref={(ref) => {
+                    setContainer(ref);
+                    attributes.ref(ref);
+                }}
             >
                 {option?.label}
                 {element.fallback && ` or "${element.fallback}"`}

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -26,7 +26,8 @@ export function VariableElement({ attributes, children, element, variables }: Pr
     const [container, setContainer] = useState<HTMLSpanElement | null>(null);
 
     const selectedNodes = Array.from(editor.nodes({ mode: 'lowest' }));
-    const isOnlyVariableSelected = selectedNodes.length === 1 && selectedNodes.every(([node]) => isVariableNode(node));
+    const isOnlyVariableSelected =
+        selectedNodes.length === 1 && selectedNodes.every(([node]) => isVariableNode(node));
 
     const options = variables.map((variable) => ({
         value: variable.key,
@@ -66,9 +67,7 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                     popperOptions={{ modifiers: { arrow: { padding: 0 } } }}
                     reference={container}
                 >
-                    <Toolbox.Header>
-                        Variable settings
-                    </Toolbox.Header>
+                    <Toolbox.Header>Variable settings</Toolbox.Header>
                     <Toolbox.Section>
                         <VStack spacing="2">
                             <Toolbox.Caption>Type</Toolbox.Caption>

--- a/packages/slate-editor/src/extensions/variables/VariableElement.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableElement.tsx
@@ -4,8 +4,8 @@ import React, { useEffect, useState } from 'react';
 import type { RenderElementProps } from 'slate-react';
 import { useSelected, useSlateStatic } from 'slate-react';
 
-import { Button, Input, Menu as BaseMenu, Toolbox, VStack } from '#components';
-import { Delete } from '#icons';
+import { Button, Input, Menu as BaseMenu, Toolbox, VStack, TooltipV2 } from '#components';
+import { Delete, Info } from '#icons';
 
 import { usePopperOptionsContext } from '#modules/popper-options-context';
 
@@ -94,7 +94,31 @@ export function VariableElement({ attributes, children, element, variables }: Pr
                         >
                             <Toolbox.Section>
                                 <VStack spacing="2">
-                                    <Toolbox.Caption>Fallback</Toolbox.Caption>
+                                    <Toolbox.Caption className={styles.Caption}>
+                                        Fallback
+                                        <TooltipV2.Tooltip
+                                            tooltip={`This text will be used if '${option.label}' is not available.`}
+                                        >
+                                            {({
+                                                ariaAttributes,
+                                                onHide,
+                                                onShow,
+                                                setReferenceElement,
+                                            }) => (
+                                                <span
+                                                    {...ariaAttributes}
+                                                    ref={setReferenceElement}
+                                                    onFocus={onShow}
+                                                    onBlur={onHide}
+                                                    onMouseEnter={onShow}
+                                                    onMouseLeave={onHide}
+                                                    className={styles.Icon}
+                                                >
+                                                    <Info />
+                                                </span>
+                                            )}
+                                        </TooltipV2.Tooltip>
+                                    </Toolbox.Caption>
                                     <Input
                                         name="fallback"
                                         value={fallback}

--- a/packages/slate-editor/src/extensions/variables/VariableMenu.module.scss
+++ b/packages/slate-editor/src/extensions/variables/VariableMenu.module.scss
@@ -1,0 +1,22 @@
+@import "styles/helpers";
+@import "styles/variables";
+
+.Dropdown {
+    width: 100% !important;
+}
+
+.Caption {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .Icon {
+        display: flex;
+        align-items: center;
+
+        > svg {
+            width: 16px;
+            height: 16px;
+        }
+    }
+}

--- a/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
@@ -1,0 +1,130 @@
+import type { VariableNode } from '@prezly/slate-types';
+import React, { useEffect, useState } from 'react';
+import { useSlateStatic } from 'slate-react';
+
+import { Button, Input, Menu as BaseMenu, Toolbox, VStack, TooltipV2 } from '#components';
+import { Delete, Info } from '#icons';
+
+import { usePopperOptionsContext } from '#modules/popper-options-context';
+
+import { Menu } from '../../components/EditorBlock';
+
+import { removeVariable, updateVariable } from './transforms';
+import type { Variable } from './types';
+import styles from './VariableMenu.module.scss';
+
+interface Props {
+    container: HTMLElement;
+    element: VariableNode;
+    variables: Variable[];
+}
+
+export function VariableMenu({ container, element, variables }: Props) {
+    const editor = useSlateStatic();
+    const popperOptions = usePopperOptionsContext();
+
+    const [fallback, setFallback] = useState<string>(element.fallback ?? '');
+    const disabled = fallback === (element.fallback ?? '');
+
+    const options = variables.map((variable) => ({
+        value: variable.key,
+        label: variable.text,
+        withFallback: variable.withFallback,
+    }));
+    const option = options.find(({ value }) => value === element.key);
+
+    function handleChangeType(newType: string) {
+        updateVariable(editor, { key: newType });
+    }
+
+    function handleSave() {
+        updateVariable(editor, { fallback: fallback !== '' ? fallback : null });
+    }
+
+    function handleRemove() {
+        removeVariable(editor);
+    }
+
+    useEffect(() => {
+        if (!option?.withFallback) {
+            updateVariable(editor, { fallback: null });
+        }
+    }, [option?.withFallback]);
+
+    return (
+        <Menu
+            popperOptions={{ ...popperOptions, modifiers: { arrow: { padding: 0 } } }}
+            reference={container}
+        >
+            <Toolbox.Header>Variable settings</Toolbox.Header>
+            {options.length > 1 && (
+                <Toolbox.Section>
+                    <VStack spacing="2">
+                        <Toolbox.Caption>Type</Toolbox.Caption>
+                        <BaseMenu.Dropdown
+                            className={styles.Dropdown}
+                            onChange={handleChangeType}
+                            options={options}
+                            value={element.key}
+                            variant="light"
+                        />
+                    </VStack>
+                </Toolbox.Section>
+            )}
+            {option?.withFallback && (
+                <form
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        handleSave();
+                    }}
+                >
+                    <Toolbox.Section>
+                        <VStack spacing="2">
+                            <Toolbox.Caption className={styles.Caption}>
+                                Fallback
+                                <TooltipV2.Tooltip
+                                    tooltip={`This text will be used if '${option.label}' is not available.`}
+                                >
+                                    {({ ariaAttributes, onHide, onShow, setReferenceElement }) => (
+                                        <span
+                                            {...ariaAttributes}
+                                            ref={setReferenceElement}
+                                            onFocus={onShow}
+                                            onBlur={onHide}
+                                            onMouseEnter={onShow}
+                                            onMouseLeave={onHide}
+                                            className={styles.Icon}
+                                        >
+                                            <Info />
+                                        </span>
+                                    )}
+                                </TooltipV2.Tooltip>
+                            </Toolbox.Caption>
+                            <Input
+                                name="fallback"
+                                value={fallback}
+                                onChange={setFallback}
+                                placeholder="Define your fallback"
+                            />
+                            <Button
+                                disabled={disabled}
+                                variant="primary"
+                                type="submit"
+                                size="small"
+                                fullWidth
+                                round
+                            >
+                                Save
+                            </Button>
+                        </VStack>
+                    </Toolbox.Section>
+                </form>
+            )}
+            <Toolbox.Footer>
+                <Button variant="clear" icon={Delete} fullWidth onClick={handleRemove}>
+                    Remove
+                </Button>
+            </Toolbox.Footer>
+        </Menu>
+    );
+}

--- a/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
@@ -16,10 +16,11 @@ import styles from './VariableMenu.module.scss';
 interface Props {
     container: HTMLElement;
     element: VariableNode;
+    onClose: () => void;
     variables: Variable[];
 }
 
-export function VariableMenu({ container, element, variables }: Props) {
+export function VariableMenu({ container, element, onClose, variables }: Props) {
     const editor = useSlateStatic();
     const popperOptions = usePopperOptionsContext();
 
@@ -60,7 +61,9 @@ export function VariableMenu({ container, element, variables }: Props) {
             popperOptions={{ ...popperOptions, modifiers: { arrow: { padding: 0 } } }}
             reference={container}
         >
-            <Toolbox.Header>Variable settings</Toolbox.Header>
+            <Toolbox.Header onCloseClick={onClose} withCloseButton>
+                Variable settings
+            </Toolbox.Header>
             {options.length > 1 && (
                 <Toolbox.Section>
                     <VStack spacing="2">

--- a/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
@@ -38,7 +38,7 @@ export function VariableMenu({ container, element, variables }: Props) {
     }
 
     function handleSave() {
-        updateVariable(editor, { fallback: fallback !== '' ? fallback : null });
+        updateVariable(editor, { fallback });
     }
 
     function handleRemove() {
@@ -47,7 +47,11 @@ export function VariableMenu({ container, element, variables }: Props) {
 
     useEffect(() => {
         if (!option?.withFallback) {
-            updateVariable(editor, { fallback: null });
+            // Even though the API supports `null` for the fallback,
+            // we can't use it here because Slate will remove this property
+            // and the API will add it back upon saving, creating an endless loop
+            // since the two values will differ.
+            updateVariable(editor, { fallback: '' });
         }
     }, [option?.withFallback]);
 

--- a/packages/slate-editor/src/extensions/variables/VariablesExtension.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariablesExtension.tsx
@@ -3,7 +3,7 @@ import { isVariableNode, VARIABLE_NODE_TYPE } from '@prezly/slate-types';
 import React from 'react';
 import type { RenderElementProps } from 'slate-react';
 
-import { MentionElement, MentionsExtension } from '#extensions/mentions';
+import { MentionsExtension } from '#extensions/mentions';
 
 import { parseSerializedElement } from './lib';
 import {
@@ -12,6 +12,7 @@ import {
     removeUnknownVariables,
 } from './normalization';
 import type { VariablesExtensionParameters } from './types';
+import { VariableElement } from './VariableElement';
 
 export const EXTENSION_ID = 'VariablesExtension';
 
@@ -29,10 +30,13 @@ export function VariablesExtension({ variables }: VariablesExtensionParameters):
         renderElement: ({ attributes, children, element }: RenderElementProps) => {
             if (isVariableNode(element)) {
                 return (
-                    <MentionElement attributes={attributes} element={element}>
-                        {`%${element.key}%`}
+                    <VariableElement
+                        attributes={attributes}
+                        element={element}
+                        variables={variables}
+                    >
                         {children}
-                    </MentionElement>
+                    </VariableElement>
                 );
             }
 

--- a/packages/slate-editor/src/extensions/variables/lib/createVariableNode.ts
+++ b/packages/slate-editor/src/extensions/variables/lib/createVariableNode.ts
@@ -4,6 +4,7 @@ export function createVariableNode(key: VariableNode['key']): VariableNode {
     return {
         children: [{ text: '' }],
         key,
+        fallback: null,
         type: VARIABLE_NODE_TYPE,
     };
 }

--- a/packages/slate-editor/src/extensions/variables/normalization/removeUnknownVariableNodeAttributes.ts
+++ b/packages/slate-editor/src/extensions/variables/normalization/removeUnknownVariableNodeAttributes.ts
@@ -6,6 +6,7 @@ const SHAPE: Record<keyof VariableNode, boolean> = {
     type: true,
     key: true,
     children: true,
+    fallback: true,
 };
 const ALLOWED_ATTRIBUTES = Object.keys(SHAPE);
 

--- a/packages/slate-editor/src/extensions/variables/transforms/index.ts
+++ b/packages/slate-editor/src/extensions/variables/transforms/index.ts
@@ -1,0 +1,2 @@
+export { removeVariable } from './removeVariable';
+export { updateVariable } from './updateVariable';

--- a/packages/slate-editor/src/extensions/variables/transforms/removeVariable.ts
+++ b/packages/slate-editor/src/extensions/variables/transforms/removeVariable.ts
@@ -1,0 +1,10 @@
+import { EditorCommands } from '@prezly/slate-commons';
+import type { VariableNode } from '@prezly/slate-types';
+import { isVariableNode } from '@prezly/slate-types';
+import type { Editor } from 'slate';
+
+export function removeVariable(editor: Editor): VariableNode | null {
+    return EditorCommands.removeNode<VariableNode>(editor, {
+        match: isVariableNode,
+    });
+}

--- a/packages/slate-editor/src/extensions/variables/transforms/updateVariable.ts
+++ b/packages/slate-editor/src/extensions/variables/transforms/updateVariable.ts
@@ -1,0 +1,16 @@
+import type { VariableNode } from '@prezly/slate-types';
+import { isVariableNode } from '@prezly/slate-types';
+import { pick } from '@technically/lodash';
+import type { Editor } from 'slate';
+import { Transforms } from 'slate';
+
+export function updateVariable(
+    editor: Editor,
+    attrs: Partial<Pick<VariableNode, 'fallback' | 'key'>>,
+) {
+    const changes = pick(attrs, ['fallback', 'key']);
+
+    Transforms.setNodes<VariableNode>(editor, changes, {
+        match: isVariableNode,
+    });
+}

--- a/packages/slate-editor/src/extensions/variables/types.ts
+++ b/packages/slate-editor/src/extensions/variables/types.ts
@@ -1,6 +1,7 @@
 export interface Variable {
     key: string;
     text: string;
+    withFallback?: boolean;
 }
 
 export interface VariablesExtensionParameters {

--- a/packages/slate-editor/src/extensions/variables/useVariables.ts
+++ b/packages/slate-editor/src/extensions/variables/useVariables.ts
@@ -44,6 +44,7 @@ export function useVariables(
     return useMentions<Variable>({
         createMentionElement: (option) => createVariableNode(option.value.key),
         isEnabled,
+        moveCursorAfterInsert: false,
         options,
         trigger: '%',
     });

--- a/packages/slate-editor/src/index.ts
+++ b/packages/slate-editor/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './extensions/placeholders';
 export { createContactNode, JobDescription } from './extensions/press-contacts';
 export type { User } from './extensions/user-mentions';
+export type { Variable } from './extensions/variables';
 export { type ResultPromise, type UploadcareOptions, withUploadcare } from './modules/uploadcare';
 
 // Editor type

--- a/packages/slate-editor/src/modules/popper-options-context/types.ts
+++ b/packages/slate-editor/src/modules/popper-options-context/types.ts
@@ -1,9 +1,11 @@
 import type * as Popper from '@popperjs/core';
+import type { ArrowModifier } from '@popperjs/core/lib/modifiers/arrow';
 import type { PreventOverflowModifier } from '@popperjs/core/lib/modifiers/preventOverflow';
 import type { RefObject } from 'react';
 
 export interface Context {
     modifiers?: {
+        arrow?: ArrowModifier['options'];
         preventOverflow?: PreventOverflowModifier['options'];
     };
     placement?: Popper.Placement;

--- a/packages/slate-types/src/nodes/VariableNode.ts
+++ b/packages/slate-types/src/nodes/VariableNode.ts
@@ -5,6 +5,7 @@ export const VARIABLE_NODE_TYPE = 'variable';
 
 export interface VariableNode extends ElementNode {
     type: typeof VARIABLE_NODE_TYPE;
+    fallback: string | null;
     key: string;
 }
 

--- a/packages/slate-types/src/nodes/VariableNode.ts
+++ b/packages/slate-types/src/nodes/VariableNode.ts
@@ -5,7 +5,7 @@ export const VARIABLE_NODE_TYPE = 'variable';
 
 export interface VariableNode extends ElementNode {
     type: typeof VARIABLE_NODE_TYPE;
-    fallback: string | null;
+    fallback?: string | null;
     key: string;
 }
 


### PR DESCRIPTION
- variables no longer show as `%something%` but instead use the label for better clarity
- variables now have a menu when selected
- variables that have `withFallback: true` can have a text fallback set for them

I still have to run this with the UX people so the UI might change.

Default:
![Screenshot 2024-08-06 at 19 00 53](https://github.com/user-attachments/assets/0342c97a-6c49-4e20-a41d-9464831f0598)

With fallback defined:
![Screenshot 2024-08-06 at 19 01 03](https://github.com/user-attachments/assets/48464254-f0ce-4403-afd7-1ddf3514b55a)

Choosing different options:
![Screenshot 2024-08-06 at 18 36 52](https://github.com/user-attachments/assets/d0cb726b-9ec9-44af-9e52-bac498e42986)
