### PR TITLE
[CARE-5943] Hide settings menu if there's only one option without a fallback support

### DIFF
--- a/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
+++ b/packages/slate-editor/src/extensions/variables/VariableMenu.tsx
@@ -51,6 +51,10 @@ export function VariableMenu({ container, element, onClose, variables }: Props) 
         removeVariable(editor);
     }
 
+    if (options.length < 2 && !option?.withFallback) {
+        return null;
+    }
+
     return (
         <Menu
             popperOptions={{ ...popperOptions, modifiers: { arrow: { padding: 0 } } }}


### PR DESCRIPTION
To prevent cases like this:

![CleanShot 2024-08-09 at 12 34 36@2x](https://github.com/user-attachments/assets/e7443d19-f65f-46ec-a17e-33319116817c)
