### PR TITLE
[DEV-13852] Refactoring - Allow custom rendering of placeholders

### DIFF
--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -83,15 +83,7 @@ export interface Parameters {
         | Pick<StoryBookmarkPlaceholderElement.Props, 'renderPlaceholder'>;
     withStoryEmbedPlaceholders?:
         | false
-        | Pick<
-              StoryEmbedPlaceholderElement.Props,
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderAddon'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-          >;
+        | Pick<StoryEmbedPlaceholderElement.Props, 'renderPlaceholder'>;
     withSocialPostPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
     withVideoPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
     withWebBookmarkPlaceholders?: false | { fetchOembed: FetchOEmbedFn };

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -61,16 +61,7 @@ export interface Parameters {
     withGalleryPlaceholders?: boolean | { withMediaGalleryTab: WithMediaGalleryTab };
     withGalleryBookmarkPlaceholders?:
         | false
-        | Pick<
-              GalleryBookmarkPlaceholderElement.Props,
-              | 'fetchOembed'
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderAddon'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-          >;
+        | Pick<GalleryBookmarkPlaceholderElement.Props, 'renderPlaceholder'>;
     withImagePlaceholders?:
         | boolean
         | { withCaptions: boolean; withMediaGalleryTab: WithMediaGalleryTab };

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -35,17 +35,7 @@ export interface Parameters {
     format?: FrameProps['format'];
     removable?: RemovableFlagConfig;
     withAttachmentPlaceholders?: boolean;
-    withContactPlaceholders?:
-        | false
-        | Pick<
-              ContactPlaceholderElement.Props,
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderAddon'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-          >;
+    withContactPlaceholders?: false | Pick<ContactPlaceholderElement.Props, 'renderPlaceholder'>;
     withCoveragePlaceholders?:
         | false
         | Pick<

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -57,14 +57,7 @@ export interface Parameters {
         | { withCaptions: boolean; withMediaGalleryTab: WithMediaGalleryTab };
     withInlineContactPlaceholders?:
         | false
-        | Pick<
-              InlineContactPlaceholderElement.Props,
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-          >;
+        | Pick<InlineContactPlaceholderElement.Props, 'renderPlaceholder'>;
     withMediaPlaceholders?:
         | boolean
         | { withCaptions: boolean; withMediaGalleryTab: WithMediaGalleryTab };

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -80,15 +80,7 @@ export interface Parameters {
         | { withCaptions: boolean; withMediaGalleryTab: WithMediaGalleryTab };
     withStoryBookmarkPlaceholders?:
         | false
-        | Pick<
-              StoryBookmarkPlaceholderElement.Props,
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderAddon'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-          >;
+        | Pick<StoryBookmarkPlaceholderElement.Props, 'renderPlaceholder'>;
     withStoryEmbedPlaceholders?:
         | false
         | Pick<

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -36,17 +36,7 @@ export interface Parameters {
     removable?: RemovableFlagConfig;
     withAttachmentPlaceholders?: boolean;
     withContactPlaceholders?: false | Pick<ContactPlaceholderElement.Props, 'renderPlaceholder'>;
-    withCoveragePlaceholders?:
-        | false
-        | Pick<
-              CoveragePlaceholderElement.Props,
-              | 'getSuggestions'
-              | 'invalidateSuggestions'
-              | 'renderEmpty'
-              | 'renderSuggestion'
-              | 'renderSuggestionsFooter'
-              | 'onCreateCoverage'
-          >;
+    withCoveragePlaceholders?: false | Pick<CoveragePlaceholderElement.Props, 'renderPlaceholder'>;
     withEmbedPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
     withGalleryPlaceholders?: boolean | { withMediaGalleryTab: WithMediaGalleryTab };
     withGalleryBookmarkPlaceholders?:

--- a/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/PlaceholdersExtension.tsx
@@ -36,7 +36,9 @@ export interface Parameters {
     removable?: RemovableFlagConfig;
     withAttachmentPlaceholders?: boolean;
     withContactPlaceholders?: false | Pick<ContactPlaceholderElement.Props, 'renderPlaceholder'>;
-    withCoveragePlaceholders?: false | Pick<CoveragePlaceholderElement.Props, 'renderPlaceholder'>;
+    withCoveragePlaceholders?:
+        | false
+        | Pick<CoveragePlaceholderElement.Props, 'onCreateCoverage' | 'renderPlaceholder'>;
     withEmbedPlaceholders?: false | { fetchOembed: FetchOEmbedFn };
     withGalleryPlaceholders?: boolean | { withMediaGalleryTab: WithMediaGalleryTab };
     withGalleryBookmarkPlaceholders?:

--- a/packages/slate-editor/src/extensions/placeholders/components/PlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/components/PlaceholderElement.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import React, { type MouseEvent, useState } from 'react';
 import { Transforms } from 'slate';
 import { ReactEditor, type RenderElementProps, useSlateStatic } from 'slate-react';
@@ -14,7 +15,9 @@ import { type Props as BaseProps, Placeholder } from './Placeholder';
 export type Props = RenderElementProps &
     Pick<BaseProps, 'icon' | 'title' | 'description' | 'format' | 'onClick' | 'onDrop'> & {
         element: PlaceholderNode;
+        overflow?: 'visible' | 'hidden' | 'auto';
         removable: RemovableFlagConfig;
+        renderFrame?: () => ReactNode;
     };
 
 export function PlaceholderElement({
@@ -27,7 +30,9 @@ export function PlaceholderElement({
     icon,
     title,
     description,
+    overflow,
     removable,
+    renderFrame,
     // Callbacks
     onClick,
     onDrop,
@@ -63,29 +68,34 @@ export function PlaceholderElement({
         <EditorBlock
             {...attributes}
             element={element}
+            overflow={overflow}
             renderAboveFrame={children}
-            renderReadOnlyFrame={({ isSelected }) => (
-                <Placeholder
-                    // Core
-                    active={isActive}
-                    format={format}
-                    icon={icon}
-                    title={title}
-                    description={description}
-                    // Variations
-                    dragOver={onDrop ? dragOver : false}
-                    dropZone={Boolean(onDrop)}
-                    selected={isSelected}
-                    progress={progress ?? isLoading}
-                    // Callbacks
-                    onClick={isLoading ? undefined : onClick}
-                    onRemove={isRemovable ? handleRemove : undefined}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onDrop={onDrop}
-                    onMouseOver={handleMouseOver}
-                />
-            )}
+            renderReadOnlyFrame={({ isSelected }) =>
+                renderFrame ? (
+                    renderFrame()
+                ) : (
+                    <Placeholder
+                        // Core
+                        active={isActive}
+                        format={format}
+                        icon={icon}
+                        title={title}
+                        description={description}
+                        // Variations
+                        dragOver={onDrop ? dragOver : false}
+                        dropZone={Boolean(onDrop)}
+                        selected={isSelected}
+                        progress={progress ?? isLoading}
+                        // Callbacks
+                        onClick={isLoading ? undefined : onClick}
+                        onRemove={isRemovable ? handleRemove : undefined}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={onDrop}
+                        onMouseOver={handleMouseOver}
+                    />
+                )
+            }
             rounded
             void
         />

--- a/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.stories.tsx
@@ -1,14 +1,10 @@
-import type { ContactInfo } from '@prezly/slate-types';
 import * as React from 'react';
 import { createEditor as createSlateEditor } from 'slate';
 import { type RenderElementProps, Slate } from 'slate-react';
 
-import { SearchInput } from '#components';
-
 import { PlaceholdersExtension } from '#extensions/placeholders';
 import { createEditor } from '#modules/editor';
 
-import type { Suggestion } from '../../../components/SearchInput/types';
 import { PlaceholderNode } from '../PlaceholderNode';
 
 import { ContactPlaceholderElement } from './ContactPlaceholderElement';
@@ -28,42 +24,6 @@ const attributes: RenderElementProps['attributes'] = {
     ref: () => null,
 };
 
-function contact(props: Partial<ContactInfo> & Pick<ContactInfo, 'name'>): ContactInfo {
-    return {
-        avatar_url: null,
-        company: '',
-        description: '',
-        address: '',
-        email: '',
-        facebook: '',
-        mobile: '',
-        phone: '',
-        twitter: '',
-        website: '',
-        ...props,
-    };
-}
-
-const suggestions: Suggestion<ContactInfo>[] = [
-    { id: '00000000-00000000-00000000-00000001', value: contact({ name: 'Frodo Baggins' }) },
-    { id: '00000000-00000000-00000000-00000002', value: contact({ name: 'Aragorn' }) },
-    { id: '00000000-00000000-00000000-00000003', value: contact({ name: 'Samwise Gamgee' }) },
-    { id: '00000000-00000000-00000000-00000004', value: contact({ name: 'Merry Brandybuck' }) },
-    { id: '00000000-00000000-00000000-00000005', value: contact({ name: 'Legolas' }) },
-    { id: '00000000-00000000-00000000-00000006', value: contact({ name: 'Pippin Took' }) },
-    { id: '00000000-00000000-00000000-00000007', value: contact({ name: 'Gandalf' }) },
-    { id: '00000000-00000000-00000000-00000008', value: contact({ name: 'Boromir' }) },
-    { id: '00000000-00000000-00000000-00000009', value: contact({ name: 'Arwen' }) },
-    { id: '00000000-00000000-00000000-00000010', value: contact({ name: 'Galadriel' }) },
-];
-
-async function getSuggestions(query: string) {
-    await delay(500 + Math.random() * 500);
-    return suggestions.filter(({ value }) =>
-        value.name.toLowerCase().includes(query.toLowerCase()),
-    );
-}
-
 export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
@@ -82,55 +42,10 @@ export function ContactPlaceholder() {
         <ContactPlaceholderElement
             attributes={attributes}
             element={placeholder}
-            getSuggestions={getSuggestions}
-            renderSuggestion={({ ref, active, disabled, suggestion, onSelect }) => (
-                <SearchInput.Option
-                    active={active}
-                    disabled={disabled}
-                    onClick={onSelect}
-                    forwardRef={ref}
-                >
-                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                        <div
-                            style={{
-                                width: 40,
-                                height: 40,
-                                textAlign: 'center',
-                                color: 'white',
-                                lineHeight: '40px',
-                                borderRadius: 6,
-                                backgroundColor: '#2FA4F9',
-                                marginRight: 16,
-                                flexGrow: 0,
-                            }}
-                        >
-                            {suggestion.value.name
-                                .split(/\s/g)
-                                .slice(0, 2)
-                                .map((word) => word.substring(0, 1))
-                                .join('')}
-                        </div>
-                        <div style={{ flexGrow: 1, fontWeight: 600, fontSize: 14 }}>
-                            {suggestion.value.name}
-                        </div>
-                    </div>
-                </SearchInput.Option>
-            )}
-            renderSuggestionsFooter={() => (
-                <div>
-                    <a href="#">+ Create a Site Contact</a>&nbsp;&nbsp;|&nbsp;&nbsp;
-                    <a href="#">Edit Site Contacts</a>
-                </div>
-            )}
             removable
+            renderPlaceholder={() => null}
         >
             {''}
         </ContactPlaceholderElement>
     );
-}
-
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
 }

--- a/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/ContactPlaceholderElement.tsx
@@ -66,7 +66,7 @@ export function ContactPlaceholderElement({
                 isCustomRendered
                     ? () =>
                           renderPlaceholder({
-                              onRemove: handleRemove,
+                              onRemove: removable ? handleRemove : undefined,
                               onSelect: handleSelect,
                               placeholder: element,
                           })
@@ -84,7 +84,7 @@ export namespace ContactPlaceholderElement {
             Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.CONTACT>;
         renderPlaceholder: (props: {
-            onRemove: () => void;
+            onRemove: (() => void) | undefined;
             onSelect: (uuid: string, contactInfo: ContactInfo) => void;
             placeholder: PlaceholderNode;
         }) => ReactNode;

--- a/packages/slate-editor/src/extensions/placeholders/elements/CoveragePlaceholderElement.module.scss
+++ b/packages/slate-editor/src/extensions/placeholders/elements/CoveragePlaceholderElement.module.scss
@@ -1,9 +1,0 @@
-@import "styles/variables";
-
-.action {
-    margin: $spacing-2 0 0;
-}
-
-.button {
-    text-decoration: none;
-}

--- a/packages/slate-editor/src/extensions/placeholders/elements/CoveragePlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/CoveragePlaceholderElement.tsx
@@ -1,90 +1,65 @@
+import type { ProgressPromise } from '@prezly/progress-promise';
 import type { CoverageNode } from '@prezly/slate-types';
-import type { PrezlyFileInfo } from '@prezly/uploadcare';
-import { toProgressPromise, UploadcareFile } from '@prezly/uploadcare';
-import uploadcare from '@prezly/uploadcare-widget';
-import type { ReactElement } from 'react';
-import React, { type DragEvent, useEffect, useState } from 'react';
+import type { UploadInfo } from '@prezly/uploadcare-widget';
+import type { ReactNode } from 'react';
+import React, { /*type DragEvent,*/ useEffect, useState } from 'react';
 import { Transforms } from 'slate';
 import { useSelected, useSlateStatic } from 'slate-react';
 
-import { Button, SearchInput } from '#components';
-import { PlaceholderCoverage, Upload } from '#icons';
-import { URL_WITH_OPTIONAL_PROTOCOL_REGEXP, useFunction } from '#lib';
+import { PlaceholderCoverage } from '#icons';
+import { useFunction } from '#lib';
 
 import { createCoverage } from '#extensions/coverage';
 import { EventsEditor } from '#modules/events';
-import { UploadcareEditor } from '#modules/uploadcare';
 
-import { InputPlaceholder } from '../components/InputPlaceholder';
 import { withLoadingDots } from '../components/LoadingDots';
 import {
-    type Props as BaseProps,
-    SearchInputPlaceholderElement,
-} from '../components/SearchInputPlaceholderElement';
+    PlaceholderElement,
+    type Props as PlaceholderElementProps,
+} from '../components/PlaceholderElement';
+import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
 import type { PlaceholderNode } from '../PlaceholderNode';
 import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
-import styles from './CoveragePlaceholderElement.module.scss';
-
-type Url = string;
 type CoverageRef = Pick<CoverageNode, 'coverage'>;
-type Mode = 'search' | 'create';
-type ModeSetter = (mode: Mode) => void;
 
 export function CoveragePlaceholderElement({
+    attributes,
     children,
     element,
     format = 'card',
-    getSuggestions,
-    renderEmpty,
-    renderSuggestion,
-    renderSuggestionsFooter,
-    onCreateCoverage,
-    ...props
+    removable,
+    renderPlaceholder,
 }: CoveragePlaceholderElement.Props) {
     const editor = useSlateStatic();
     const isSelected = useSelected();
-    const [mode, setMode] = useState<Mode>('search');
-    const onMode = setMode;
+    const [isCustomRendered, setCustomRendered] = useState(true);
 
-    const handleTrigger = useFunction(() => {
-        PlaceholdersManager.activate(element);
-    });
+    const handleUpload = useFunction(
+        (promise: Promise<CoverageRef> | ProgressPromise<CoverageRef, UploadInfo>) => {
+            setCustomRendered(false);
+            PlaceholdersManager.register(element.type, element.uuid, promise);
+        },
+    );
 
-    const handleUpload = useFunction(async () => {
-        const files = await UploadcareEditor.upload(editor, { multiple: false });
-        if (!files) {
-            return;
-        }
+    // const handleDrop = useFunction((event: DragEvent) => {
+    //     event.preventDefault();
+    //     event.stopPropagation();
 
-        setMode('search');
-        const uploading = toProgressPromise(files[0]).then(async (fileInfo: PrezlyFileInfo) => {
-            const file = UploadcareFile.createFromUploadcareWidgetPayload(fileInfo);
-            const ref = await onCreateCoverage(file);
+    //     const [file] = Array.from(event.dataTransfer.files)
+    //         .slice(0, 1)
+    //         .map((file) => uploadcare.fileFrom('object', file));
 
-            return { coverage: { id: ref.coverage.id } };
-        });
-        PlaceholdersManager.register(element.type, element.uuid, uploading);
-    });
-
-    const handleDrop = useFunction((event: DragEvent) => {
-        event.preventDefault();
-        event.stopPropagation();
-
-        const [file] = Array.from(event.dataTransfer.files)
-            .slice(0, 1)
-            .map((file) => uploadcare.fileFrom('object', file));
-
-        if (file) {
-            const uploading = toProgressPromise(file).then(async (fileInfo: PrezlyFileInfo) => {
-                const file = UploadcareFile.createFromUploadcareWidgetPayload(fileInfo);
-                const ref = await onCreateCoverage(file);
-                return { coverage: { id: ref.coverage.id } };
-            });
-            PlaceholdersManager.register(element.type, element.uuid, uploading);
-        }
-    });
+    //     if (file) {
+    //         const uploading = toProgressPromise(file).then(async (fileInfo: PrezlyFileInfo) => {
+    //             const file = UploadcareFile.createFromUploadcareWidgetPayload(fileInfo);
+    //             const ref = await onCreateCoverage(file);
+    //             return { coverage: { id: ref.coverage.id } };
+    //         });
+    //         PlaceholdersManager.register(element.type, element.uuid, uploading);
+    //     }
+    // });
 
     const handleSelect = useFunction((data: CoverageRef) => {
         EventsEditor.dispatchEvent(editor, 'coverage-placeholder-submitted', {
@@ -96,138 +71,60 @@ export function CoveragePlaceholderElement({
         });
     });
 
-    const handleSubmitUrl = useFunction((input: string) => {
-        setMode('search');
-
-        const loading = (async () => {
-            const ref = await onCreateCoverage(input);
-            return { coverage: { id: ref.coverage.id } };
-        })();
-
-        PlaceholdersManager.register(element.type, element.uuid, loading);
-    });
-
-    const handleDragOver = useFunction(() => {
-        setMode('search');
-    });
-
     const handleRemove = useFunction(() => {
         Transforms.removeNodes(editor, { at: [], match: (node) => node === element });
     });
 
-    const { isActive } = usePlaceholderManagement(element.type, element.uuid, {
+    usePlaceholderManagement(element.type, element.uuid, {
         onResolve: handleSelect,
-        onTrigger: handleTrigger,
     });
 
     useEffect(() => {
-        if (!isActive && mode === 'create') {
-            setMode('search');
+        if (!isSelected) {
+            setCustomRendered(false);
         }
-    }, [isActive]);
+    }, [isSelected]);
 
     return (
-        <SearchInputPlaceholderElement<CoverageRef>
-            {...props}
+        <PlaceholderElement
+            attributes={attributes}
             element={element}
-            // Core
             format={format}
             icon={PlaceholderCoverage}
             title={Title}
             description={Description}
-            // Input
-            getSuggestions={getSuggestions}
-            renderEmpty={(props) => renderEmpty?.({ ...props, onMode }) ?? null}
-            renderSuggestion={(props) => renderSuggestion?.({ ...props, onMode }) ?? null}
-            renderSuggestions={(props) => (
-                <SearchInput.Suggestions
-                    activeElement={props.activeElement}
-                    query={props.query}
-                    suggestions={props.suggestions}
-                    footer={renderSuggestionsFooter?.({ ...props, onMode })}
-                    origin={props.origin}
-                >
-                    {props.children}
-                </SearchInput.Suggestions>
-            )}
-            renderFrame={() =>
-                mode === 'create' ? (
-                    <InputPlaceholder
-                        autoFocus
-                        format="card"
-                        selected={isSelected}
-                        title="Log new coverage"
-                        description="Paste a coverage URL or upload a coverage file (you can also drop it here)."
-                        placeholder="www.website.com/article"
-                        pattern={URL_WITH_OPTIONAL_PROTOCOL_REGEXP.source}
-                        action="Add coverage"
-                        onDragOver={handleDragOver}
-                        onDrop={handleDrop}
-                        onEsc={() => PlaceholdersManager.deactivate(element)}
-                        onRemove={handleRemove}
-                        onSubmit={handleSubmitUrl}
-                    >
-                        <div className={styles.action}>
-                            <Button
-                                className={styles.button}
-                                icon={Upload}
-                                onClick={handleUpload}
-                                variant="underlined"
-                            >
-                                Upload a coverage file
-                            </Button>
-                        </div>
-                    </InputPlaceholder>
-                ) : undefined
+            onClick={() => setCustomRendered(true)}
+            removable={removable}
+            renderFrame={
+                isCustomRendered
+                    ? () =>
+                          renderPlaceholder({
+                              onRemove: removable ? handleRemove : undefined,
+                              onSelect: handleSelect,
+                              onUpload: handleUpload,
+                              placeholder: element,
+                          })
+                    : undefined
             }
-            inputTitle="Coverage"
-            inputDescription="Select coverage to insert"
-            inputPlaceholder="Search for coverage"
-            onDrop={handleDrop}
-            onSelect={(_, entry) => handleSelect(entry)}
         >
             {children}
-        </SearchInputPlaceholderElement>
+        </PlaceholderElement>
     );
 }
 
 export namespace CoveragePlaceholderElement {
     export interface Props
-        extends Omit<
-            BaseProps<CoverageRef>,
-            | 'onSelect'
-            | 'icon'
-            | 'title'
-            | 'description'
-            | 'inputTitle'
-            | 'inputDescription'
-            | 'inputPlaceholder'
-            | 'renderEmpty'
-            | 'renderSuggestion'
-            | 'renderSuggestions'
-        > {
+        extends Pick<BaseProps<CoverageRef>, 'attributes' | 'children' | 'format'>,
+            Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.COVERAGE>;
-
-        // SearchInput
-        renderEmpty?: (
-            props: SearchInput.Props.Empty & { placeholder: PlaceholderNode; onMode: ModeSetter },
-        ) => ReactElement | null;
-
-        renderSuggestion?: (
-            props: SearchInput.Props.Option<CoverageRef> & {
-                placeholder: PlaceholderNode;
-                onMode: ModeSetter;
-            },
-        ) => ReactElement | null;
-
-        renderSuggestionsFooter?: (
-            props: SearchInput.Props.Suggestions<CoverageRef> & {
-                placeholder: PlaceholderNode;
-                onMode: ModeSetter;
-            },
-        ) => ReactElement | null;
-
-        onCreateCoverage(input: Url | UploadcareFile): Promise<CoverageRef>;
+        renderPlaceholder: (props: {
+            onRemove: (() => void) | undefined;
+            onSelect: (data: CoverageRef) => void;
+            onUpload: (
+                promise: Promise<CoverageRef> | ProgressPromise<CoverageRef, UploadInfo>,
+            ) => void;
+            placeholder: PlaceholderNode;
+        }) => ReactNode;
     }
 }
 

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
@@ -83,7 +83,11 @@ export function GalleryBookmarkPlaceholderElement({
             overflow="visible"
             renderFrame={
                 isCustomRendered
-                    ? () => renderPlaceholder({ onRemove: handleRemove, onSelect: handleSelect })
+                    ? () =>
+                          renderPlaceholder({
+                              onRemove: removable ? handleRemove : undefined,
+                              onSelect: handleSelect,
+                          })
                     : undefined
             }
             removable={removable}
@@ -98,7 +102,7 @@ export namespace GalleryBookmarkPlaceholderElement {
         extends Pick<BaseProps<NewsroomGallery>, 'attributes' | 'children' | 'element' | 'format'>,
             Pick<PlaceholderElementProps, 'removable'> {
         renderPlaceholder: (props: {
-            onRemove: () => void;
+            onRemove: (() => void) | undefined;
             onSelect: (promise: Promise<{ oembed?: OEmbedInfo; url: string }>) => void;
         }) => ReactNode;
     }

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
@@ -27,13 +27,9 @@ export function GalleryBookmarkPlaceholderElement({
     removable,
     renderPlaceholder,
 }: GalleryBookmarkPlaceholderElement.Props) {
-    const [isCustomRendered, setCustomRendered] = useState(false);
+    const [isCustomRendered, setCustomRendered] = useState(true);
     const editor = useSlateStatic();
     const isSelected = useSelected();
-
-    const handleTrigger = useFunction(() => {
-        PlaceholdersManager.activate(element);
-    });
 
     const handleSelect = useFunction(
         (promise: Promise<{ oembed?: BookmarkNode['oembed']; url: BookmarkNode['url'] }>) => {
@@ -65,7 +61,6 @@ export function GalleryBookmarkPlaceholderElement({
     );
 
     usePlaceholderManagement(element.type, element.uuid, {
-        onTrigger: handleTrigger,
         // @ts-expect-error Figure out how to fix this
         onResolve: handleData,
     });

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
@@ -17,6 +17,7 @@ import {
 } from '../components/PlaceholderElement';
 import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
+import type { PlaceholderNode } from '../PlaceholderNode';
 import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
 export function GalleryBookmarkPlaceholderElement({
@@ -61,7 +62,6 @@ export function GalleryBookmarkPlaceholderElement({
     );
 
     usePlaceholderManagement(element.type, element.uuid, {
-        // @ts-expect-error Figure out how to fix this
         onResolve: handleData,
     });
 
@@ -99,8 +99,9 @@ export function GalleryBookmarkPlaceholderElement({
 
 export namespace GalleryBookmarkPlaceholderElement {
     export interface Props
-        extends Pick<BaseProps<NewsroomGallery>, 'attributes' | 'children' | 'element' | 'format'>,
+        extends Pick<BaseProps<NewsroomGallery>, 'attributes' | 'children' | 'format'>,
             Pick<PlaceholderElementProps, 'removable'> {
+        element: PlaceholderNode<PlaceholderNode.Type.GALLERY_BOOKMARK>;
         renderPlaceholder: (props: {
             onRemove: (() => void) | undefined;
             onSelect: (promise: Promise<{ oembed?: OEmbedInfo; url: string }>) => void;

--- a/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/GalleryBookmarkPlaceholderElement.tsx
@@ -1,16 +1,16 @@
 import type { NewsroomGallery, OEmbedInfo } from '@prezly/sdk';
 import type { BookmarkNode } from '@prezly/slate-types';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Transforms } from 'slate';
 import { useSelected, useSlateStatic } from 'slate-react';
 
 import { PlaceholderGallery } from '#icons';
 import { useFunction } from '#lib';
 
-import { createGalleryBookmark } from '#extensions/gallery-bookmark';
 import { EventsEditor } from '#modules/events';
 
+import { createGalleryBookmark } from '../../gallery-bookmark';
 import {
     PlaceholderElement,
     type Props as PlaceholderElementProps,
@@ -69,6 +69,12 @@ export function GalleryBookmarkPlaceholderElement({
         // @ts-expect-error Figure out how to fix this
         onResolve: handleData,
     });
+
+    useEffect(() => {
+        if (!isSelected) {
+            setCustomRendered(false);
+        }
+    }, [isSelected]);
 
     return (
         <PlaceholderElement

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.stories.tsx
@@ -1,16 +1,10 @@
-import type { CultureRef, NewsroomRef, StoryRef } from '@prezly/sdk';
-import { Culture, Newsroom, Story } from '@prezly/sdk';
 import * as React from 'react';
 import { createEditor as createSlateEditor } from 'slate';
 import { type RenderElementProps, Slate } from 'slate-react';
-import * as uuid from 'uuid';
-
-import { SearchInput } from '#components';
 
 import { PlaceholdersExtension } from '#extensions/placeholders';
 import { createEditor } from '#modules/editor';
 
-import type { Suggestion } from '../../../components/SearchInput/types';
 import { PlaceholderNode } from '../PlaceholderNode';
 
 import { StoryBookmarkPlaceholderElement } from './StoryBookmarkPlaceholderElement';
@@ -30,180 +24,6 @@ const attributes: RenderElementProps['attributes'] = {
     ref: () => null,
 };
 
-let lastStoryId = 0;
-let lastNewsroomId = 0;
-
-const EN: CultureRef = {
-    name: 'English',
-    code: 'en',
-    locale: 'en',
-    direction: Culture.TextDirection.LTR,
-    native_name: 'English',
-    language_code: 'en',
-};
-
-const THUMBNAIL = [
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-White.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Circus.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Mosque.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-FairyLights.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Goemetry.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Comb.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Floral.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Stripes.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Map.jpg',
-];
-
-const NEWSROOM = [
-    { name: 'Apple' },
-    { name: 'Banana' },
-    { name: 'Cinnamon' },
-    { name: 'Durian' },
-    { name: 'Elderberry' },
-];
-
-function newsroom(): NewsroomRef {
-    const id = ++lastNewsroomId;
-    return {
-        uuid: uuid.v4(),
-        /**
-         * @deprecated Please use `uuid` instead.
-         * @see uuid
-         */
-        id,
-        display_name: NEWSROOM[id % NEWSROOM.length].name,
-        thumbnail_url: THUMBNAIL[(id + 5) % THUMBNAIL.length],
-        name: NEWSROOM[id % NEWSROOM.length].name,
-        subdomain: NEWSROOM[id % NEWSROOM.length].name.toLowerCase(),
-        status: Newsroom.Status.ACTIVE,
-        is_active: true,
-        is_archived: false,
-        is_multilingual: true,
-        is_indexable: true,
-        timezone: 'Europe/Brussels',
-        time_format: 'HH:mm',
-        date_format: 'DD.MM.YYYY',
-        is_offline: false,
-        is_online: true,
-        is_demo: false,
-        url: NEWSROOM[id % NEWSROOM.length].name.toLowerCase() + '.prezly.com',
-        /**
-         * @deprecated Do not rely on these.
-         */
-        links: {
-            media_gallery_api: '',
-            analytics_and_visibility_settings: '',
-            categories_management: '',
-            company_info_settings: '',
-            contacts_management: '',
-            domain_settings: '',
-            edit: '',
-            gallery_management: '',
-            hub_settings: '',
-            languages: '',
-            look_and_feel_settings: '',
-            manual_subscription_management: '',
-            privacy_settings: '',
-            widget_settings: '',
-        },
-    };
-}
-
-function story(props: Partial<StoryRef> & Pick<StoryRef, 'uuid' | 'title'>): StoryRef {
-    const { uuid, title, ...rest } = props;
-    const id = ++lastStoryId;
-    return {
-        uuid,
-        title,
-        /**
-         * @deprecated Please use `uuid` as an identifier instead.
-         * @see uuid
-         */
-        id: lastStoryId++,
-        slug: title.toLowerCase(),
-        status: Story.Status.PUBLISHED,
-        lifecycle_status: Story.Status.PUBLISHED,
-        publication_status: Story.PublicationStatus.PUBLISHED,
-        visibility: Story.Visibility.PUBLIC,
-        thumbnail_url: THUMBNAIL[id % THUMBNAIL.length],
-        created_at: '2023-06-29T13:03:00Z',
-        updated_at: '2023-06-29T13:03:00Z',
-        published_at: '2023-06-29T13:03:00Z',
-        scheduled_at: null,
-        culture: EN,
-        author: null,
-        newsroom: newsroom(),
-        oembed: {
-            type: 'link',
-            version: '1.0',
-            url: '',
-        },
-        links: {
-            edit: '',
-            newsroom_view: '',
-            report: '',
-        },
-
-        ...rest,
-    } as StoryRef;
-}
-
-function suggestion(
-    props: Partial<StoryRef> & Pick<StoryRef, 'uuid' | 'title'>,
-): Suggestion<StoryRef> {
-    return { id: props.uuid, value: story(props) };
-}
-
-const suggestions: Suggestion<StoryRef>[] = [
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000001',
-        title: 'The "Made with Prezly" badge',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000002',
-        title: 'The new side navigation layout',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000003',
-        title: 'Story headers, titles and subtitles are now one with the editor',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000004',
-        title: 'Introducing: Improved Campaign click reporting',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000005',
-        title: 'Improvement: Site contacts and email signatures',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000006',
-        title: 'Prezly themes got an upgrade',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000007',
-        title: 'Recent improvements & fixes',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000008',
-        title: 'Introducing the revamped Contact preview',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000009',
-        title: 'In beta: The Site activity dashboard',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000010',
-        title: 'Revamping billing: A new Plans page & a self-upgrade option',
-    }),
-];
-
-async function getSuggestions(query: string) {
-    await delay(500 + Math.random() * 500);
-    return suggestions.filter(({ value }) =>
-        value.title.toLowerCase().includes(query.toLowerCase()),
-    );
-}
-
 export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
@@ -222,50 +42,10 @@ export function StoryBookmarkPlaceholder() {
         <StoryBookmarkPlaceholderElement
             attributes={attributes}
             element={placeholder}
-            getSuggestions={getSuggestions}
-            renderSuggestion={({ ref, active, disabled, suggestion, onSelect }) => (
-                <SearchInput.Option
-                    active={active}
-                    disabled={disabled}
-                    onClick={onSelect}
-                    forwardRef={ref}
-                >
-                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                        <img
-                            src={suggestion.value.thumbnail_url}
-                            style={{
-                                width: 40,
-                                height: 40,
-                                textAlign: 'center',
-                                color: 'white',
-                                lineHeight: '40px',
-                                borderRadius: 6,
-                                backgroundColor: '#2FA4F9',
-                                marginRight: 16,
-                                flexGrow: 0,
-                            }}
-                        />
-                        <div style={{ flexGrow: 1, fontWeight: 600, fontSize: 14 }}>
-                            {suggestion.value.title}
-                        </div>
-                    </div>
-                </SearchInput.Option>
-            )}
-            renderSuggestionsFooter={() => (
-                <div>
-                    <a href="#">+ Create a new story</a>&nbsp;&nbsp;|&nbsp;&nbsp;
-                    <a href="#">Manage stories</a>
-                </div>
-            )}
+            renderPlaceholder={() => null}
             removable
         >
             {''}
         </StoryBookmarkPlaceholderElement>
     );
-}
-
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
 }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
@@ -15,7 +15,6 @@ import {
 import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
 import type { PlaceholderNode } from '../PlaceholderNode';
-import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
 export function StoryBookmarkPlaceholderElement({
     attributes,
@@ -25,13 +24,9 @@ export function StoryBookmarkPlaceholderElement({
     removable,
     renderPlaceholder,
 }: StoryBookmarkPlaceholderElement.Props) {
-    const [isCustomRendered, setCustomRendered] = useState(false);
+    const [isCustomRendered, setCustomRendered] = useState(true);
     const editor = useSlateStatic();
     const isSelected = useSelected();
-
-    const handleTrigger = useFunction(() => {
-        PlaceholdersManager.activate(element);
-    });
 
     const handleSelect = useFunction((uuid: StoryRef['uuid']) => {
         replacePlaceholder(editor, element, createStoryBookmark({ story: { uuid } }), {
@@ -41,10 +36,6 @@ export function StoryBookmarkPlaceholderElement({
 
     const handleRemove = useFunction(() => {
         Transforms.removeNodes(editor, { at: [], match: (node) => node === element });
-    });
-
-    usePlaceholderManagement(element.type, element.uuid, {
-        onTrigger: handleTrigger,
     });
 
     useEffect(() => {

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
@@ -7,6 +7,8 @@ import { useSelected, useSlateStatic } from 'slate-react';
 import { PlaceholderStory } from '#icons';
 import { useFunction } from '#lib';
 
+import { EventsEditor } from '#modules/events';
+
 import { createStoryBookmark } from '../../story-bookmark';
 import {
     PlaceholderElement,
@@ -29,6 +31,10 @@ export function StoryBookmarkPlaceholderElement({
     const isSelected = useSelected();
 
     const handleSelect = useFunction((uuid: StoryRef['uuid']) => {
+        EventsEditor.dispatchEvent(editor, 'story-bookmark-placeholder-submitted', {
+            story: { uuid },
+        });
+
         replacePlaceholder(editor, element, createStoryBookmark({ story: { uuid } }), {
             select: isSelected,
         });

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
@@ -56,7 +56,11 @@ export function StoryBookmarkPlaceholderElement({
             overflow="visible"
             renderFrame={
                 isCustomRendered
-                    ? () => renderPlaceholder({ onRemove: handleRemove, onSelect: handleSelect })
+                    ? () =>
+                          renderPlaceholder({
+                              onRemove: removable ? handleRemove : undefined,
+                              onSelect: handleSelect,
+                          })
                     : undefined
             }
             removable={removable}
@@ -72,7 +76,7 @@ export namespace StoryBookmarkPlaceholderElement {
             Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.STORY_BOOKMARK>;
         renderPlaceholder: (props: {
-            onRemove: () => void;
+            onRemove: (() => void) | undefined;
             onSelect: (uuid: string) => void;
         }) => ReactNode;
     }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryBookmarkPlaceholderElement.tsx
@@ -1,35 +1,31 @@
 import type { StoryRef } from '@prezly/sdk';
-import React from 'react';
+import type { ReactNode } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Transforms } from 'slate';
 import { useSelected, useSlateStatic } from 'slate-react';
 
-import { SearchInput } from '#components';
 import { PlaceholderStory } from '#icons';
 import { useFunction } from '#lib';
 
-import { EventsEditor } from '#modules/events';
-
 import { createStoryBookmark } from '../../story-bookmark';
-import type { Props as PlaceholderElementProps } from '../components/PlaceholderElement';
 import {
-    type Props as BaseProps,
-    SearchInputPlaceholderElement,
-} from '../components/SearchInputPlaceholderElement';
+    PlaceholderElement,
+    type Props as PlaceholderElementProps,
+} from '../components/PlaceholderElement';
+import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
 import type { PlaceholderNode } from '../PlaceholderNode';
 import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
 export function StoryBookmarkPlaceholderElement({
+    attributes,
     children,
     element,
     format = 'card',
-    getSuggestions,
     removable,
-    renderAddon,
-    renderEmpty,
-    renderSuggestion,
-    renderSuggestionsFooter,
-    ...props
+    renderPlaceholder,
 }: StoryBookmarkPlaceholderElement.Props) {
+    const [isCustomRendered, setCustomRendered] = useState(false);
     const editor = useSlateStatic();
     const isSelected = useSelected();
 
@@ -38,70 +34,55 @@ export function StoryBookmarkPlaceholderElement({
     });
 
     const handleSelect = useFunction((uuid: StoryRef['uuid']) => {
-        EventsEditor.dispatchEvent(editor, 'story-bookmark-placeholder-submitted', {
-            story: { uuid },
-        });
-
         replacePlaceholder(editor, element, createStoryBookmark({ story: { uuid } }), {
             select: isSelected,
         });
+    });
+
+    const handleRemove = useFunction(() => {
+        Transforms.removeNodes(editor, { at: [], match: (node) => node === element });
     });
 
     usePlaceholderManagement(element.type, element.uuid, {
         onTrigger: handleTrigger,
     });
 
+    useEffect(() => {
+        if (!isSelected) {
+            setCustomRendered(false);
+        }
+    }, [isSelected]);
+
     return (
-        <SearchInputPlaceholderElement<StoryRef>
-            {...props}
+        <PlaceholderElement
+            attributes={attributes}
             element={element}
-            // Core
             format={format}
             icon={PlaceholderStory}
             title="Click to insert a story bookmark"
             description="Add one of your Prezly stories"
-            // Input
-            getSuggestions={getSuggestions}
-            renderAddon={renderAddon}
-            renderEmpty={renderEmpty}
-            renderSuggestion={renderSuggestion}
-            renderSuggestions={(props) => (
-                <SearchInput.Suggestions
-                    activeElement={props.activeElement}
-                    query={props.query}
-                    suggestions={props.suggestions}
-                    footer={renderSuggestionsFooter?.(props)}
-                    origin={props.origin}
-                >
-                    {props.children}
-                </SearchInput.Suggestions>
-            )}
-            inputTitle="Story bookmark"
-            inputDescription="Add a story card to your stories, campaigns and pitches"
-            inputPlaceholder="Search Prezly stories"
-            onSelect={handleSelect}
+            onClick={() => setCustomRendered(true)}
+            overflow="visible"
+            renderFrame={
+                isCustomRendered
+                    ? () => renderPlaceholder({ onRemove: handleRemove, onSelect: handleSelect })
+                    : undefined
+            }
             removable={removable}
         >
             {children}
-        </SearchInputPlaceholderElement>
+        </PlaceholderElement>
     );
 }
 
 export namespace StoryBookmarkPlaceholderElement {
     export interface Props
-        extends Omit<
-                BaseProps<StoryRef>,
-                | 'onSelect'
-                | 'icon'
-                | 'title'
-                | 'description'
-                | 'inputTitle'
-                | 'inputDescription'
-                | 'inputPlaceholder'
-                | 'renderSuggestions'
-            >,
+        extends Pick<BaseProps<StoryRef>, 'attributes' | 'children' | 'format'>,
             Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.STORY_BOOKMARK>;
-        renderSuggestionsFooter?: BaseProps<StoryRef>['renderSuggestions'];
+        renderPlaceholder: (props: {
+            onRemove: () => void;
+            onSelect: (uuid: string) => void;
+        }) => ReactNode;
     }
 }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.stories.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.stories.tsx
@@ -1,16 +1,10 @@
-import type { CultureRef, NewsroomRef, StoryRef } from '@prezly/sdk';
-import { Culture, Newsroom, Story } from '@prezly/sdk';
 import * as React from 'react';
 import { createEditor as createSlateEditor } from 'slate';
 import { type RenderElementProps, Slate } from 'slate-react';
-import * as uuid from 'uuid';
-
-import { SearchInput } from '#components';
 
 import { PlaceholdersExtension } from '#extensions/placeholders';
 import { createEditor } from '#modules/editor';
 
-import type { Suggestion } from '../../../components/SearchInput/types';
 import { PlaceholderNode } from '../PlaceholderNode';
 
 import { StoryEmbedPlaceholderElement } from './StoryEmbedPlaceholderElement';
@@ -30,180 +24,6 @@ const attributes: RenderElementProps['attributes'] = {
     ref: () => null,
 };
 
-let lastStoryId = 0;
-let lastNewsroomId = 0;
-
-const EN: CultureRef = {
-    name: 'English',
-    code: 'en',
-    locale: 'en',
-    direction: Culture.TextDirection.LTR,
-    native_name: 'English',
-    language_code: 'en',
-};
-
-const THUMBNAIL = [
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-White.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Circus.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Mosque.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-FairyLights.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Goemetry.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Comb.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Floral.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Stripes.jpg',
-    'https://img.dummy-image-generator.com/abstract/dummy-48x48-Map.jpg',
-];
-
-const NEWSROOM = [
-    { name: 'Apple' },
-    { name: 'Banana' },
-    { name: 'Cinnamon' },
-    { name: 'Durian' },
-    { name: 'Elderberry' },
-];
-
-function newsroom(): NewsroomRef {
-    const id = ++lastNewsroomId;
-    return {
-        uuid: uuid.v4(),
-        /**
-         * @deprecated Please use `uuid` instead.
-         * @see uuid
-         */
-        id,
-        display_name: NEWSROOM[id % NEWSROOM.length].name,
-        thumbnail_url: THUMBNAIL[(id + 5) % THUMBNAIL.length],
-        name: NEWSROOM[id % NEWSROOM.length].name,
-        subdomain: NEWSROOM[id % NEWSROOM.length].name.toLowerCase(),
-        status: Newsroom.Status.ACTIVE,
-        is_active: true,
-        is_archived: false,
-        is_multilingual: true,
-        is_indexable: true,
-        timezone: 'Europe/Brussels',
-        time_format: 'HH:mm',
-        date_format: 'DD.MM.YYYY',
-        is_offline: false,
-        is_online: true,
-        is_demo: false,
-        url: NEWSROOM[id % NEWSROOM.length].name.toLowerCase() + '.prezly.com',
-        /**
-         * @deprecated Do not rely on these.
-         */
-        links: {
-            media_gallery_api: '',
-            analytics_and_visibility_settings: '',
-            categories_management: '',
-            company_info_settings: '',
-            contacts_management: '',
-            domain_settings: '',
-            edit: '',
-            gallery_management: '',
-            hub_settings: '',
-            languages: '',
-            look_and_feel_settings: '',
-            manual_subscription_management: '',
-            privacy_settings: '',
-            widget_settings: '',
-        },
-    };
-}
-
-function story(props: Partial<StoryRef> & Pick<StoryRef, 'uuid' | 'title'>): StoryRef {
-    const { uuid, title, ...rest } = props;
-    const id = ++lastStoryId;
-    return {
-        uuid,
-        title,
-        /**
-         * @deprecated Please use `uuid` as an identifier instead.
-         * @see uuid
-         */
-        id: lastStoryId++,
-        slug: title.toLowerCase(),
-        status: Story.Status.PUBLISHED,
-        lifecycle_status: Story.Status.PUBLISHED,
-        publication_status: Story.PublicationStatus.PUBLISHED,
-        visibility: Story.Visibility.PUBLIC,
-        thumbnail_url: THUMBNAIL[id % THUMBNAIL.length],
-        created_at: '2023-06-29T13:03:00Z',
-        updated_at: '2023-06-29T13:03:00Z',
-        published_at: '2023-06-29T13:03:00Z',
-        scheduled_at: null,
-        culture: EN,
-        author: null,
-        newsroom: newsroom(),
-        oembed: {
-            type: 'link',
-            version: '1.0',
-            url: '',
-        },
-        links: {
-            edit: '',
-            newsroom_view: '',
-            report: '',
-        },
-
-        ...rest,
-    } as StoryRef;
-}
-
-function suggestion(
-    props: Partial<StoryRef> & Pick<StoryRef, 'uuid' | 'title'>,
-): Suggestion<StoryRef> {
-    return { id: props.uuid, value: story(props) };
-}
-
-const suggestions: Suggestion<StoryRef>[] = [
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000001',
-        title: 'The "Made with Prezly" badge',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000002',
-        title: 'The new side navigation layout',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000003',
-        title: 'Story headers, titles and subtitles are now one with the editor',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000004',
-        title: 'Introducing: Improved Campaign click reporting',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000005',
-        title: 'Improvement: Site contacts and email signatures',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000006',
-        title: 'Prezly themes got an upgrade',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000007',
-        title: 'Recent improvements & fixes',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000008',
-        title: 'Introducing the revamped Contact preview',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000009',
-        title: 'In beta: The Site activity dashboard',
-    }),
-    suggestion({
-        uuid: '00000000-00000000-00000000-00000010',
-        title: 'Revamping billing: A new Plans page & a self-upgrade option',
-    }),
-];
-
-async function getSuggestions(query: string) {
-    await delay(500 + Math.random() * 500);
-    return suggestions.filter(({ value }) =>
-        value.title.toLowerCase().includes(query.toLowerCase()),
-    );
-}
-
 export default {
     title: 'Extensions/Placeholders/elements',
     decorators: [
@@ -222,50 +42,10 @@ export function StoryEmbedPlaceholder() {
         <StoryEmbedPlaceholderElement
             attributes={attributes}
             element={placeholder}
-            getSuggestions={getSuggestions}
-            renderSuggestion={({ ref, active, disabled, suggestion, onSelect }) => (
-                <SearchInput.Option
-                    active={active}
-                    disabled={disabled}
-                    onClick={onSelect}
-                    forwardRef={ref}
-                >
-                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                        <img
-                            src={suggestion.value.thumbnail_url}
-                            style={{
-                                width: 40,
-                                height: 40,
-                                textAlign: 'center',
-                                color: 'white',
-                                lineHeight: '40px',
-                                borderRadius: 6,
-                                backgroundColor: '#2FA4F9',
-                                marginRight: 16,
-                                flexGrow: 0,
-                            }}
-                        />
-                        <div style={{ flexGrow: 1, fontWeight: 600, fontSize: 14 }}>
-                            {suggestion.value.title}
-                        </div>
-                    </div>
-                </SearchInput.Option>
-            )}
-            renderSuggestionsFooter={() => (
-                <div>
-                    <a href="#">+ Create a new story</a>&nbsp;&nbsp;|&nbsp;&nbsp;
-                    <a href="#">Manage stories</a>
-                </div>
-            )}
             removable
+            renderPlaceholder={() => null}
         >
             {''}
         </StoryEmbedPlaceholderElement>
     );
-}
-
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
 }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
@@ -62,7 +62,11 @@ export function StoryEmbedPlaceholderElement({
             overflow="visible"
             renderFrame={
                 isCustomRendered
-                    ? () => renderPlaceholder({ onRemove: handleRemove, onSelect: handleSelect })
+                    ? () =>
+                          renderPlaceholder({
+                              onRemove: removable ? handleRemove : undefined,
+                              onSelect: handleSelect,
+                          })
                     : undefined
             }
             removable={removable}
@@ -78,7 +82,7 @@ export namespace StoryEmbedPlaceholderElement {
             Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.STORY_EMBED>;
         renderPlaceholder: (props: {
-            onRemove: () => void;
+            onRemove: (() => void) | undefined;
             onSelect: (uuid: string) => void;
         }) => ReactNode;
     }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
@@ -1,35 +1,33 @@
 import type { StoryRef } from '@prezly/sdk';
-import React from 'react';
+import type { ReactNode } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Transforms } from 'slate';
 import { useSelected, useSlateStatic } from 'slate-react';
 
-import { SearchInput } from '#components';
 import { PlaceholderStory } from '#icons';
 import { useFunction } from '#lib';
 
 import { createStoryEmbed } from '#extensions/story-embed';
 import { EventsEditor } from '#modules/events';
 
-import type { Props as PlaceholderElementProps } from '../components/PlaceholderElement';
 import {
-    type Props as BaseProps,
-    SearchInputPlaceholderElement,
-} from '../components/SearchInputPlaceholderElement';
+    PlaceholderElement,
+    type Props as PlaceholderElementProps,
+} from '../components/PlaceholderElement';
+import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
 import type { PlaceholderNode } from '../PlaceholderNode';
 import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
 export function StoryEmbedPlaceholderElement({
+    attributes,
     children,
     element,
     format = 'card',
-    getSuggestions,
     removable,
-    renderAddon,
-    renderEmpty,
-    renderSuggestion,
-    renderSuggestionsFooter,
-    ...props
+    renderPlaceholder,
 }: StoryEmbedPlaceholderElement.Props) {
+    const [isCustomRendered, setCustomRendered] = useState(false);
     const editor = useSlateStatic();
     const isSelected = useSelected();
 
@@ -47,61 +45,50 @@ export function StoryEmbedPlaceholderElement({
         });
     });
 
+    const handleRemove = useFunction(() => {
+        Transforms.removeNodes(editor, { at: [], match: (node) => node === element });
+    });
+
     usePlaceholderManagement(element.type, element.uuid, {
         onTrigger: handleTrigger,
     });
 
+    useEffect(() => {
+        if (!isSelected) {
+            setCustomRendered(false);
+        }
+    }, [isSelected]);
+
     return (
-        <SearchInputPlaceholderElement<StoryRef>
-            {...props}
+        <PlaceholderElement
+            attributes={attributes}
             element={element}
-            // Core
             format={format}
             icon={PlaceholderStory}
             title="Click to insert a story"
             description="Add one of your Prezly stories"
-            // Input
-            getSuggestions={getSuggestions}
-            renderAddon={renderAddon}
-            renderEmpty={renderEmpty}
-            renderSuggestion={renderSuggestion}
-            renderSuggestions={(props) => (
-                <SearchInput.Suggestions
-                    activeElement={props.activeElement}
-                    query={props.query}
-                    suggestions={props.suggestions}
-                    footer={renderSuggestionsFooter?.(props)}
-                    origin={props.origin}
-                >
-                    {props.children}
-                </SearchInput.Suggestions>
-            )}
-            inputTitle="Story embed"
-            inputDescription="Add a story to your stories, campaigns and pitches"
-            inputPlaceholder="Search Prezly stories"
-            onSelect={handleSelect}
+            onClick={() => setCustomRendered(true)}
+            overflow="visible"
+            renderFrame={
+                isCustomRendered
+                    ? () => renderPlaceholder({ onRemove: handleRemove, onSelect: handleSelect })
+                    : undefined
+            }
             removable={removable}
         >
             {children}
-        </SearchInputPlaceholderElement>
+        </PlaceholderElement>
     );
 }
 
 export namespace StoryEmbedPlaceholderElement {
     export interface Props
-        extends Omit<
-                BaseProps<StoryRef>,
-                | 'onSelect'
-                | 'icon'
-                | 'title'
-                | 'description'
-                | 'inputTitle'
-                | 'inputDescription'
-                | 'inputPlaceholder'
-                | 'renderSuggestions'
-            >,
+        extends Pick<BaseProps<StoryRef>, 'attributes' | 'children' | 'format'>,
             Pick<PlaceholderElementProps, 'removable'> {
         element: PlaceholderNode<PlaceholderNode.Type.STORY_EMBED>;
-        renderSuggestionsFooter?: BaseProps<StoryRef>['renderSuggestions'];
+        renderPlaceholder: (props: {
+            onRemove: () => void;
+            onSelect: (uuid: string) => void;
+        }) => ReactNode;
     }
 }

--- a/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
+++ b/packages/slate-editor/src/extensions/placeholders/elements/StoryEmbedPlaceholderElement.tsx
@@ -17,7 +17,6 @@ import {
 import { type Props as BaseProps } from '../components/SearchInputPlaceholderElement';
 import { replacePlaceholder } from '../lib';
 import type { PlaceholderNode } from '../PlaceholderNode';
-import { PlaceholdersManager, usePlaceholderManagement } from '../PlaceholdersManager';
 
 export function StoryEmbedPlaceholderElement({
     attributes,
@@ -27,13 +26,9 @@ export function StoryEmbedPlaceholderElement({
     removable,
     renderPlaceholder,
 }: StoryEmbedPlaceholderElement.Props) {
-    const [isCustomRendered, setCustomRendered] = useState(false);
+    const [isCustomRendered, setCustomRendered] = useState(true);
     const editor = useSlateStatic();
     const isSelected = useSelected();
-
-    const handleTrigger = useFunction(() => {
-        PlaceholdersManager.activate(element);
-    });
 
     const handleSelect = useFunction((uuid: StoryRef['uuid']) => {
         EventsEditor.dispatchEvent(editor, 'story-embed-placeholder-submitted', {
@@ -47,10 +42,6 @@ export function StoryEmbedPlaceholderElement({
 
     const handleRemove = useFunction(() => {
         Transforms.removeNodes(editor, { at: [], match: (node) => node === element });
-    });
-
-    usePlaceholderManagement(element.type, element.uuid, {
-        onTrigger: handleTrigger,
     });
 
     useEffect(() => {

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -49,8 +49,7 @@ export function getAllExtensions() {
             withFloatingAddMenu: true,
             withGalleries: {},
             withGalleryBookmarks: {
-                fetchOembed,
-                getSuggestions: () => [],
+                renderPlaceholder: () => null,
             },
             withHeadings: true,
             withImages: {

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -31,12 +31,8 @@ export function getAllExtensions() {
             withCoverage: {
                 dateFormat: 'YYYY/MM/DD',
                 fetchCoverage: createDelayedResolve(coverage),
-                getSuggestions: () => [],
-                renderEmpty: () => null,
-                renderSuggestion: () => null,
-                renderSuggestionsFooter: () => null,
-                onCreateCoverage: createDelayedResolve({ coverage }),
                 onEdit: () => {},
+                renderPlaceholder: () => null,
                 withLayoutOptions: true,
             },
             withCustomNormalization: false,

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -61,11 +61,8 @@ export function getAllExtensions() {
             withLists: true,
             withPlaceholders: {},
             withPressContacts: {
-                getSuggestions: () => [],
                 onEdit: () => {},
-                renderEmpty: () => null,
-                renderSuggestion: () => null,
-                renderSuggestionsFooter: () => null,
+                renderPlaceholder: () => null,
             },
             withStoryBookmarks: {
                 loadStory: () => Promise.reject(),

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -31,6 +31,7 @@ export function getAllExtensions() {
             withCoverage: {
                 dateFormat: 'YYYY/MM/DD',
                 fetchCoverage: createDelayedResolve(coverage),
+                onCreateCoverage: createDelayedResolve({ coverage }),
                 onEdit: () => {},
                 renderPlaceholder: () => null,
                 withLayoutOptions: true,

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -71,7 +71,7 @@ export function getAllExtensions() {
                 loadStory: () => Promise.reject(),
                 generateEditUrl: (story) => `/stories/${story.id}/edit`,
                 generatePreviewUrl: (story) => `/stories/${story.id}/preview`,
-                getSuggestions: () => [],
+                renderPlaceholder: () => null,
             },
             withStoryEmbeds: {
                 render: () => null,

--- a/packages/slate-editor/src/modules/editor/test-utils.ts
+++ b/packages/slate-editor/src/modules/editor/test-utils.ts
@@ -75,7 +75,7 @@ export function getAllExtensions() {
             },
             withStoryEmbeds: {
                 render: () => null,
-                getSuggestions: () => [],
+                renderPlaceholder: () => null,
             },
             withTextStyling: true,
             withTables: true,

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -144,6 +144,9 @@ export type EditorEventMap = {
     'story-embed-placeholder-submitted': {
         story: Pick<Story, 'uuid'>;
     };
+    'story-bookmark-placeholder-submitted': {
+        story: Pick<Story, 'uuid'>;
+    };
     'story-bookmark-removed': {
         uuid: string;
     };

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -144,9 +144,6 @@ export type EditorEventMap = {
     'story-embed-placeholder-submitted': {
         story: Pick<Story, 'uuid'>;
     };
-    'story-bookmark-placeholder-submitted': {
-        story: Pick<Story, 'uuid'>;
-    };
     'story-bookmark-removed': {
         uuid: string;
     };

--- a/packages/slate-editor/src/modules/events/types.ts
+++ b/packages/slate-editor/src/modules/events/types.ts
@@ -1,11 +1,5 @@
 import type { Listener } from '@prezly/events';
-import type {
-    CoverageEntry,
-    NewsroomContact,
-    NewsroomGallery,
-    OEmbedInfo,
-    Story,
-} from '@prezly/sdk';
+import type { CoverageEntry, NewsroomContact, OEmbedInfo, Story } from '@prezly/sdk';
 import type {
     GalleryImageSize,
     GalleryLayout,
@@ -109,9 +103,6 @@ export type EditorEventMap = {
     };
     'gallery-layout-changed': {
         layout: GalleryLayout;
-    };
-    'gallery-bookmark-placeholder-submitted': {
-        gallery: Pick<NewsroomGallery, 'uuid'>;
     };
     'image-added': {
         description: string;


### PR DESCRIPTION
The main idea behind this refactoring is to simplify the rendering of placeholders, allowing full control over the contents of the placeholders as soon as they're clicked and to also improve the developer experience when adding or modifying the existing UI. Since a lot of the placeholder code will now be part of the consumer codebase, we don't have to release new versions of the editor when doing copy changes for example.

I chose the `GalleryBookmarkPlaceholderElement` as a proof of concept since it also contains the site switcher. The plan is (if we agree to it) to rework the remaining "search input" placeholders and then eventually rework the regular "input" placeholders as well.

The interface has been simplified into sort of a "headless" approach, so now the consumer only needs to provide a `renderPlaceholder` function that will receive different props based on the required logic.

This allows full control over the UI and also allows usage of consumer code's UI components instead of having to rely on the UI components present (or not present) in the editor. This way, we can get rid of things like `invalidateSuggestions` etc. that were more of a band-aid to the current solution rather than a proper fix.

In this case, the gallery bookmark placeholder rendering function will receive props like `onSelect` (when an option is selected) and `onRemove` (when we want to remove the placeholder).

For example, the `onSelect` callback expects a promise that will resolve to an object containing the `OEmbedInfo` of a given gallery, so we no longer need to provide `fetchOembed` to the editor and we can do all of this outside in the app.

You can see how the new approach is implemented in https://github.com/prezly/prezly/pull/15756.

Please also read the comment below and provide your thoughts on this approach.