### PR TITLE
[DEV-13410] Fix - Coverage placeholder search input

### DIFF
--- a/packages/slate-editor/src/components/SearchInput/Suggestions.tsx
+++ b/packages/slate-editor/src/components/SearchInput/Suggestions.tsx
@@ -53,7 +53,7 @@ export function Suggestions<T>({
         placement: 'bottom-end',
     });
 
-    const updatePanelSizeAndPosition = useFunction(() => {
+    const updatePanelSize = useFunction(() => {
         setHeight(childrenContainer.current?.getBoundingClientRect().height);
 
         if (container.current) {
@@ -65,18 +65,22 @@ export function Suggestions<T>({
         }
     });
 
-    useEffect(updatePanelSizeAndPosition, [
-        query,
-        suggestions,
-        calculatedMaxHeight,
-        minHeight,
-        maxHeight,
-    ]);
+    useEffect(() => {
+        window.addEventListener('scroll', updatePanelSize);
+        window.addEventListener('resize', updatePanelSize);
+
+        return () => {
+            window.removeEventListener('scroll', updatePanelSize);
+            window.removeEventListener('resize', updatePanelSize);
+        };
+    }, [updatePanelSize]);
+
+    useEffect(updatePanelSize, [query, suggestions, minHeight, maxHeight]);
 
     useEffect(() => {
         async function repositionPopper() {
             await popper.update?.();
-            updatePanelSizeAndPosition();
+            updatePanelSize();
 
             if (activeElement) {
                 scrollarea?.ensureVisible(activeElement);

--- a/packages/slate-editor/src/components/SearchInput/Suggestions.tsx
+++ b/packages/slate-editor/src/components/SearchInput/Suggestions.tsx
@@ -1,5 +1,4 @@
 import type { FlipModifier } from '@popperjs/core/lib/modifiers/flip';
-import type { PreventOverflowModifier } from '@popperjs/core/lib/modifiers/preventOverflow';
 import classNames from 'classnames';
 import type { HTMLAttributes, ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
@@ -16,6 +15,7 @@ import type { Suggestion } from './types';
 export interface Props<T> extends HTMLAttributes<HTMLDivElement> {
     activeElement: HTMLElement | undefined;
     footer?: ReactNode;
+    minHeight?: number;
     maxHeight?: number;
     origin: HTMLElement | null;
     query: string;
@@ -27,13 +27,15 @@ export function Suggestions<T>({
     children,
     className,
     footer,
-    maxHeight = 500,
+    minHeight = 200,
+    maxHeight = 400,
     origin,
     query,
     suggestions,
     ...attributes
 }: Props<T>) {
     const [height, setHeight] = useState<number>();
+    const [calculatedMaxHeight, setMaxHeight] = useState<number>();
     const container = useRef<HTMLDivElement | null>(null);
     const childrenContainer = useRef<HTMLDivElement | null>(null);
     const [scrollarea, setScrollarea] = useState<FancyScrollbars | null>(null);
@@ -44,42 +46,51 @@ export function Suggestions<T>({
                 name: 'flip',
                 enabled: true,
                 options: {
-                    fallbackPlacements: ['top'],
+                    fallbackPlacements: ['top-end'],
                 },
             } satisfies Partial<FlipModifier>,
-            {
-                name: 'preventOverflow',
-                enabled: true,
-                options: {
-                    altAxis: true,
-                    mainAxis: true,
-                },
-            } satisfies Partial<PreventOverflowModifier>,
         ],
-        placement: 'bottom',
+        placement: 'bottom-end',
     });
 
     const updatePanelSizeAndPosition = useFunction(() => {
         setHeight(childrenContainer.current?.getBoundingClientRect().height);
+
+        if (container.current) {
+            const viewport = document.body.getBoundingClientRect();
+            const rect = container.current.getBoundingClientRect();
+            setMaxHeight(clamp(viewport.height - rect.top - 4, minHeight, maxHeight));
+        } else {
+            setMaxHeight(undefined);
+        }
     });
 
-    useEffect(updatePanelSizeAndPosition, [query, suggestions, maxHeight]);
+    useEffect(updatePanelSizeAndPosition, [
+        query,
+        suggestions,
+        calculatedMaxHeight,
+        minHeight,
+        maxHeight,
+    ]);
 
     useEffect(() => {
-        if (activeElement) {
-            scrollarea?.ensureVisible(activeElement);
+        async function repositionPopper() {
+            await popper.update?.();
+            updatePanelSizeAndPosition();
+
+            if (activeElement) {
+                scrollarea?.ensureVisible(activeElement);
+            }
         }
-    }, [scrollarea, activeElement]);
 
-    useEffect(() => {
-        popper.update?.();
-    }, [height]);
+        repositionPopper();
+    }, [activeElement, calculatedMaxHeight]);
 
     return (
         <Panel
             {...attributes}
             {...popper.attributes.popper}
-            style={{ maxHeight, ...attributes.style, ...popper.styles.popper }}
+            style={{ maxHeight: calculatedMaxHeight, ...attributes.style, ...popper.styles.popper }}
             ref={container}
             className={classNames(className, styles.Suggestions)}
             footer={footer}
@@ -90,4 +101,10 @@ export function Suggestions<T>({
             </FancyScrollbars>
         </Panel>
     );
+}
+
+function clamp(num: number, min: number, max: number) {
+    if (num < min) return min;
+    if (num > max) return max;
+    return num;
 }


### PR DESCRIPTION
I've noticed some problems in the app with the usage of Popper, so I've brought back the minHeight and maxHeight calculation, so Popper doesn't have to flip the entire dropdown unless the available space is less than minHeight.

This makes the dropdown still usable while opened near the bottom of the screen.

There was also a bug with the position of the dropdown when addon is present - this was due to usage of `bottom` placement which anchors to the center of the element (the search input). I've changed it to anchor to `bottom-end`, so it's always aligned.

Another thing that has been fixed is the active element is now properly visible when the dropdown is displayed (previously the active item was sometimes hidden, since the dropdown was scrolled down a bit).

![Screenshot 2024-11-01 at 15 53 04](https://github.com/user-attachments/assets/282672b3-34fb-4751-b3a3-31eb7507d8c0)
![Screenshot 2024-11-01 at 15 53 10](https://github.com/user-attachments/assets/95b126b0-751e-4488-979a-84f79d3d221b)
![Screenshot 2024-11-01 at 15 53 33](https://github.com/user-attachments/assets/72860dc7-b0ec-4f6d-af55-5efe03514d96)
