### PR TITLE
[CARE-5939] Expose EditorBlock `align` mode as an HTML attr

### DIFF
--- a/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/slate-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -154,6 +154,7 @@ export const EditorBlock = forwardRef<HTMLDivElement, Props>(function (
                 [styles.loading]: loading,
             })}
             data-slate-block-layout={layout}
+            data-slate-block-align={align}
             onClick={closeMenu}
             ref={ref}
         >


### PR DESCRIPTION
To allow styling these blocks with an external stylesheet