### PR TITLE
[DEV-18770] Fix - Allow LinkMenu to flip so it's not cut off if there's not enough space

### DIFF
--- a/packages/slate-editor/src/components/Portals/BasePortalV2.tsx
+++ b/packages/slate-editor/src/components/Portals/BasePortalV2.tsx
@@ -78,7 +78,7 @@ export const BasePortalV2: FunctionComponent<Props> = ({
         });
     }
 
-    const { attributes, styles } = usePopper(referenceElement, popperElement, {
+    const { attributes, state, styles } = usePopper(referenceElement, popperElement, {
         modifiers: popperModifiers,
         placement,
     });
@@ -108,6 +108,8 @@ export const BasePortalV2: FunctionComponent<Props> = ({
         }
     });
 
+    const computedPlacement = state?.placement ?? placement;
+
     return (
         <Portal node={containerElement}>
             <div
@@ -124,10 +126,10 @@ export const BasePortalV2: FunctionComponent<Props> = ({
                     <div
                         ref={setArrowElement}
                         className={classNames(arrowClassName, portalStyles.arrow, {
-                            [portalStyles.top]: placement.indexOf('top') >= 0,
-                            [portalStyles.bottom]: placement.indexOf('bottom') >= 0,
-                            [portalStyles.left]: placement.indexOf('left') >= 0,
-                            [portalStyles.right]: placement.indexOf('right') >= 0,
+                            [portalStyles.top]: computedPlacement.indexOf('top') >= 0,
+                            [portalStyles.bottom]: computedPlacement.indexOf('bottom') >= 0,
+                            [portalStyles.left]: computedPlacement.indexOf('left') >= 0,
+                            [portalStyles.right]: computedPlacement.indexOf('right') >= 0,
                         })}
                         style={styles.arrow}
                     />

--- a/packages/slate-editor/src/modules/rich-formatting-menu/RichFormattingMenu.tsx
+++ b/packages/slate-editor/src/modules/rich-formatting-menu/RichFormattingMenu.tsx
@@ -60,6 +60,11 @@ const LINK_MENU_OFFSET_MODIFIER: Modifier<'offset'> = {
     },
 };
 
+const LINK_MENU_FLIP_MODIFIER: Modifier<'flip'> = {
+    name: 'flip',
+    enabled: true,
+};
+
 export function RichFormattingMenu({
     availableWidth,
     containerElement,
@@ -200,7 +205,7 @@ export function RichFormattingMenu({
         return (
             <TextSelectionPortalV2
                 containerElement={containerElement}
-                modifiers={[LINK_MENU_OFFSET_MODIFIER]}
+                modifiers={[LINK_MENU_OFFSET_MODIFIER, LINK_MENU_FLIP_MODIFIER]}
                 modifySelectionRect={getTextSelectionLeftTopCornerRect}
                 placement="bottom-start"
                 arrowClassName={styles.LinkMenu}


### PR DESCRIPTION
I've also fixed a bug with the arrow using the "desired" placement value instead of the actual value.

![Screenshot 2025-01-10 at 14 50 13](https://github.com/user-attachments/assets/79aca664-a9d5-47b1-b3e7-77d189757adc)
